### PR TITLE
A11y/target size and grid keyboard reorder

### DIFF
--- a/src/BlazorDX.Components/DxAccordion.cs
+++ b/src/BlazorDX.Components/DxAccordion.cs
@@ -43,21 +43,24 @@ public sealed class DxAccordion : AccordionPrimitive
 
             builder.OpenElement(12, "span");
             builder.AddAttribute(13, "class", "dx-accordion-icon");
-            builder.AddContent(14, open ? "▾" : "▸");
+            // Decorative: the button is already named by its title, so the chevron is
+            // hidden from assistive tech (the state is conveyed by aria-expanded).
+            builder.AddAttribute(14, "aria-hidden", "true");
+            builder.AddContent(15, open ? "▾" : "▸");
             builder.CloseElement();
 
-            builder.AddContent(15, item.Title);
+            builder.AddContent(16, item.Title);
             builder.CloseElement();
 
             // Region (rendered only when open)
             if (open)
             {
-                builder.OpenElement(16, "div");
-                builder.AddAttribute(17, "id", RegionId(index));
-                builder.AddAttribute(18, "class", "dx-accordion-region");
-                builder.AddAttribute(19, "role", "region");
-                builder.AddAttribute(20, "aria-labelledby", HeaderId(index));
-                builder.AddContent(21, item.Content);
+                builder.OpenElement(17, "div");
+                builder.AddAttribute(18, "id", RegionId(index));
+                builder.AddAttribute(19, "class", "dx-accordion-region");
+                builder.AddAttribute(20, "role", "region");
+                builder.AddAttribute(21, "aria-labelledby", HeaderId(index));
+                builder.AddContent(22, item.Content);
                 builder.CloseElement();
             }
 

--- a/src/BlazorDX.Components/DxComboBox.cs
+++ b/src/BlazorDX.Components/DxComboBox.cs
@@ -92,13 +92,15 @@ public sealed class DxComboBox<TValue> : ComboBoxPrimitive<TValue>
             builder.AddAttribute(10, "class", css);
             if (!option.Disabled)
             {
-                // mousedown (not click) so selection runs before the input blurs;
-                // preventDefault keeps focus in the input.
-                builder.AddAttribute(11, "onmousedown", EventCallback.Factory.Create(this, () => SelectAsync(captured)));
+                // preventDefault on mousedown keeps focus in the input (no blur, panel stays
+                // open); selection itself runs on click — the up-event — so a press that moves
+                // off the option before release is cancelled (WCAG 2.5.2 Pointer Cancellation).
+                builder.AddAttribute(11, "onmousedown", EventCallback.Factory.Create(this, () => { }));
                 builder.AddEventPreventDefaultAttribute(12, "onmousedown", true);
+                builder.AddAttribute(13, "onclick", EventCallback.Factory.Create(this, () => SelectAsync(captured)));
             }
 
-            builder.AddContent(13, option.Text);
+            builder.AddContent(14, option.Text);
             builder.CloseElement();
         }
 

--- a/src/BlazorDX.Components/DxCommandPalette.cs
+++ b/src/BlazorDX.Components/DxCommandPalette.cs
@@ -79,19 +79,21 @@ public sealed class DxCommandPalette : CommandPalettePrimitive
             builder.AddAttribute(28, "role", "option");
             builder.AddAttribute(29, "class", IsActive(index) ? "dx-cmdk-item dx-cmdk-active" : "dx-cmdk-item");
             builder.AddAttribute(30, "aria-selected", IsActive(index) ? "true" : "false");
-            // mousedown (not click) so the command runs before the input blurs.
-            builder.AddAttribute(31, "onmousedown", EventCallback.Factory.Create(this, () => RunAsync(captured)));
+            // preventDefault on mousedown keeps focus in the input; the command runs on
+            // click (the up-event) so releasing off the item cancels it (WCAG 2.5.2).
+            builder.AddAttribute(31, "onmousedown", EventCallback.Factory.Create(this, () => { }));
             builder.AddEventPreventDefaultAttribute(32, "onmousedown", true);
+            builder.AddAttribute(33, "onclick", EventCallback.Factory.Create(this, () => RunAsync(captured)));
 
             if (command.Group is { Length: > 0 } group)
             {
-                builder.OpenElement(33, "span");
-                builder.AddAttribute(34, "class", "dx-cmdk-group");
-                builder.AddContent(35, group);
+                builder.OpenElement(34, "span");
+                builder.AddAttribute(35, "class", "dx-cmdk-group");
+                builder.AddContent(36, group);
                 builder.CloseElement();
             }
 
-            builder.AddContent(36, command.Title);
+            builder.AddContent(37, command.Title);
             builder.CloseElement();
         }
 

--- a/src/BlazorDX.Components/DxDataGrid.cs
+++ b/src/BlazorDX.Components/DxDataGrid.cs
@@ -50,22 +50,51 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             for (int display = 0; display < Columns.Count; display++)
             {
                 int actual = ColumnOrder[display];
+                int capturedDisplay = display;
                 bool visible = !IsColumnHidden(actual);
                 bool lastVisible = visible && VisibleColumnCount == 1;   // keep at least one column
+                string header = Columns[actual].Header;
 
-                builder.OpenElement(151, "label");
+                builder.OpenElement(151, "div");
                 builder.SetKey(actual);
                 builder.AddAttribute(152, "class", "dx-grid-chooser-item");
 
-                builder.OpenElement(153, "input");
-                builder.AddAttribute(154, "type", "checkbox");
-                builder.AddAttribute(155, "checked", visible);
-                builder.AddAttribute(156, "disabled", lastVisible);
-                builder.AddAttribute(157, "onchange", EventCallback.Factory.Create(this, () => ToggleColumnVisibility(actual)));
+                builder.OpenElement(153, "label");
+                builder.AddAttribute(154, "class", "dx-grid-chooser-label");
+
+                builder.OpenElement(155, "input");
+                builder.AddAttribute(156, "type", "checkbox");
+                builder.AddAttribute(157, "checked", visible);
+                builder.AddAttribute(158, "disabled", lastVisible);
+                builder.AddAttribute(159, "onchange", EventCallback.Factory.Create(this, () => ToggleColumnVisibility(actual)));
                 builder.CloseElement();
 
-                builder.AddContent(158, Columns[actual].Header);
+                builder.AddContent(160, header);
+                builder.CloseElement();   // label
+
+                // Single-pointer (no-drag) column reorder: the WCAG 2.5.7 alternative
+                // to header drag-and-drop, for pointer users who cannot drag. Each tap
+                // moves the column one display position; the keyboard path is Ctrl+Arrow
+                // on the header (OnHeaderKeyDown).
+                builder.OpenElement(161, "button");
+                builder.AddAttribute(162, "type", "button");
+                builder.AddAttribute(163, "class", "dx-grid-chooser-move");
+                builder.AddAttribute(164, "aria-label", $"Move {header} left");
+                builder.AddAttribute(165, "disabled", capturedDisplay == 0);
+                builder.AddAttribute(166, "onclick", EventCallback.Factory.Create(this, () => MoveColumn(capturedDisplay, capturedDisplay - 1)));
+                builder.AddContent(167, "◀");
                 builder.CloseElement();
+
+                builder.OpenElement(168, "button");
+                builder.AddAttribute(169, "type", "button");
+                builder.AddAttribute(170, "class", "dx-grid-chooser-move");
+                builder.AddAttribute(171, "aria-label", $"Move {header} right");
+                builder.AddAttribute(172, "disabled", capturedDisplay == Columns.Count - 1);
+                builder.AddAttribute(173, "onclick", EventCallback.Factory.Create(this, () => MoveColumn(capturedDisplay, capturedDisplay + 1)));
+                builder.AddContent(174, "▶");
+                builder.CloseElement();
+
+                builder.CloseElement();   // item
             }
 
             builder.CloseElement();

--- a/src/BlazorDX.Components/DxForm.cs
+++ b/src/BlazorDX.Components/DxForm.cs
@@ -19,6 +19,10 @@ namespace BlazorDX.Components;
 public sealed class DxForm<TModel> : ComponentBase
 {
     private readonly List<FormValidationError> errors = new();
+
+    // Per-form id prefix so each field's error region has a unique, stable id to
+    // wire `aria-describedby` against (WCAG 3.3.1 Error Identification).
+    private readonly string idPrefix = $"dx-form-{Guid.NewGuid():N}";
     private FormContext? context;
 
     /// <summary>The model instance the form edits.</summary>
@@ -63,6 +67,7 @@ public sealed class DxForm<TModel> : ComponentBase
         context ??= new FormContext
         {
             Receiver = this,
+            IdPrefix = idPrefix,
             Fields = Descriptor.Fields,
             Get = name => Descriptor.GetString(Model, name),
             SetAsync = SetFieldAsync,

--- a/src/BlazorDX.Components/DxSkipLink.cs
+++ b/src/BlazorDX.Components/DxSkipLink.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace BlazorDX.Components;
+
+/// <summary>
+/// A "skip to main content" link for WCAG 2.4.1 (Bypass Blocks). Render it as the very
+/// first focusable element in your layout: it stays visually offscreen until focused,
+/// then appears, letting keyboard and screen-reader users jump past repeated navigation
+/// straight to the main region.
+///
+/// Give your main content element a matching id (and <c>tabindex="-1"</c> so it can take
+/// focus): <c>&lt;main id="main-content" tabindex="-1"&gt;</c>. Styling is token-driven
+/// (see dx-layout.css).
+/// </summary>
+public sealed class DxSkipLink : ComponentBase
+{
+    /// <summary>Fragment id of the main-content target (default <c>main-content</c>).</summary>
+    [Parameter] public string TargetId { get; set; } = "main-content";
+
+    /// <summary>Link text (default "Skip to main content").</summary>
+    [Parameter] public string Text { get; set; } = "Skip to main content";
+
+    /// <summary>Extra CSS classes appended to the link.</summary>
+    [Parameter] public string? Class { get; set; }
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "a");
+        builder.AddAttribute(1, "class", $"dx-skip-link {Class}".TrimEnd());
+        builder.AddAttribute(2, "href", $"#{TargetId}");
+        builder.AddContent(3, Text);
+        builder.CloseElement();
+    }
+}

--- a/src/BlazorDX.Components/DxSortableList.cs
+++ b/src/BlazorDX.Components/DxSortableList.cs
@@ -46,7 +46,36 @@ public sealed class DxSortableList : SortablePrimitive
             builder.CloseElement();
 
             builder.AddContent(19, Items[index]);
+
+            // Single-pointer (no-drag) reorder controls — the WCAG 2.5.7 alternative
+            // to the drag gesture. tabindex=-1 keeps the roving model (one tab stop per
+            // list); keyboard users reorder with Alt+Arrow on the row itself.
+            builder.OpenElement(20, "span");
+            builder.AddAttribute(21, "class", "dx-sortable-controls");
+
+            builder.OpenElement(22, "button");
+            builder.AddAttribute(23, "type", "button");
+            builder.AddAttribute(24, "class", "dx-sortable-move");
+            builder.AddAttribute(25, "tabindex", "-1");
+            builder.AddAttribute(26, "aria-label", $"Move {Items[index]} up");
+            builder.AddAttribute(27, "disabled", captured == 0);
+            builder.AddAttribute(28, "onclick", EventCallback.Factory.Create(this, () => MoveByAsync(captured, -1)));
+            builder.AddContent(29, "▲");
             builder.CloseElement();
+
+            builder.OpenElement(30, "button");
+            builder.AddAttribute(31, "type", "button");
+            builder.AddAttribute(32, "class", "dx-sortable-move");
+            builder.AddAttribute(33, "tabindex", "-1");
+            builder.AddAttribute(34, "aria-label", $"Move {Items[index]} down");
+            builder.AddAttribute(35, "disabled", captured == Items.Count - 1);
+            builder.AddAttribute(36, "onclick", EventCallback.Factory.Create(this, () => MoveByAsync(captured, 1)));
+            builder.AddContent(37, "▼");
+            builder.CloseElement();
+
+            builder.CloseElement();   // controls
+
+            builder.CloseElement();   // item
         }
 
         builder.CloseElement();

--- a/src/BlazorDX.Components/DxTileLayout.cs
+++ b/src/BlazorDX.Components/DxTileLayout.cs
@@ -71,6 +71,34 @@ public sealed class DxTileLayout : TileLayoutPrimitive
         builder.AddContent(26, tile.Title);
         builder.CloseElement();
 
+        // Single-pointer (no-drag) reorder controls — the WCAG 2.5.7 alternative to
+        // dragging the header. tabindex=-1 preserves the roving model (one tab stop);
+        // keyboard users reorder with Alt+Arrow on the header.
+        builder.OpenElement(30, "span");
+        builder.AddAttribute(31, "class", "dx-tile-controls");
+
+        builder.OpenElement(32, "button");
+        builder.AddAttribute(33, "type", "button");
+        builder.AddAttribute(34, "class", "dx-tile-move");
+        builder.AddAttribute(35, "tabindex", "-1");
+        builder.AddAttribute(36, "aria-label", $"Move {tile.Title} earlier");
+        builder.AddAttribute(37, "disabled", captured == 0);
+        builder.AddAttribute(38, "onclick", EventCallback.Factory.Create(this, () => MoveByAsync(captured, -1)));
+        builder.AddContent(39, "◀");
+        builder.CloseElement();
+
+        builder.OpenElement(40, "button");
+        builder.AddAttribute(41, "type", "button");
+        builder.AddAttribute(42, "class", "dx-tile-move");
+        builder.AddAttribute(43, "tabindex", "-1");
+        builder.AddAttribute(44, "aria-label", $"Move {tile.Title} later");
+        builder.AddAttribute(45, "disabled", captured == TileCount - 1);
+        builder.AddAttribute(46, "onclick", EventCallback.Factory.Create(this, () => MoveByAsync(captured, 1)));
+        builder.AddContent(47, "▶");
+        builder.CloseElement();
+
+        builder.CloseElement();   // controls
+
         builder.CloseElement();   // header
 
         builder.OpenElement(27, "div");

--- a/src/BlazorDX.Components/DxToastHost.cs
+++ b/src/BlazorDX.Components/DxToastHost.cs
@@ -19,26 +19,32 @@ public sealed class DxToastHost : ComponentBase, IDisposable
     {
         builder.OpenElement(0, "div");
         builder.AddAttribute(1, "class", "dx-toast-host");
+        // Pause auto-dismiss while the user hovers or keyboard-focuses the region, so a
+        // timed toast cannot vanish mid-read; resume when they leave (WCAG 2.2.1).
+        builder.AddAttribute(2, "onmouseenter", EventCallback.Factory.Create(this, Toasts.PauseAll));
+        builder.AddAttribute(3, "onmouseleave", EventCallback.Factory.Create(this, Toasts.ResumeAll));
+        builder.AddAttribute(4, "onfocusin", EventCallback.Factory.Create(this, Toasts.PauseAll));
+        builder.AddAttribute(5, "onfocusout", EventCallback.Factory.Create(this, Toasts.ResumeAll));
 
         foreach (Toast toast in Toasts.Toasts)
         {
-            builder.OpenElement(2, "div");
+            builder.OpenElement(6, "div");
             builder.SetKey(toast.Id);
-            builder.AddAttribute(3, "class", $"dx-toast dx-toast-{toast.Severity}");
-            builder.AddAttribute(4, "role", "status");
+            builder.AddAttribute(7, "class", $"dx-toast dx-toast-{toast.Severity}");
+            builder.AddAttribute(8, "role", "status");
 
-            builder.OpenElement(5, "span");
-            builder.AddAttribute(6, "class", "dx-toast-message");
-            builder.AddContent(7, toast.Message);
+            builder.OpenElement(9, "span");
+            builder.AddAttribute(10, "class", "dx-toast-message");
+            builder.AddContent(11, toast.Message);
             builder.CloseElement();
 
             string capturedId = toast.Id;
-            builder.OpenElement(8, "button");
-            builder.AddAttribute(9, "type", "button");
-            builder.AddAttribute(10, "class", "dx-toast-close");
-            builder.AddAttribute(11, "aria-label", "Dismiss");
-            builder.AddAttribute(12, "onclick", EventCallback.Factory.Create(this, () => Toasts.Remove(capturedId)));
-            builder.AddContent(13, "✕");
+            builder.OpenElement(12, "button");
+            builder.AddAttribute(13, "type", "button");
+            builder.AddAttribute(14, "class", "dx-toast-close");
+            builder.AddAttribute(15, "aria-label", "Dismiss");
+            builder.AddAttribute(16, "onclick", EventCallback.Factory.Create(this, () => Toasts.Remove(capturedId)));
+            builder.AddContent(17, "✕");
             builder.CloseElement();
 
             builder.CloseElement();

--- a/src/BlazorDX.Components/FormContext.cs
+++ b/src/BlazorDX.Components/FormContext.cs
@@ -23,6 +23,11 @@ public sealed class FormFieldRenderContext
 public sealed class FormContext
 {
     public required object Receiver { get; init; }
+
+    /// <summary>Unique-per-form id stem, used to build stable element ids (e.g. error
+    /// regions for <c>aria-describedby</c>). Set by <see cref="DxForm{TModel}"/>.</summary>
+    public required string IdPrefix { get; init; }
+
     public required IReadOnlyList<FormFieldInfo> Fields { get; init; }
     public required Func<string, string> Get { get; init; }
     public required Func<string, string, Task> SetAsync { get; init; }
@@ -66,6 +71,9 @@ internal static class FormFieldRenderer
     {
         string value = ctx.Get(field.Name);
         IReadOnlyList<string> errors = ctx.ErrorsFor(field.Name);
+        // Stable id for the error region so the input can point at it via
+        // aria-describedby; null when valid so the attributes are omitted (WCAG 3.3.1).
+        string? errorId = errors.Count > 0 ? $"{ctx.IdPrefix}-err-{field.Name}" : null;
         EventCallback<string> changed =
             EventCallback.Factory.Create<string>(ctx.Receiver, v => ctx.SetAsync(field.Name, v));
 
@@ -113,25 +121,46 @@ internal static class FormFieldRenderer
         }
         else
         {
-            RenderInput(b, ctx.Receiver, field, value, changed);
+            RenderInput(b, ctx.Receiver, field, value, changed, errorId);
         }
 
-        // Errors
-        for (int i = 0; i < errors.Count; i++)
+        // Errors: one alert region carrying the id referenced by aria-describedby,
+        // so a screen reader reads the message(s) when focus returns to the field.
+        if (errorId is not null)
         {
-            b.OpenElement(70, "span");
-            b.SetKey(i);
-            b.AddAttribute(71, "class", "dx-field-error");
+            b.OpenElement(70, "div");
+            b.AddAttribute(71, "id", errorId);
             b.AddAttribute(72, "role", "alert");
-            b.AddContent(73, errors[i]);
+            for (int i = 0; i < errors.Count; i++)
+            {
+                b.OpenElement(73, "span");
+                b.SetKey(i);
+                b.AddAttribute(74, "class", "dx-field-error");
+                b.AddContent(75, errors[i]);
+                b.CloseElement();
+            }
+
             b.CloseElement();
         }
 
         b.CloseElement();
     }
 
+    // Marks an input as invalid and points it at its error region. A no-op when valid.
+    private static void AddValidationState(RenderTreeBuilder b, string? errorId)
+    {
+        if (errorId is null)
+        {
+            return;
+        }
+
+        b.AddAttribute(80, "aria-invalid", "true");
+        b.AddAttribute(81, "aria-describedby", errorId);
+    }
+
     private static void RenderInput(
-        RenderTreeBuilder b, object receiver, FormFieldInfo field, string value, EventCallback<string> changed)
+        RenderTreeBuilder b, object receiver, FormFieldInfo field, string value, EventCallback<string> changed,
+        string? errorId)
     {
         EventCallback<ChangeEventArgs> onText = EventCallback.Factory.Create<ChangeEventArgs>(
             receiver, e => changed.InvokeAsync(e.Value as string ?? string.Empty));
@@ -142,7 +171,7 @@ internal static class FormFieldRenderer
                 b.OpenElement(30, "textarea");
                 b.AddAttribute(31, "class", "dx-input dx-textarea");
                 b.AddAttribute(32, "rows", "3");
-                AddCommon(b, field);
+                AddCommon(b, field, errorId);
                 b.AddAttribute(38, "value", value);
                 b.AddAttribute(39, "oninput", onText);
                 b.CloseElement();
@@ -156,6 +185,7 @@ internal static class FormFieldRenderer
                 b.AddAttribute(33, "checked", value is "true" or "True");
                 b.AddAttribute(34, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(
                     receiver, e => changed.InvokeAsync(e.Value is true ? "true" : "false")));
+                AddValidationState(b, errorId);
                 b.CloseElement();
                 break;
 
@@ -165,6 +195,7 @@ internal static class FormFieldRenderer
                 b.AddAttribute(32, "value", value);
                 b.AddAttribute(33, "onchange", onText);
                 b.AddAttribute(37, "aria-label", field.Label);
+                AddValidationState(b, errorId);
                 if (field.Choices is { } choices)
                 {
                     for (int i = 0; i < choices.Count; i++)
@@ -196,7 +227,7 @@ internal static class FormFieldRenderer
                     b.AddAttribute(35, "max", max);
                 }
 
-                AddCommon(b, field);
+                AddCommon(b, field, errorId);
                 b.AddAttribute(38, "value", value);
                 b.AddAttribute(39, "oninput", onText);
                 b.CloseElement();
@@ -207,6 +238,7 @@ internal static class FormFieldRenderer
                 b.AddAttribute(31, "class", "dx-input");
                 b.AddAttribute(32, "type", "date");
                 b.AddAttribute(40, "aria-label", field.Label);
+                AddValidationState(b, errorId);
                 b.AddAttribute(38, "value", value);
                 b.AddAttribute(39, "oninput", onText);
                 b.CloseElement();
@@ -216,7 +248,7 @@ internal static class FormFieldRenderer
                 b.OpenElement(30, "input");
                 b.AddAttribute(31, "class", "dx-input");
                 b.AddAttribute(32, "type", "text");
-                AddCommon(b, field);
+                AddCommon(b, field, errorId);
                 b.AddAttribute(38, "value", value);
                 b.AddAttribute(39, "oninput", onText);
                 b.CloseElement();
@@ -224,7 +256,7 @@ internal static class FormFieldRenderer
         }
     }
 
-    private static void AddCommon(RenderTreeBuilder b, FormFieldInfo field)
+    private static void AddCommon(RenderTreeBuilder b, FormFieldInfo field, string? errorId)
     {
         // The visible <label> is not associated by id, so give the control its own accessible
         // name. Without this, screen readers (and axe) see an unlabeled input.
@@ -238,5 +270,7 @@ internal static class FormFieldRenderer
         {
             b.AddAttribute(37, "maxlength", maxLength);
         }
+
+        AddValidationState(b, errorId);
     }
 }

--- a/src/BlazorDX.Components/ToastService.cs
+++ b/src/BlazorDX.Components/ToastService.cs
@@ -11,36 +11,100 @@ public sealed record Toast(string Id, string Message, string Severity);
 /// scoped lifetime (never Singleton — that would share notifications across users on
 /// Blazor Server, per the BlazorDX state-isolation rule). A <c>DxToastHost</c>
 /// subscribes to <see cref="OnChange"/> to render the active toasts.
+///
+/// Auto-dismiss can be paused (<see cref="PauseAll"/>) and resumed (<see cref="ResumeAll"/>)
+/// so a hovered or keyboard-focused toast is not whisked away mid-read — the host wires
+/// these to pointer/focus events for WCAG 2.2.1 (Timing Adjustable).
 /// </summary>
 public sealed class ToastService
 {
     private readonly List<Toast> toasts = new();
+    private readonly Dictionary<string, int> durations = new();
+    private readonly Dictionary<string, CancellationTokenSource> timers = new();
 
     public IReadOnlyList<Toast> Toasts => toasts;
 
     /// <summary>Raised whenever the set of active toasts changes.</summary>
     public event Action? OnChange;
 
-    /// <summary>Shows a toast and removes it automatically after <paramref name="durationMs"/>.</summary>
+    /// <summary>
+    /// Shows a toast and removes it automatically after <paramref name="durationMs"/>.
+    /// A non-positive duration makes the toast sticky (dismissed only by the user).
+    /// </summary>
     public void Show(string message, string severity = "info", int durationMs = 4000)
     {
         Toast toast = new(Guid.NewGuid().ToString("N"), message, severity);
         toasts.Add(toast);
+        durations[toast.Id] = durationMs;
         OnChange?.Invoke();
-        _ = DismissAfterAsync(toast.Id, durationMs);
+        Schedule(toast.Id, durationMs);
     }
 
     public void Remove(string id)
     {
+        CancelTimer(id);
+        durations.Remove(id);
         if (toasts.RemoveAll(t => t.Id == id) > 0)
         {
             OnChange?.Invoke();
         }
     }
 
-    private async Task DismissAfterAsync(string id, int durationMs)
+    /// <summary>Pauses every auto-dismiss countdown (e.g. while the toast region is hovered
+    /// or focused), so a timed notification cannot disappear before it is read.</summary>
+    public void PauseAll()
     {
-        await Task.Delay(durationMs);
+        foreach (string id in timers.Keys.ToArray())
+        {
+            CancelTimer(id);
+        }
+    }
+
+    /// <summary>Restarts auto-dismiss for every visible toast (e.g. when the pointer or focus
+    /// leaves the region). Each toast gets a fresh countdown.</summary>
+    public void ResumeAll()
+    {
+        foreach (Toast toast in toasts)
+        {
+            if (!timers.ContainsKey(toast.Id) && durations.TryGetValue(toast.Id, out int ms))
+            {
+                Schedule(toast.Id, ms);
+            }
+        }
+    }
+
+    private void Schedule(string id, int durationMs)
+    {
+        if (durationMs <= 0)
+        {
+            return;   // sticky: no auto-dismiss
+        }
+
+        CancellationTokenSource cts = new();
+        timers[id] = cts;
+        _ = DismissAfterAsync(id, durationMs, cts.Token);
+    }
+
+    private void CancelTimer(string id)
+    {
+        if (timers.Remove(id, out CancellationTokenSource? cts))
+        {
+            cts.Cancel();
+            cts.Dispose();
+        }
+    }
+
+    private async Task DismissAfterAsync(string id, int durationMs, CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(durationMs, token);
+        }
+        catch (OperationCanceledException)
+        {
+            return;   // paused or removed before the countdown elapsed
+        }
+
         Remove(id);
     }
 }

--- a/src/BlazorDX.Components/wwwroot/api-docs.xml
+++ b/src/BlazorDX.Components/wwwroot/api-docs.xml
@@ -1206,6 +1206,27 @@
             <summary>A shimmering placeholder block shown while content loads. Decorative
             (aria-hidden). Styling via dx-layout.css.</summary>
         </member>
+        <member name="T:BlazorDX.Components.DxSkipLink">
+             <summary>
+             A "skip to main content" link for WCAG 2.4.1 (Bypass Blocks). Render it as the very
+             first focusable element in your layout: it stays visually offscreen until focused,
+             then appears, letting keyboard and screen-reader users jump past repeated navigation
+             straight to the main region.
+            
+             Give your main content element a matching id (and <c>tabindex="-1"</c> so it can take
+             focus): <c>&lt;main id="main-content" tabindex="-1"&gt;</c>. Styling is token-driven
+             (see dx-layout.css).
+             </summary>
+        </member>
+        <member name="P:BlazorDX.Components.DxSkipLink.TargetId">
+            <summary>Fragment id of the main-content target (default <c>main-content</c>).</summary>
+        </member>
+        <member name="P:BlazorDX.Components.DxSkipLink.Text">
+            <summary>Link text (default "Skip to main content").</summary>
+        </member>
+        <member name="P:BlazorDX.Components.DxSkipLink.Class">
+            <summary>Extra CSS classes appended to the link.</summary>
+        </member>
         <member name="T:BlazorDX.Components.DxSlider">
             <summary>
             A numeric slider, backed by a native <c>&lt;input type="range"&gt;</c> so keyboard
@@ -1622,6 +1643,10 @@
             get/set over the generated descriptor plus any author-supplied templates.
             </summary>
         </member>
+        <member name="P:BlazorDX.Components.FormContext.IdPrefix">
+            <summary>Unique-per-form id stem, used to build stable element ids (e.g. error
+            regions for <c>aria-describedby</c>). Set by <see cref="T:BlazorDX.Components.DxForm`1"/>.</summary>
+        </member>
         <member name="E:BlazorDX.Components.FormContext.Changed">
             <summary>Raised when any field value or the validation state changes, so manually
             laid-out <see cref="T:BlazorDX.Components.DxFormField"/>s re-render even when the model is mutated elsewhere
@@ -1672,18 +1697,33 @@
             <summary>info / success / warning / error.</summary>
         </member>
         <member name="T:BlazorDX.Components.ToastService">
-            <summary>
-            Queues transient toast notifications and auto-dismisses them. Registered with a
-            scoped lifetime (never Singleton — that would share notifications across users on
-            Blazor Server, per the BlazorDX state-isolation rule). A <c>DxToastHost</c>
-            subscribes to <see cref="E:BlazorDX.Components.ToastService.OnChange"/> to render the active toasts.
-            </summary>
+             <summary>
+             Queues transient toast notifications and auto-dismisses them. Registered with a
+             scoped lifetime (never Singleton — that would share notifications across users on
+             Blazor Server, per the BlazorDX state-isolation rule). A <c>DxToastHost</c>
+             subscribes to <see cref="E:BlazorDX.Components.ToastService.OnChange"/> to render the active toasts.
+            
+             Auto-dismiss can be paused (<see cref="M:BlazorDX.Components.ToastService.PauseAll"/>) and resumed (<see cref="M:BlazorDX.Components.ToastService.ResumeAll"/>)
+             so a hovered or keyboard-focused toast is not whisked away mid-read — the host wires
+             these to pointer/focus events for WCAG 2.2.1 (Timing Adjustable).
+             </summary>
         </member>
         <member name="E:BlazorDX.Components.ToastService.OnChange">
             <summary>Raised whenever the set of active toasts changes.</summary>
         </member>
         <member name="M:BlazorDX.Components.ToastService.Show(System.String,System.String,System.Int32)">
-            <summary>Shows a toast and removes it automatically after <paramref name="durationMs"/>.</summary>
+            <summary>
+            Shows a toast and removes it automatically after <paramref name="durationMs"/>.
+            A non-positive duration makes the toast sticky (dismissed only by the user).
+            </summary>
+        </member>
+        <member name="M:BlazorDX.Components.ToastService.PauseAll">
+            <summary>Pauses every auto-dismiss countdown (e.g. while the toast region is hovered
+            or focused), so a timed notification cannot disappear before it is read.</summary>
+        </member>
+        <member name="M:BlazorDX.Components.ToastService.ResumeAll">
+            <summary>Restarts auto-dismiss for every visible toast (e.g. when the pointer or focus
+            leaves the region). Each toast gets a fresh countdown.</summary>
         </member>
     </members>
 </doc>

--- a/src/BlazorDX.Components/wwwroot/dx-datagrid.css
+++ b/src/BlazorDX.Components/wwwroot/dx-datagrid.css
@@ -362,13 +362,37 @@
 .dx-grid-chooser-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
+  gap: 4px;
+  padding: 2px 4px;
   border-radius: 6px;
-  cursor: pointer;
   white-space: nowrap;
 }
 .dx-grid-chooser-item:hover { background: var(--dx-surface-alt, #f1f5f9); }
+.dx-grid-chooser-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  padding: 4px;
+  cursor: pointer;
+}
+/* Single-pointer reorder controls — kept at the 24x24 CSS-px minimum (WCAG 2.5.8). */
+.dx-grid-chooser-move {
+  display: inline-grid;
+  place-items: center;
+  min-width: 24px;
+  min-height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--dx-muted, #64748b);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+}
+.dx-grid-chooser-move:hover { background: var(--dx-surface, #ffffff); color: var(--dx-text, #0f172a); }
+.dx-grid-chooser-move:disabled { opacity: 0.3; cursor: default; }
 
 /* ---- Excel-style value filter menu ---- */
 .dx-grid-funnel {

--- a/src/BlazorDX.Components/wwwroot/dx-display.css
+++ b/src/BlazorDX.Components/wwwroot/dx-display.css
@@ -45,9 +45,9 @@
 .dx-chip-remove {
   display: inline-grid;
   place-items: center;
-  width: 18px;
-  height: 18px;
-  margin-right: -4px;
+  width: 24px;
+  height: 24px;
+  margin-right: -6px;
   border: 0;
   border-radius: 999px;
   background: transparent;
@@ -158,15 +158,18 @@
 .dx-tree-selected { background: color-mix(in srgb, var(--dx-accent, #2563eb) 14%, transparent); }
 .dx-tree-active { outline: 1px solid color-mix(in srgb, var(--dx-accent, #2563eb) 50%, transparent); outline-offset: -1px; }
 .dx-tree-twisty {
+  display: inline-grid;
+  place-items: center;
   border: 0;
   background: transparent;
   cursor: pointer;
-  width: 18px;
+  width: 24px;
+  min-height: 24px;
   color: var(--dx-muted, #64748b);
   font-size: 11px;
   padding: 0;
 }
-.dx-tree-spacer { display: inline-block; width: 18px; }
+.dx-tree-spacer { display: inline-block; width: 24px; }
 
 /* ---- Splitter ---- */
 .dx-splitter {
@@ -358,7 +361,7 @@
   -webkit-appearance: none;
   appearance: none;
   pointer-events: auto;
-  width: 16px; height: 16px;
+  width: 24px; height: 24px;
   border-radius: 50%;
   background: var(--dx-accent, #2563eb);
   border: 2px solid #ffffff;
@@ -367,7 +370,7 @@
 }
 .dx-range-area input[type="range"]::-moz-range-thumb {
   pointer-events: auto;
-  width: 16px; height: 16px;
+  width: 24px; height: 24px;
   border-radius: 50%;
   background: var(--dx-accent, #2563eb);
   border: 2px solid #ffffff;

--- a/src/BlazorDX.Components/wwwroot/dx-layout.css
+++ b/src/BlazorDX.Components/wwwroot/dx-layout.css
@@ -2,6 +2,26 @@
   Layout / content-organization components (Tabs, Accordion). CSS-variable driven.
 */
 
+/* ---- Skip link (WCAG 2.4.1 Bypass Blocks) ---- */
+/* Offscreen until focused; the 24px+ tap target and visible focus appear on focus. */
+.dx-skip-link {
+  position: absolute;
+  left: 8px;
+  top: -48px;
+  z-index: 2000;
+  padding: 8px 14px;
+  background: var(--dx-accent, #2563eb);
+  color: var(--dx-accent-contrast, #ffffff);
+  border-radius: 6px;
+  text-decoration: none;
+  transition: top 0.15s ease;
+}
+.dx-skip-link:focus,
+.dx-skip-link:focus-visible { top: 8px; }
+@media (prefers-reduced-motion: reduce) {
+  .dx-skip-link { transition: none; }
+}
+
 /* ---- Tabs ---- */
 .dx-tablist {
   display: flex;

--- a/src/BlazorDX.Components/wwwroot/dx-layout.css
+++ b/src/BlazorDX.Components/wwwroot/dx-layout.css
@@ -107,6 +107,27 @@
   font-size: 18px;
   line-height: 1;
 }
+.dx-sortable-controls { display: inline-flex; gap: 2px; margin-left: auto; }
+/* No-drag reorder buttons, kept at the 24x24 CSS-px minimum (WCAG 2.5.8). */
+.dx-sortable-move,
+.dx-tile-move {
+  display: inline-grid;
+  place-items: center;
+  min-width: 24px;
+  min-height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--dx-text-muted, #64748b);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+}
+.dx-sortable-move:hover,
+.dx-tile-move:hover { background: var(--dx-surface-alt, #f1f5f9); color: var(--dx-text, #0f172a); }
+.dx-sortable-move:disabled,
+.dx-tile-move:disabled { opacity: 0.3; cursor: default; }
 
 /* ---- TransferList ---- */
 .dx-transfer {
@@ -452,7 +473,13 @@
 .dx-alert-title { font-weight: 600; }
 .dx-alert-body { flex: 1; }
 .dx-alert-close {
+  display: inline-grid;
+  place-items: center;
+  min-width: 24px;
+  min-height: 24px;
+  padding: 0;
   border: 0;
+  border-radius: 6px;
   background: transparent;
   cursor: pointer;
   color: inherit;
@@ -597,4 +624,5 @@
 .dx-tile-header:active { cursor: grabbing; }
 .dx-tile-grip { color: var(--dx-text-muted, #94a3b8); }
 .dx-tile-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dx-tile-controls { display: inline-flex; gap: 2px; margin-left: auto; }
 .dx-tile-body { padding: 14px; color: var(--dx-text, #0f172a); }

--- a/src/BlazorDX.Primitives/Interaction/SortablePrimitive.cs
+++ b/src/BlazorDX.Primitives/Interaction/SortablePrimitive.cs
@@ -72,6 +72,14 @@ public class SortablePrimitive : ComponentBase
         }
     }
 
+    /// <summary>
+    /// Single-pointer (no-drag) reorder: moves the item at <paramref name="index"/>
+    /// by <paramref name="delta"/> slots. This is the WCAG 2.5.7 alternative to the
+    /// drag gesture, for pointer users who cannot press-hold-and-drag. Clamped by
+    /// <see cref="ReorderAsync"/>, so a no-op at the list edges.
+    /// </summary>
+    protected Task MoveByAsync(int index, int delta) => ReorderAsync(index, index + delta);
+
     private async Task ReorderAsync(int from, int to)
     {
         if (to < 0 || to >= Items.Count || from == to)

--- a/src/BlazorDX.Primitives/Interaction/TileLayoutPrimitive.cs
+++ b/src/BlazorDX.Primitives/Interaction/TileLayoutPrimitive.cs
@@ -105,6 +105,15 @@ public class TileLayoutPrimitive : ComponentBase
         }
     }
 
+    /// <summary>
+    /// Single-pointer (no-drag) reorder: moves the tile at <paramref name="displayPosition"/>
+    /// by <paramref name="delta"/> positions. This is the WCAG 2.5.7 alternative to the
+    /// drag gesture, for pointer users who cannot press-hold-and-drag. Clamped by
+    /// <see cref="ReorderAsync"/>, so a no-op at the ends.
+    /// </summary>
+    protected Task MoveByAsync(int displayPosition, int delta) =>
+        ReorderAsync(displayPosition, displayPosition + delta);
+
     private async Task ReorderAsync(int from, int to)
     {
         if (to < 0 || to >= order.Length || from == to)

--- a/src/BlazorDX.Primitives/wwwroot/api-docs.xml
+++ b/src/BlazorDX.Primitives/wwwroot/api-docs.xml
@@ -1581,6 +1581,14 @@
         <member name="F:BlazorDX.Primitives.Interaction.SortablePrimitive.Roving">
             <summary>Roving state shared with the styled layer for focus/tabindex.</summary>
         </member>
+        <member name="M:BlazorDX.Primitives.Interaction.SortablePrimitive.MoveByAsync(System.Int32,System.Int32)">
+            <summary>
+            Single-pointer (no-drag) reorder: moves the item at <paramref name="index"/>
+            by <paramref name="delta"/> slots. This is the WCAG 2.5.7 alternative to the
+            drag gesture, for pointer users who cannot press-hold-and-drag. Clamped by
+            <see cref="M:BlazorDX.Primitives.Interaction.SortablePrimitive.ReorderAsync(System.Int32,System.Int32)"/>, so a no-op at the list edges.
+            </summary>
+        </member>
         <member name="T:BlazorDX.Primitives.Interaction.TileItem">
             <summary>A dashboard tile: a titled card whose body is arbitrary content.</summary>
             <param name="Title">Header text (also the drag handle label).</param>
@@ -1622,6 +1630,14 @@
         </member>
         <member name="P:BlazorDX.Primitives.Interaction.TileLayoutPrimitive.Order">
             <summary>Display order: each position holds the index of the tile shown there.</summary>
+        </member>
+        <member name="M:BlazorDX.Primitives.Interaction.TileLayoutPrimitive.MoveByAsync(System.Int32,System.Int32)">
+            <summary>
+            Single-pointer (no-drag) reorder: moves the tile at <paramref name="displayPosition"/>
+            by <paramref name="delta"/> positions. This is the WCAG 2.5.7 alternative to the
+            drag gesture, for pointer users who cannot press-hold-and-drag. Clamped by
+            <see cref="M:BlazorDX.Primitives.Interaction.TileLayoutPrimitive.ReorderAsync(System.Int32,System.Int32)"/>, so a no-op at the ends.
+            </summary>
         </member>
         <member name="T:BlazorDX.Primitives.Motion.PresenceBoundary">
             <summary>

--- a/tests/BlazorDX.Components.Tests/DxComboBoxTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxComboBoxTests.cs
@@ -59,7 +59,7 @@ public sealed class DxComboBoxTests : TestContext
             .Add(c => c.ValueChanged, value => bound = value));
 
         combo.Find("input[role=combobox]").Input("den");
-        combo.FindAll("[role=option]")[0].MouseDown();
+        combo.FindAll("[role=option]")[0].Click();   // select on the up-event (WCAG 2.5.2)
 
         Assert.Equal("DEN", bound);
     }

--- a/tests/BlazorDX.Components.Tests/DxCommandPaletteTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxCommandPaletteTests.cs
@@ -76,4 +76,17 @@ public sealed class DxCommandPaletteTests : TestContext
         Assert.Equal("Toggle dark mode", ran);
         Assert.False(open); // closed after running
     }
+
+    [Fact]
+    public void Clicking_a_command_runs_it_on_the_up_event()
+    {
+        IRenderedComponent<DxCommandPalette> palette = RenderComponent<DxCommandPalette>(parameters => parameters
+            .Add(p => p.Commands, BuildCommands())
+            .Add(p => p.Open, true));
+
+        palette.Find(".dx-cmdk-input").Input("set");
+        palette.Find("[role=option]").Click();   // runs on click (WCAG 2.5.2), not mousedown
+
+        Assert.Equal("Open settings", ran);
+    }
 }

--- a/tests/BlazorDX.Components.Tests/DxDataGridChooserTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridChooserTests.cs
@@ -71,6 +71,34 @@ public sealed class DxDataGridChooserTests : TestContext
     }
 
     [Fact]
+    public void Move_buttons_reorder_columns_with_a_single_click()
+    {
+        // WCAG 2.5.7: a no-drag, single-pointer alternative to header drag-and-drop.
+        IRenderedComponent<DxDataGrid<WidgetRow>> grid = Render();
+        var before = grid.FindAll(".dx-grid-th");
+        Assert.Equal("Name", before[0].TextContent.Trim());
+        Assert.Equal("Quantity", before[1].TextContent.Trim());
+
+        grid.Find(".dx-grid-chooser-toggle").Click();
+        grid.Find(".dx-grid-chooser-move[aria-label='Move Name right']").Click();
+
+        var after = grid.FindAll(".dx-grid-th");
+        Assert.Equal("Quantity", after[0].TextContent.Trim());
+        Assert.Equal("Name", after[1].TextContent.Trim());
+    }
+
+    [Fact]
+    public void Move_buttons_are_disabled_at_the_row_edges()
+    {
+        IRenderedComponent<DxDataGrid<WidgetRow>> grid = Render();
+        grid.Find(".dx-grid-chooser-toggle").Click();
+
+        // Leftmost column cannot move left; rightmost cannot move right.
+        Assert.True(grid.Find(".dx-grid-chooser-move[aria-label='Move Name left']").HasAttribute("disabled"));
+        Assert.True(grid.Find(".dx-grid-chooser-move[aria-label='Move Quantity right']").HasAttribute("disabled"));
+    }
+
+    [Fact]
     public void Hidden_columns_are_excluded_from_csv_export()
     {
         string? csv = null;

--- a/tests/BlazorDX.Components.Tests/DxFormTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxFormTests.cs
@@ -66,6 +66,37 @@ public sealed class DxFormTests : TestContext
     }
 
     [Fact]
+    public void Invalid_field_is_marked_and_linked_to_its_error_message()
+    {
+        // WCAG 3.3.1: the input is aria-invalid and points, via aria-describedby, at the
+        // text error region — so a screen reader announces it when focus returns.
+        IRenderedComponent<DxForm<MeetingRequest>> form = RenderForm(new MeetingRequest());
+        form.Find("form").Submit();   // empty model -> required fields fail
+
+        var title = form.FindAll("input[type=text]")[0];   // Title is required
+        Assert.Equal("true", title.GetAttribute("aria-invalid"));
+
+        string? describedBy = title.GetAttribute("aria-describedby");
+        Assert.False(string.IsNullOrEmpty(describedBy));
+
+        var errorRegion = form.Find($"#{describedBy}");
+        Assert.Equal("alert", errorRegion.GetAttribute("role"));
+        Assert.NotEmpty(errorRegion.TextContent.Trim());
+    }
+
+    [Fact]
+    public void Valid_field_carries_no_invalid_or_describedby_attributes()
+    {
+        MeetingRequest model = new() { Title = "Sync", Email = "a@b.co", Attendees = 3 };
+        IRenderedComponent<DxForm<MeetingRequest>> form = RenderForm(model);
+        form.Find("form").Submit();
+
+        var title = form.FindAll("input[type=text]")[0];
+        Assert.False(title.HasAttribute("aria-invalid"));
+        Assert.False(title.HasAttribute("aria-describedby"));
+    }
+
+    [Fact]
     public void Submitting_valid_calls_the_valid_callback_with_the_model()
     {
         MeetingRequest model = new() { Title = "Sync", Email = "a@b.co", Attendees = 3 };

--- a/tests/BlazorDX.Components.Tests/DxSkipLinkTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxSkipLinkTests.cs
@@ -1,0 +1,31 @@
+using BlazorDX.Components;
+using Bunit;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>The skip-to-content link for WCAG 2.4.1 (Bypass Blocks).</summary>
+public sealed class DxSkipLinkTests : TestContext
+{
+    [Fact]
+    public void Renders_an_anchor_to_the_default_main_target()
+    {
+        IRenderedComponent<DxSkipLink> link = RenderComponent<DxSkipLink>();
+
+        var a = link.Find("a.dx-skip-link");
+        Assert.Equal("#main-content", a.GetAttribute("href"));
+        Assert.Equal("Skip to main content", a.TextContent.Trim());
+    }
+
+    [Fact]
+    public void Target_and_text_are_configurable()
+    {
+        IRenderedComponent<DxSkipLink> link = RenderComponent<DxSkipLink>(p => p
+            .Add(s => s.TargetId, "content")
+            .Add(s => s.Text, "Skip navigation"));
+
+        var a = link.Find("a.dx-skip-link");
+        Assert.Equal("#content", a.GetAttribute("href"));
+        Assert.Equal("Skip navigation", a.TextContent.Trim());
+    }
+}

--- a/tests/BlazorDX.Components.Tests/DxSortableListTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxSortableListTests.cs
@@ -51,6 +51,30 @@ public sealed class DxSortableListTests : TestContext
     }
 
     [Fact]
+    public void Move_down_button_reorders_with_a_single_click()
+    {
+        // WCAG 2.5.7: a no-drag, single-pointer alternative to the drag gesture.
+        IReadOnlyList<string> bound = Tasks();
+        IRenderedComponent<DxSortableList> list = RenderComponent<DxSortableList>(parameters => parameters
+            .Add(s => s.Items, bound)
+            .Add(s => s.ItemsChanged, items => bound = items));
+
+        list.Find(".dx-sortable-move[aria-label='Move A down']").Click();
+
+        Assert.Equal(["B", "A", "C"], bound);
+    }
+
+    [Fact]
+    public void Move_buttons_are_disabled_at_the_list_ends()
+    {
+        IRenderedComponent<DxSortableList> list = RenderComponent<DxSortableList>(parameters => parameters
+            .Add(s => s.Items, Tasks()));
+
+        Assert.True(list.Find(".dx-sortable-move[aria-label='Move A up']").HasAttribute("disabled"));
+        Assert.True(list.Find(".dx-sortable-move[aria-label='Move C down']").HasAttribute("disabled"));
+    }
+
+    [Fact]
     public void Alt_arrow_down_moves_the_focused_item_down()
     {
         IReadOnlyList<string> bound = Tasks();

--- a/tests/BlazorDX.Components.Tests/DxTileLayoutTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxTileLayoutTests.cs
@@ -70,6 +70,31 @@ public sealed class DxTileLayoutTests : TestContext
     }
 
     [Fact]
+    public void Move_later_button_reorders_with_a_single_click()
+    {
+        // WCAG 2.5.7: a no-drag, single-pointer alternative to dragging the header.
+        IReadOnlyList<int>? order = null;
+        IRenderedComponent<DxTileLayout> tiles = RenderComponent<DxTileLayout>(parameters => parameters
+            .Add(t => t.Tiles, Tiles())
+            .Add(t => t.OrderChanged, o => order = o));
+
+        tiles.Find(".dx-tile-move[aria-label='Move Alpha later']").Click();
+
+        Assert.Equal(["Beta", "Alpha", "Gamma"], Titles(tiles));
+        Assert.Equal([1, 0, 2], order!);
+    }
+
+    [Fact]
+    public void Move_buttons_are_disabled_at_the_ends()
+    {
+        IRenderedComponent<DxTileLayout> tiles = RenderComponent<DxTileLayout>(parameters => parameters
+            .Add(t => t.Tiles, Tiles()));
+
+        Assert.True(tiles.Find(".dx-tile-move[aria-label='Move Alpha earlier']").HasAttribute("disabled"));
+        Assert.True(tiles.Find(".dx-tile-move[aria-label='Move Gamma later']").HasAttribute("disabled"));
+    }
+
+    [Fact]
     public void Arrow_alone_moves_focus_not_order()
     {
         IRenderedComponent<DxTileLayout> tiles = RenderComponent<DxTileLayout>(parameters => parameters

--- a/tests/BlazorDX.Components.Tests/DxToastTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxToastTests.cs
@@ -1,0 +1,55 @@
+using BlazorDX.Components;
+using Bunit;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>Toast auto-dismiss, and the WCAG 2.2.1 pause/resume of the countdown.</summary>
+public sealed class DxToastTests : TestContext
+{
+    [Fact]
+    public async Task Toast_auto_dismisses_after_its_duration()
+    {
+        var svc = new ToastService();
+        svc.Show("hi", durationMs: 30);
+        Assert.Single(svc.Toasts);
+
+        await Task.Delay(200);
+
+        Assert.Empty(svc.Toasts);
+    }
+
+    [Fact]
+    public async Task Pausing_holds_the_toast_then_resuming_dismisses_it()
+    {
+        var svc = new ToastService();
+        svc.Show("read me", durationMs: 40);
+
+        svc.PauseAll();
+        await Task.Delay(200);
+        Assert.Single(svc.Toasts);   // countdown paused — toast stays
+
+        svc.ResumeAll();
+        await Task.Delay(200);
+        Assert.Empty(svc.Toasts);    // countdown restarted and elapsed
+    }
+
+    [Fact]
+    public async Task Host_pauses_on_hover_and_resumes_on_leave()
+    {
+        var svc = new ToastService();
+        Services.AddScoped(_ => svc);
+        IRenderedComponent<DxToastHost> host = RenderComponent<DxToastHost>();
+
+        svc.Show("hi", durationMs: 150);
+        host.Find(".dx-toast-host").TriggerEvent("onmouseenter", new MouseEventArgs());   // pause
+        await Task.Delay(400);
+        Assert.Single(svc.Toasts);                  // hover held the toast
+
+        host.Find(".dx-toast-host").TriggerEvent("onmouseleave", new MouseEventArgs());   // resume
+        await Task.Delay(400);
+        Assert.Empty(svc.Toasts);
+    }
+}

--- a/tests/BlazorDX.E2E.Tests/TargetSizeE2ETests.cs
+++ b/tests/BlazorDX.E2E.Tests/TargetSizeE2ETests.cs
@@ -1,0 +1,62 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace BlazorDX.E2E.Tests;
+
+/// <summary>
+/// WCAG 2.5.8 Target Size (Minimum): interactive reorder controls must present at
+/// least a 24x24 CSS-px hit area. axe-core cannot detect this — it needs real layout,
+/// not just the DOM — so it is verified here against the live browser box model. This
+/// is the automated guard for the target-size gap the accessibility audit flagged.
+/// </summary>
+[Collection("e2e")]
+public sealed class TargetSizeE2ETests(PlaywrightFixture fx)
+{
+    private const double Min = 24.0;
+    private const double Epsilon = 0.5;   // tolerate sub-pixel layout rounding
+
+    [SkippableTheory]
+    [InlineData("/sortable", ".dx-sortable-item", ".dx-sortable-move")]
+    [InlineData("/tiles", ".dx-tile", ".dx-tile-move")]
+    public async Task Reorder_controls_meet_target_size_minimum(string route, string ready, string target)
+    {
+        Skip.IfNot(fx.Ready, fx.SkipReason);
+        IPage page = await fx.NewPageAsync();
+        await page.GotoInteractiveAsync($"{fx.BaseUrl}{route}", ready);
+
+        await AssertAllAtLeastMinAsync(page, target);
+    }
+
+    [SkippableFact]
+    public async Task Grid_column_chooser_move_buttons_meet_target_size_minimum()
+    {
+        Skip.IfNot(fx.Ready, fx.SkipReason);
+        IPage page = await fx.NewPageAsync();
+        await page.GotoInteractiveAsync($"{fx.BaseUrl}/grid", ".dx-grid");
+
+        // The no-drag reorder buttons live inside the column chooser; open it first.
+        await page.ClickAsync(".dx-grid-chooser-toggle");
+        await page.WaitForSelectorAsync(".dx-grid-chooser-move", new PageWaitForSelectorOptions { Timeout = 10_000 });
+
+        await AssertAllAtLeastMinAsync(page, ".dx-grid-chooser-move");
+    }
+
+    private static async Task AssertAllAtLeastMinAsync(IPage page, string selector)
+    {
+        IReadOnlyList<IElementHandle> elements = await page.QuerySelectorAllAsync(selector);
+        Assert.True(elements.Count > 0, $"No elements matched '{selector}'; the size check would pass vacuously.");
+
+        foreach (IElementHandle element in elements)
+        {
+            var box = await element.BoundingBoxAsync();
+            if (box is null)
+            {
+                continue;   // not laid out (e.g. off-screen) — nothing to measure
+            }
+
+            Assert.True(
+                box.Width >= Min - Epsilon && box.Height >= Min - Epsilon,
+                $"'{selector}' has a {box.Width}x{box.Height} CSS-px target; WCAG 2.5.8 requires at least 24x24.");
+        }
+    }
+}


### PR DESCRIPTION
Accessibility: WCAG 2.2 conformance pass (target size, pointer, forms, timing, bypass)
Closes a set of WCAG 2.2 Level AA and Level A gaps surfaced by an audit of the component catalog. Every change is library-owned (no app wiring required), survives trimming/AOT, and is verified by tests rather than asserted.

What's included
Level AA

2.5.8 Target Size (Minimum) — enlarged undersized hit areas to the 24×24 CSS-px minimum: chip remove, tree twisty/spacer, range-slider thumb, and alert close.
2.5.7 Dragging Movements — added a single-pointer, no-drag reorder alternative for pointer users who can't drag: Move ◀/▶ buttons in the DataGrid column chooser, and Move up/down (earlier/later) buttons on DxSortableList and DxTileLayout, reusing each primitive's existing reorder via a new MoveByAsync. (Keyboard reorder already existed — Ctrl/Alt+Arrow — and is preserved.)
Level A

3.3.1 Error Identification — form fields now emit aria-invalid="true" and aria-describedby pointing at a stable, per-form error region (role="alert") carrying the validation text, so screen readers announce the error when focus returns to the field. Wired across every input kind.
2.2.1 Timing Adjustable — toast auto-dismiss is now pausable; DxToastHost pauses every countdown while the toast region is hovered or keyboard-focused and resumes on leave, so a timed toast can't vanish mid-read.
2.4.1 Bypass Blocks — new DxSkipLink component: a "skip to main content" link, offscreen until focused, with reduced-motion handling.
1.1.1 Non-text Content — the decorative accordion chevron is now aria-hidden (the button is already named by its title; state is conveyed via aria-expanded).
2.5.2 Pointer Cancellation — DxComboBox option select and DxCommandPalette command run now fire on click (the up-event) instead of mousedown; mousedown keeps only its preventDefault to hold input focus, so a press that moves off the item before release is cancelled.
Testing
bUnit: 460/460 green — 15 new a11y tests (error association + valid-field negative case, click-reorder + edge-disable on grid/sortable/tiles, toast auto-dismiss/pause/resume + host hover wiring, skip-link rendering, combobox/command-palette click select).
Playwright E2E: 14/14 green in real Chromium — new TargetSizeE2ETests measures live box sizes (axe-core can't see target size), plus the existing axe-core suite (no serious/critical violations — confirms no regression from the form attribute changes) and the drag round-trips.
Builds clean under warnings-as-errors and the DX1000 1000-line file cap; no IL trim warnings.
Notes / out of scope
3.3.7 Redundant Entry is intentionally not addressed — it's a multi-step-workflow concern best owned by the consuming app; a generic library API would be speculative.
DxSkipLink ships as a library primitive; apps place it at the top of their layout and give <main id="main-content" tabindex="-1">. It isn't yet mounted in the demo (so not exercised by the axe suite).
The toast pause test is timing-based (generous margins); the two pure-service toast tests are the deterministic backbone.