### PR TITLE
Release 0.2.0: bump version for the WCAG 2.2 accessibility pass

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
     <RepositoryUrl>https://github.com/logixrcorp/BlazorDX.git</RepositoryUrl>
     <PackageProjectUrl>https://blazordx.com</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Description>BlazorDX — a secure-by-default, AOT-safe, headless Blazor component system for .NET 10. Zero runtime reflection; C# + Rust + TypeScript. Beta / AI-generated; not for production use.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>blazor;components;datagrid;headless;aot;trimming;wasm;rust;ui;dotnet</PackageTags>


### PR DESCRIPTION
Minor bump (additive): new DxSkipLink component, single-pointer no-drag reorder for grid/sortable/tiles, toast pause-on-hover/focus, and form error association (aria-invalid / aria-describedby).