### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-unit:
     name: Build + unit tests


### PR DESCRIPTION
Potential fix for [https://github.com/logixrcorp/BlazorDX/security/code-scanning/3](https://github.com/logixrcorp/BlazorDX/security/code-scanning/3)

Add an explicit workflow-level `permissions` block with least privilege so all jobs inherit it unless overridden.  
Best fix for this file is to add:

```yml
permissions:
  contents: read
```

directly under the `on:` triggers (before `jobs:`). This does not change existing CI functionality (checkout/build/test still work) and satisfies CodeQL’s requirement for explicit token scope limitation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
