### PR TITLE
Localization & RTL Phase 0: prove the mechanism, pilot two components

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,10 @@
     <!-- IHttpClientFactory for the SSRS reporting integration: a typed/named
          HttpClient is the supported way to reach the report server. -->
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <!-- IStringLocalizer<T> — the localization spike (ADR 0016). Under evaluation
+         against this project's AOT/trim gate before it's adopted repo-wide; see
+         docs/adr/0016-localization-rtl-strategy.md for the outcome. -->
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup Label="Blazor Web App (demo)">
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />

--- a/docs/adr/0016-localization-rtl-strategy.md
+++ b/docs/adr/0016-localization-rtl-strategy.md
@@ -1,0 +1,128 @@
+# ADR 0016 — Localization mechanism and RTL layout strategy
+
+**Status:** Accepted
+
+## Context
+
+The completion audit named this the single largest remaining engineering item: zero
+localization infrastructure existed anywhere in the repo (no `IStringLocalizer`, no
+`.resx`, no reference to `Microsoft.Extensions.Localization`), and ~90 user-facing strings
+sat as hardcoded literals across the 133 `Dx*` components in `src/BlazorDX.Components`
+(zero in `src/BlazorDX.Primitives` — primitives are unlabeled by design, per
+[ADR 0001](0001-two-tier-headless.md)'s two-tier split, so this work is scoped to the
+styled tier only). Separately, CSS across `wwwroot/*.css` was 100% physical directional
+properties, 0% logical.
+
+This decision covers Phase 0 only: proving a string-externalization and RTL mechanism
+end to end on a real pilot slice, verified against this repo's actual AOT-publish CI gate
+rather than assumed. The other ~130 components are a separate, later, multi-phase effort.
+
+## The fork: `IStringLocalizer<T>` vs. a source-generated alternative
+
+BlazorDX's identity is built on zero runtime reflection ([ADR 0002](0002-zero-reflection-source-generation.md):
+*"Forbid runtime reflection on any hot or trimmable path... A custom generator is a
+maintenance surface, accepted for the safety it gives"*), enforced by a dedicated CI job
+(`aot-publish`) that AOT-publishes the whole demo with `-p:EnableAot=true` and treats
+warnings as errors. `IStringLocalizer<T>`'s default implementation resolves through
+`ResourceManager`/satellite assemblies, which has a documented history of AOT/trim
+friction in Blazor WASM. Rather than assume either way, this was resolved empirically: a
+real component was wired to `IStringLocalizer<T>` + `.resx`, then published with the
+*exact* command `aot-publish` runs in CI
+(`dotnet publish samples/BlazorDX.Demo/BlazorDX.Demo/BlazorDX.Demo.csproj -c Release
+-p:EnableAot=true -o publish`).
+
+**Result: clean.** Zero warnings, zero errors, on a build that treats every trim/AOT
+warning as an error. The published output's WASM client bundle
+(`wwwroot/_framework/fr/BlazorDX.Components.resources.*.wasm`) genuinely contains the
+French satellite resource assembly, trimmed and AOT-compiled alongside everything else.
+
+## Decision
+
+**`IStringLocalizer<T>` + `.resx`, at the project root — not under a `ResourcesPath`
+subfolder.**
+
+The first attempt put `.resx` files under a `Localization/` subfolder with
+`<ResourcesPath>Localization</ResourcesPath>` set on the csproj. This compiled and ran,
+and appeared to work for the pilot component (`DxAlert`) — but only by coincidence: its
+one resource key, `"Dismiss"`, is identical to its English value, so a broken lookup
+silently falling back to returning the raw *key* was indistinguishable from a correct
+lookup returning the real *value*. It surfaced for real on the second pilot component
+(`DxDataGrid`), whose keys (`"SelectAllRows"`) don't match their values (`"Select all
+rows"`) — every localized string came back as the literal key.
+
+Root cause: MSBuild embeds a `.resx` under `ResourcesPath` with that path folded into the
+manifest resource name (`BlazorDX.Components.Localization.DxAlert.resources`), but
+`IStringLocalizerFactory`'s default resource-name computation is unaware of
+`ResourcesPath` unless it is *also* configured identically on the runtime side —
+`AddLocalization(o => o.ResourcesPath = "Localization")` — in **every** consuming app and
+**every** test project. That's an easy, silent way to reintroduce this exact bug across
+130 more components and dozens of test files. Root-level `.resx` (`DxAlert.resx`, next to
+`DxAlert.cs`) matches the default manifest-name convention (`BlazorDX.Components.DxAlert`)
+with zero extra configuration anywhere, eliminating the whole bug class.
+
+**Verification technique for future pilots:** a bUnit test asserting a component renders
+its real English string proves nothing — a broken lookup falling back to the raw key can
+coincidentally match. Assert a *sentinel* value from an explicitly-registered fake
+localizer (proves the component is wired to the DI-resolved localizer, not still
+hardcoded), **and** assert the real English value with the real `AddLocalization()`
+factory registered and no override (proves the `.resx` resource pipeline itself
+resolves correctly) — both are required; either alone can pass while the other is broken.
+
+**Generic components need a non-generic marker type.** `DxDataGrid<TRow>` cannot inject
+`IStringLocalizer<DxDataGrid<TRow>>` directly: the resource-name computation for an open
+generic type varies by which `TRow` closes it, so `DxDataGrid<Person>` and
+`DxDataGrid<Order>` would each expect a differently-named resource even though one
+`DxDataGridResources.resx` file is meant to serve every `TRow`. The fix is the standard
+one: a non-generic marker type (`DxDataGridResources`) that `IStringLocalizer<T>` injects
+against instead, with the resx file named to match the marker.
+
+**RTL: convert physical CSS properties to logical properties**
+(`margin-inline-start`/`inset-inline-start`/`text-align: start` etc.), which the browser
+flips automatically under `dir="rtl"` with no separate override rule needed for the common
+case. Piloted on `dx-overlay.css` (backs `DxDialog`): 5 physical declarations converted
+(`text-align: left` → `start` ×3, `margin-left` → `margin-inline-start` ×2), zero
+physical directional declarations remain in the file.
+
+**Not every `left`/`right` is a text-direction concern.** `DxSheet`'s
+`dx-sheet-panel-left`/`-right` classes are an explicit "which physical screen edge" API
+choice a developer makes (`Side="right"`), the same way every other drawer/sheet component
+works — not something that should flip under `dir="rtl"`, or `Side="right"` would visually
+dock left, contradicting its own name. Left physical, documented in place.
+
+## Consequences
+
+- **A real, reproducible resource-naming bug was caught and fixed before it could
+  propagate across the other 130 components' worth of future work** — the actual value of
+  running this as an empirical Phase 0 spike rather than assuming a pattern from the first
+  component that happened to work.
+- Every future pilot's test suite must include both the sentinel test and the real-resource
+  fallback test (see above) — a convention, not enforced by tooling yet. `DX1003` (a future
+  analyzer banning new hardcoded literal strings, timed for after Phase 0, before the
+  multi-component rollout) does not by itself guard against this specific resource-naming
+  regression; that needs the two-test pattern.
+- `.resx` files live at each component's project root, one pair per marker type
+  (`Component.resx` + `Component.{culture}.resx`), not organized into a subfolder — a
+  minor organizational cost accepted for eliminating an entire class of silent
+  misconfiguration.
+- Generic components need a marker type for localization; this is now the established
+  pattern for any other generic `Dx*` component the later rollout touches.
+- **A live browser demonstration of culture-switching was attempted and deliberately
+  abandoned, not shipped as broken code.** A `?culture=` query-string toggle was wired on
+  both the server (via `RequestLocalizationMiddleware`, confirmed correctly setting
+  `CultureInfo.CurrentCulture` at the request level via a diagnostic endpoint) and the
+  client (via direct `CultureInfo.CurrentCulture`/`CurrentUICulture` assignment before
+  `RunAsync()`). Neither reliably changed what `@rendermode InteractiveWebAssembly`
+  components actually rendered: the server-side value never reached
+  `DxAlert.BuildRenderTree()`'s `IStringLocalizer` call (Razor Components' prerender
+  dispatch for WASM render mode appears not to flow ambient request culture into render
+  execution — plausibly deliberate, since real client-side WASM execution has no HTTP
+  request to derive a culture from at all), and WASM hydration adopting an
+  already-prerendered DOM does not force a fresh render of unchanged components, so even a
+  correctly-applied client-side culture switch wouldn't visibly repaint. This is a real,
+  unresolved gap in *demonstrating* culture-switching live in a browser — it is not a gap
+  in the underlying mechanism, which is proven independently and more rigorously by the
+  bUnit sentinel/fallback tests and the real AOT publish. Future work wanting a live demo
+  toggle should investigate `IHostEnvironmentAuthenticationStateProvider`-style
+  state-flow patterns or a forced `StateHasChanged()` after culture changes, rather than
+  assuming ambient `CultureInfo` propagates through Blazor's renderer the way it does
+  through plain ASP.NET Core middleware.

--- a/samples/BlazorDX.Demo/BlazorDX.Demo.Client/Program.cs
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo.Client/Program.cs
@@ -7,10 +7,15 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 // XML doc comments (/_content/<lib>/api-docs.xml) for parameter descriptions.
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
+// IStringLocalizer<T> resolution (ADR 0016's spike) -- needed on both the client
+// and server (the server's own AddLocalization() call is in its Program.cs) since
+// pages prerender server-side too.
+builder.Services.AddLocalization();
+
 // Registers IGridCompute; in the browser this resolves to the Rust/wasm backend.
 // (AddBlazorDXCompute also registers every BlazorDX.Interop bridge -- grid DOM/wasm,
-// overlay, richtext, hotkeys, image editor, file DnD/hash, scheduler, document viewer,
-// and the ephemeral chat crypto/DOM bridge -- with their real, browser-only implementations.)
+// overlay, richtext, hotkeys, image editor, file DnD/hash, scheduler, and document
+// viewer -- with their real, browser-only implementations.)
 builder.Services.AddBlazorDXCompute();
 
 // DxPowerBiReport's browser bridge (the [JSImport] wrapper over dx-powerbi.js).

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/Components/App.razor
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/Components/App.razor
@@ -1,7 +1,7 @@
 ﻿@inject NavigationManager Nav
 @inject IConfiguration Configuration
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="@Dir">
 
 <head>
     <meta charset="utf-8" />
@@ -135,4 +135,12 @@
     // Canonical / og:url for the current request, without query string or fragment.
     // Behind the Cloudflare tunnel, forwarded headers make this the public https URL.
     private string CanonicalUrl => new Uri(Nav.Uri).GetLeftPart(UriPartial.Path);
+
+    // Demo-only RTL toggle for manually verifying logical-property CSS conversions and
+    // driving the axe-core RTL sweep (ADR 0016's spike): ?dir=rtl on any route sets the
+    // document direction. App.razor runs server-side (including for interactive-WASM
+    // pages' initial prerender), so this covers both the static-SSR and prerendered-WASM
+    // cases without any client-side wiring.
+    private string Dir =>
+        System.Web.HttpUtility.ParseQueryString(new Uri(Nav.Uri).Query)["dir"] == "rtl" ? "rtl" : "ltr";
 }

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/Program.cs
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/Program.cs
@@ -43,6 +43,10 @@ builder.Services.AddDataProtection()
     .SetApplicationName("BlazorDX.Demo")
     .PersistKeysToFileSystem(new DirectoryInfo(dataProtectionKeysPath));
 
+// IStringLocalizer<T> resolution (ADR 0016's spike) -- also registered client-side
+// (see BlazorDX.Demo.Client's Program.cs) since pages prerender server-side too.
+builder.Services.AddLocalization();
+
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents()

--- a/src/BlazorDX.Components/BlazorDX.Components.csproj
+++ b/src/BlazorDX.Components/BlazorDX.Components.csproj
@@ -12,6 +12,14 @@
          Suppress "missing XML comment" families so warnings-as-errors stays green. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591;CS1573;CS1572;CS1574;CS1710;CS1711;CS1712;CS1734</NoWarn>
+    <!-- .resx resources live at the project root, named after the component type
+         (DxAlert.resx / DxAlert.fr.resx / ...) — deliberately NOT under a ResourcesPath
+         subfolder: that MSBuild property changes where the .resx *file* lives without
+         changing the runtime IStringLocalizerFactory's expected resource name unless
+         AddLocalization(o => o.ResourcesPath = ...) is ALSO configured, identically, in
+         every consuming app AND every test project. Root-level resx keeps the default
+         manifest-name convention working with zero extra configuration anywhere — see
+         docs/adr/0016-localization-rtl-strategy.md for the real bug this avoided. -->
   </PropertyGroup>
 
   <!-- Stage the generated XML doc as a static web asset so the docs app can fetch it
@@ -24,6 +32,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <!-- IStringLocalizer<T> for user-facing strings (see DxAlert's Dismiss label) —
+         see docs/adr/0016-localization-rtl-strategy.md. -->
+    <PackageReference Include="Microsoft.Extensions.Localization" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorDX.Components/DxAlert.cs
+++ b/src/BlazorDX.Components/DxAlert.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.Localization;
 
 namespace BlazorDX.Components;
 
@@ -9,6 +10,8 @@ namespace BlazorDX.Components;
 /// </summary>
 public sealed class DxAlert : ComponentBase
 {
+    [Inject] private IStringLocalizer<DxAlert> L { get; set; } = default!;
+
     [Parameter] public string Severity { get; set; } = "info";
 
     [Parameter] public string? Title { get; set; }
@@ -59,7 +62,7 @@ public sealed class DxAlert : ComponentBase
             builder.OpenElement(13, "button");
             builder.AddAttribute(14, "type", "button");
             builder.AddAttribute(15, "class", "dx-alert-close");
-            builder.AddAttribute(16, "aria-label", "Dismiss");
+            builder.AddAttribute(16, "aria-label", L["Dismiss"].Value);
             builder.AddAttribute(17, "onclick", OnDismiss);
             builder.AddContent(18, "✕");
             builder.CloseElement();

--- a/src/BlazorDX.Components/DxAlert.fr.resx
+++ b/src/BlazorDX.Components/DxAlert.fr.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Dismiss" xml:space="preserve">
+    <value>Ignorer</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxAlert.resx
+++ b/src/BlazorDX.Components/DxAlert.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Dismiss" xml:space="preserve">
+    <value>Dismiss</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxDataGrid.cs
+++ b/src/BlazorDX.Components/DxDataGrid.cs
@@ -4,6 +4,7 @@ using BlazorDX.Primitives.Grid;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Localization;
 
 namespace BlazorDX.Components;
 
@@ -17,6 +18,14 @@ namespace BlazorDX.Components;
 /// <typeparam name="TRow">The row type, bound via a generated accessor.</typeparam>
 public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
 {
+    // Not IStringLocalizer<DxDataGrid<TRow>>: the default ResourceManagerStringLocalizerFactory
+    // computes a resource-manifest name from the injected type's *closed* generic identity, which
+    // would vary per TRow instantiation (DxDataGrid<Person> and DxDataGrid<Order> would each look
+    // for a differently-named resource) even though DxDataGrid.resx is one file shared by every
+    // TRow. DxDataGridResources is a non-generic marker type solely so the resource lookup has one
+    // stable name -- the standard workaround for localizing a generic type (see ADR 0016).
+    [Inject] private IStringLocalizer<DxDataGridResources> L { get; set; } = default!;
+
     /// <summary>Optional extra CSS classes appended to the grid container.</summary>
     [Parameter] public string? Class { get; set; }
 
@@ -38,7 +47,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
         builder.AddAttribute(144, "class", "dx-grid-chooser-toggle");
         builder.AddAttribute(145, "aria-expanded", chooserOpen ? "true" : "false");
         builder.AddAttribute(146, "onclick", EventCallback.Factory.Create(this, () => chooserOpen = !chooserOpen));
-        builder.AddContent(147, $"Columns ({VisibleColumnCount}/{Columns.Count}) ▾");
+        builder.AddContent(147, $"{L["ColumnsToggle", VisibleColumnCount, Columns.Count]} ▾");
         builder.CloseElement();
 
         if (chooserOpen)
@@ -76,10 +85,17 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 // to header drag-and-drop, for pointer users who cannot drag. Each tap
                 // moves the column one display position; the keyboard path is Ctrl+Arrow
                 // on the header (OnHeaderKeyDown).
+                // KNOWN RTL GAP (ADR 0016 non-CSS review, tracked not silently fixed): these
+                // labels/glyphs describe the CURRENT physical layout ("left"/"◀" = earlier
+                // display position). Under dir="rtl" this grid's column order isn't verified
+                // to visually reverse (CSS Grid track order follows document/writing-mode, not
+                // just `dir`), so "left" may or may not match what a reader in RTL actually
+                // sees -- needs a real RTL layout check before this is called correct, not just
+                // localized. Left as-is (not guessed at) for that review.
                 builder.OpenElement(161, "button");
                 builder.AddAttribute(162, "type", "button");
                 builder.AddAttribute(163, "class", "dx-grid-chooser-move");
-                builder.AddAttribute(164, "aria-label", $"Move {header} left");
+                builder.AddAttribute(164, "aria-label", L["MoveColumnLeft", header].Value);
                 builder.AddAttribute(165, "disabled", capturedDisplay == 0);
                 builder.AddAttribute(166, "onclick", EventCallback.Factory.Create(this, () => MoveColumn(capturedDisplay, capturedDisplay - 1)));
                 builder.AddContent(167, "◀");
@@ -88,7 +104,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.OpenElement(168, "button");
                 builder.AddAttribute(169, "type", "button");
                 builder.AddAttribute(170, "class", "dx-grid-chooser-move");
-                builder.AddAttribute(171, "aria-label", $"Move {header} right");
+                builder.AddAttribute(171, "aria-label", L["MoveColumnRight", header].Value);
                 builder.AddAttribute(172, "disabled", capturedDisplay == Columns.Count - 1);
                 builder.AddAttribute(173, "onclick", EventCallback.Factory.Create(this, () => MoveColumn(capturedDisplay, capturedDisplay + 1)));
                 builder.AddContent(174, "▶");
@@ -123,7 +139,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.AddAttribute(138, "type", "button");
                 builder.AddAttribute(139, "class", "dx-grid-export");
                 builder.AddAttribute(190, "onclick", EventCallback.Factory.Create(this, CopySelectionAsync));
-                builder.AddContent(191, "⧉ Copy");
+                builder.AddContent(191, $"⧉ {L["Copy"]}");
                 builder.CloseElement();
             }
 
@@ -133,7 +149,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.AddAttribute(133, "type", "button");
                 builder.AddAttribute(134, "class", "dx-grid-export");
                 builder.AddAttribute(135, "onclick", EventCallback.Factory.Create(this, ExportCsvAsync));
-                builder.AddContent(136, "⭳ Export CSV");
+                builder.AddContent(136, $"⭳ {L["ExportCsv"]}");
                 builder.CloseElement();
             }
 
@@ -143,7 +159,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.AddAttribute(193, "type", "button");
                 builder.AddAttribute(194, "class", "dx-grid-export");
                 builder.AddAttribute(195, "onclick", EventCallback.Factory.Create(this, ExportXlsxAsync));
-                builder.AddContent(196, "⭳ Export Excel");
+                builder.AddContent(196, $"⭳ {L["ExportExcel"]}");
                 builder.CloseElement();
             }
 
@@ -153,7 +169,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.AddAttribute(198, "type", "button");
                 builder.AddAttribute(199, "class", "dx-grid-export");
                 builder.AddAttribute(200, "onclick", EventCallback.Factory.Create(this, ExportPdfAsync));
-                builder.AddContent(201, "⭳ Export PDF");
+                builder.AddContent(201, $"⭳ {L["ExportPdf"]}");
                 builder.CloseElement();
             }
 
@@ -297,8 +313,8 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.OpenElement(69, "input");
             builder.AddAttribute(70, "class", "dx-grid-filter-input");
             builder.AddAttribute(71, "type", "text");
-            builder.AddAttribute(72, "placeholder", "Filter…");
-            builder.AddAttribute(73, "aria-label", $"Filter {Columns[actual].Header}");
+            builder.AddAttribute(72, "placeholder", L["FilterPlaceholder"].Value);
+            builder.AddAttribute(73, "aria-label", L["FilterColumn", Columns[actual].Header].Value);
             builder.AddAttribute(74, "value", ColumnFilter(actual));
             builder.AddAttribute(75, "oninput",
                 EventCallback.Factory.Create<ChangeEventArgs>(this, e => SetFilter(actual, e.Value as string)));
@@ -392,7 +408,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.OpenElement(79, "input");
             builder.AddAttribute(80, "type", "checkbox");
             builder.AddAttribute(81, "class", "dx-grid-select");
-            builder.AddAttribute(82, "aria-label", "Select all rows");
+            builder.AddAttribute(82, "aria-label", L["SelectAllRows"].Value);
             builder.AddAttribute(83, "checked", AllVisibleSelected);
             builder.AddAttribute(84, "indeterminate", SomeVisibleSelected);
             builder.AddAttribute(85, "onchange", EventCallback.Factory.Create(this, ToggleSelectAll));
@@ -421,7 +437,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.AddAttribute(14, "aria-sort", AriaSortFor(actual));
             // Don't make the header draggable mid-resize, or the browser starts a drag.
             builder.AddAttribute(15, "draggable", IsResizing ? "false" : "true");
-            builder.AddAttribute(16, "title", "Drag, or Ctrl+Arrow, to reorder");
+            builder.AddAttribute(16, "title", L["DragToReorder"].Value);
             builder.AddAttribute(18, "ondragstart", EventCallback.Factory.Create(this, () => dragColumn = capturedDisplay));
             builder.AddAttribute(19, "ondragover", EventCallback.Factory.Create(this, () => { }));
             builder.AddEventPreventDefaultAttribute(20, "ondragover", true);
@@ -433,7 +449,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.OpenElement(25, "button");
             builder.AddAttribute(26, "type", "button");
             builder.AddAttribute(27, "class", "dx-grid-th-label");
-            builder.AddAttribute(28, "title", "Click to sort; Shift+Click for multi-column sort");
+            builder.AddAttribute(28, "title", L["SortTitle"].Value);
             builder.AddAttribute(48, "onclick", EventCallback.Factory.Create<MouseEventArgs>(this, e => SortByAsync(actual, e.ShiftKey)));
             builder.AddContent(29, column.Header);
             builder.AddContent(30, SortIndicatorFor(actual));
@@ -442,7 +458,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.OpenElement(31, "span");
             builder.AddAttribute(32, "class", "dx-grid-resize");
             builder.AddAttribute(33, "aria-hidden", "true");
-            builder.AddAttribute(34, "title", "Drag to resize");
+            builder.AddAttribute(34, "title", L["DragToResize"].Value);
             builder.AddAttribute(35, "onpointerdown",
                 EventCallback.Factory.Create<PointerEventArgs>(this, e => StartColumnResize(actual, e.ClientX)));
             builder.AddEventStopPropagationAttribute(36, "onpointerdown", true);
@@ -468,7 +484,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
         builder.OpenElement(160, "button");
         builder.AddAttribute(161, "type", "button");
         builder.AddAttribute(162, "class", active ? "dx-grid-funnel dx-grid-funnel-active" : "dx-grid-funnel");
-        builder.AddAttribute(163, "aria-label", $"Filter {header}");
+        builder.AddAttribute(163, "aria-label", L["FilterColumn", header].Value);
         builder.AddAttribute(164, "aria-expanded", openMenuColumn == actual ? "true" : "false");
         builder.AddAttribute(165, "onclick",
             EventCallback.Factory.Create(this, () => openMenuColumn = openMenuColumn == actual ? -1 : actual));
@@ -497,7 +513,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.AddAttribute(175, "onchange", EventCallback.Factory.Create(this, () => ToggleValueFilter(actual, captured)));
             builder.CloseElement();
 
-            builder.AddContent(176, value.Length == 0 ? "(blank)" : value);
+            builder.AddContent(176, value.Length == 0 ? L["BlankValue"].Value : value);
             builder.CloseElement();
         }
 
@@ -506,7 +522,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
         builder.AddAttribute(179, "class", "dx-grid-valuemenu-clear");
         builder.AddAttribute(180, "disabled", !active);
         builder.AddAttribute(181, "onclick", EventCallback.Factory.Create(this, () => ClearValueFilter(actual)));
-        builder.AddContent(182, "Clear filter");
+        builder.AddContent(182, L["ClearFilter"].Value);
         builder.CloseElement();
 
         builder.CloseElement();
@@ -611,7 +627,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.OpenElement(89, "input");
             builder.AddAttribute(90, "type", "checkbox");
             builder.AddAttribute(91, "class", "dx-grid-select");
-            builder.AddAttribute(92, "aria-label", "Select row");
+            builder.AddAttribute(92, "aria-label", L["SelectRow"].Value);
             builder.AddAttribute(93, "checked", selected);
             builder.AddAttribute(94, "onchange", EventCallback.Factory.Create(this, () => ToggleRow(capturedRow)));
             builder.CloseElement();
@@ -653,7 +669,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             if (editable && !editing)
             {
                 builder.AddAttribute(103, "ondblclick", EventCallback.Factory.Create(this, () => BeginEdit(capturedRow, actual)));
-                builder.AddAttribute(104, "title", "Double-click to edit");
+                builder.AddAttribute(104, "title", L["DoubleClickToEdit"].Value);
             }
 
             // The expand twisty lives in the first visible cell when a detail is set.
@@ -663,7 +679,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.OpenElement(107, "button");
                 builder.AddAttribute(108, "type", "button");
                 builder.AddAttribute(109, "class", "dx-grid-detail-toggle");
-                builder.AddAttribute(110, "aria-label", expanded ? "Collapse details" : "Expand details");
+                builder.AddAttribute(110, "aria-label", (expanded ? L["CollapseDetails"] : L["ExpandDetails"]).Value);
                 builder.AddAttribute(111, "aria-expanded", expanded ? "true" : "false");
                 builder.AddAttribute(112, "onclick", EventCallback.Factory.Create(this, () => ToggleRowExpanded(capturedRow)));
                 builder.AddContent(113, expanded ? "▾" : "▸");
@@ -732,7 +748,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
         builder.AddAttribute(111, "class", "dx-grid-edit-input");
         builder.AddAttribute(112, "type", "text");
         builder.AddAttribute(113, "value", EditDraft);
-        builder.AddAttribute(114, "aria-label", $"Edit {Columns[actual].Header}");
+        builder.AddAttribute(114, "aria-label", L["EditColumn", Columns[actual].Header].Value);
         builder.AddAttribute(115, "oninput", EventCallback.Factory.Create<ChangeEventArgs>(this, e => SetEditDraft(e.Value as string)));
         builder.AddAttribute(116, "onchange", EventCallback.Factory.Create(this, CommitEditAsync));
         builder.AddAttribute(117, "onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(this, OnEditKeyDownAsync));
@@ -829,3 +845,11 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
         return SortKeyCount > 1 ? $"{arrow}{order}" : arrow;
     }
 }
+
+/// <summary>
+/// Non-generic marker type <see cref="DxDataGrid{TRow}"/> injects <see cref="IStringLocalizer{T}"/>
+/// against, so its resource lookup has one stable name shared across every <c>TRow</c>
+/// instantiation instead of one that varies per closed generic type. See the doc comment on
+/// <see cref="DxDataGrid{TRow}"/>'s own <c>L</c> field.
+/// </summary>
+public sealed class DxDataGridResources;

--- a/src/BlazorDX.Components/DxDataGridResources.fr.resx
+++ b/src/BlazorDX.Components/DxDataGridResources.fr.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ColumnsToggle" xml:space="preserve">
+    <value>Colonnes ({0}/{1})</value>
+  </data>
+  <data name="MoveColumnLeft" xml:space="preserve">
+    <value>Déplacer {0} vers la gauche</value>
+  </data>
+  <data name="MoveColumnRight" xml:space="preserve">
+    <value>Déplacer {0} vers la droite</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Copier</value>
+  </data>
+  <data name="ExportCsv" xml:space="preserve">
+    <value>Exporter en CSV</value>
+  </data>
+  <data name="ExportExcel" xml:space="preserve">
+    <value>Exporter en Excel</value>
+  </data>
+  <data name="ExportPdf" xml:space="preserve">
+    <value>Exporter en PDF</value>
+  </data>
+  <data name="FilterPlaceholder" xml:space="preserve">
+    <value>Filtrer…</value>
+  </data>
+  <data name="FilterColumn" xml:space="preserve">
+    <value>Filtrer {0}</value>
+  </data>
+  <data name="SelectAllRows" xml:space="preserve">
+    <value>Sélectionner toutes les lignes</value>
+  </data>
+  <data name="DragToReorder" xml:space="preserve">
+    <value>Faire glisser, ou Ctrl+Flèche, pour réorganiser</value>
+  </data>
+  <data name="SortTitle" xml:space="preserve">
+    <value>Cliquer pour trier ; Maj+clic pour un tri multi-colonnes</value>
+  </data>
+  <data name="DragToResize" xml:space="preserve">
+    <value>Faire glisser pour redimensionner</value>
+  </data>
+  <data name="BlankValue" xml:space="preserve">
+    <value>(vide)</value>
+  </data>
+  <data name="ClearFilter" xml:space="preserve">
+    <value>Effacer le filtre</value>
+  </data>
+  <data name="SelectRow" xml:space="preserve">
+    <value>Sélectionner la ligne</value>
+  </data>
+  <data name="DoubleClickToEdit" xml:space="preserve">
+    <value>Double-cliquer pour modifier</value>
+  </data>
+  <data name="CollapseDetails" xml:space="preserve">
+    <value>Réduire les détails</value>
+  </data>
+  <data name="ExpandDetails" xml:space="preserve">
+    <value>Développer les détails</value>
+  </data>
+  <data name="EditColumn" xml:space="preserve">
+    <value>Modifier {0}</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxDataGridResources.resx
+++ b/src/BlazorDX.Components/DxDataGridResources.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ColumnsToggle" xml:space="preserve">
+    <value>Columns ({0}/{1})</value>
+  </data>
+  <data name="MoveColumnLeft" xml:space="preserve">
+    <value>Move {0} left</value>
+  </data>
+  <data name="MoveColumnRight" xml:space="preserve">
+    <value>Move {0} right</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="ExportCsv" xml:space="preserve">
+    <value>Export CSV</value>
+  </data>
+  <data name="ExportExcel" xml:space="preserve">
+    <value>Export Excel</value>
+  </data>
+  <data name="ExportPdf" xml:space="preserve">
+    <value>Export PDF</value>
+  </data>
+  <data name="FilterPlaceholder" xml:space="preserve">
+    <value>Filter…</value>
+  </data>
+  <data name="FilterColumn" xml:space="preserve">
+    <value>Filter {0}</value>
+  </data>
+  <data name="SelectAllRows" xml:space="preserve">
+    <value>Select all rows</value>
+  </data>
+  <data name="DragToReorder" xml:space="preserve">
+    <value>Drag, or Ctrl+Arrow, to reorder</value>
+  </data>
+  <data name="SortTitle" xml:space="preserve">
+    <value>Click to sort; Shift+Click for multi-column sort</value>
+  </data>
+  <data name="DragToResize" xml:space="preserve">
+    <value>Drag to resize</value>
+  </data>
+  <data name="BlankValue" xml:space="preserve">
+    <value>(blank)</value>
+  </data>
+  <data name="ClearFilter" xml:space="preserve">
+    <value>Clear filter</value>
+  </data>
+  <data name="SelectRow" xml:space="preserve">
+    <value>Select row</value>
+  </data>
+  <data name="DoubleClickToEdit" xml:space="preserve">
+    <value>Double-click to edit</value>
+  </data>
+  <data name="CollapseDetails" xml:space="preserve">
+    <value>Collapse details</value>
+  </data>
+  <data name="ExpandDetails" xml:space="preserve">
+    <value>Expand details</value>
+  </data>
+  <data name="EditColumn" xml:space="preserve">
+    <value>Edit {0}</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/wwwroot/api-docs.xml
+++ b/src/BlazorDX.Components/wwwroot/api-docs.xml
@@ -863,6 +863,14 @@
         <member name="P:BlazorDX.Components.DxDataGrid`1.Class">
             <summary>Optional extra CSS classes appended to the grid container.</summary>
         </member>
+        <member name="T:BlazorDX.Components.DxDataGridResources">
+            <summary>
+            Non-generic marker type <see cref="T:BlazorDX.Components.DxDataGrid`1"/> injects <see cref="T:Microsoft.Extensions.Localization.IStringLocalizer`1"/>
+            against, so its resource lookup has one stable name shared across every <c>TRow</c>
+            instantiation instead of one that varies per closed generic type. See the doc comment on
+            <see cref="T:BlazorDX.Components.DxDataGrid`1"/>'s own <c>L</c> field.
+            </summary>
+        </member>
         <member name="T:BlazorDX.Components.DxDatePicker">
             <summary>
             Tier 2 styled date picker. Inherits all behavior from

--- a/src/BlazorDX.Components/wwwroot/dx-overlay.css
+++ b/src/BlazorDX.Components/wwwroot/dx-overlay.css
@@ -134,7 +134,7 @@
 .dx-menu-item {
   display: block;
   width: 100%;
-  text-align: left;
+  text-align: start;
   padding: 8px 10px;
   border: 0;
   border-radius: 6px;
@@ -165,7 +165,7 @@
   min-width: 12rem;
   padding: 8px 12px;
   font: inherit;
-  text-align: left;
+  text-align: start;
   background: #ffffff;
   color: #0f172a;
   border: 1px solid #cbd5e1;
@@ -209,7 +209,7 @@
 }
 .dx-select-option-selected::after {
   content: "✓";
-  margin-left: 12px;
+  margin-inline-start: 12px;
 }
 .dx-select-option-disabled {
   opacity: 0.5;
@@ -243,7 +243,7 @@
 }
 .dx-listbox-option-selected::after {
   content: "✓";
-  margin-left: 12px;
+  margin-inline-start: 12px;
 }
 .dx-listbox-option-disabled {
   opacity: 0.5;
@@ -287,6 +287,13 @@
   padding: 20px;
   overflow: auto;
 }
+/* Deliberately physical, not logical (ADR 0016): DxSheet's Side="left"/"right" is an
+   explicit "which physical screen edge" choice a developer makes, the same way it works
+   in every other sheet/drawer component -- not a reading-direction concern the way
+   text-align/margin above are. Converting these to inline-start/inline-end would make
+   Side="right" dock to the visual left under dir="rtl", contradicting the parameter's own
+   name. RTL support here means the sheet's *content* reads correctly, not that the sheet
+   silently swaps sides. */
 .dx-sheet-panel-right { top: 0; right: 0; bottom: 0; width: min(90vw, 22rem); }
 .dx-sheet-panel-left { top: 0; left: 0; bottom: 0; width: min(90vw, 22rem); }
 .dx-sheet-panel-top { top: 0; left: 0; right: 0; height: min(90vh, 18rem); }
@@ -390,7 +397,7 @@
   min-width: 12rem;
   padding: 8px 12px;
   font: inherit;
-  text-align: left;
+  text-align: start;
   background: #ffffff;
   color: #0f172a;
   border: 1px solid #cbd5e1;

--- a/tests/BlazorDX.Components.Tests/DxAlertTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxAlertTests.cs
@@ -1,0 +1,94 @@
+using AngleSharp.Dom;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// <see cref="DxAlert"/>'s <c>Dismiss</c> aria-label is injected via
+/// <see cref="IStringLocalizer{DxAlert}"/> (ADR 0016's localization spike) -- every test that
+/// renders the component needs one registered (Blazor resolves <c>[Inject]</c> properties
+/// unconditionally at activation, whether or not the component logic ends up reading them),
+/// so each test explicitly registers either the real localizer (<see cref="Services"/>'s
+/// <c>AddLocalization()</c>, resolving <c>DxAlert.resx</c>'s real values) or
+/// <see cref="FakeStringLocalizer{T}"/> (a sentinel, for the one test that needs to prove the
+/// string is actually wired through the localizer rather than still hardcoded).
+/// </summary>
+public sealed class DxAlertTests : TestContext
+{
+    [Fact]
+    public void Renders_severity_class_role_and_title()
+    {
+        Services.AddLocalization();
+        IRenderedComponent<DxAlert> alert = RenderComponent<DxAlert>(p => p
+            .Add(a => a.Severity, "error")
+            .Add(a => a.Title, "Build failed"));
+
+        IElement root = alert.Find("div.dx-alert");
+        Assert.Contains("dx-alert-error", root.ClassName);
+        Assert.Equal("alert", root.GetAttribute("role"));
+        Assert.Contains("Build failed", alert.Markup);
+    }
+
+    [Fact]
+    public void Dismiss_button_hidden_unless_Dismissible()
+    {
+        Services.AddLocalization();
+        IRenderedComponent<DxAlert> alert = RenderComponent<DxAlert>(p => p
+            .Add(a => a.Severity, "info"));
+
+        Assert.Empty(alert.FindAll("button.dx-alert-close"));
+    }
+
+    [Fact]
+    public void Dismiss_aria_label_is_wired_through_the_localizer_not_hardcoded()
+    {
+        // The real English resource value is also "Dismiss" -- asserting that string would
+        // pass whether or not the component actually calls the localizer. The sentinel is
+        // the only assertion that distinguishes "wired to IStringLocalizer<DxAlert>" from
+        // "still a hardcoded literal that happens to match."
+        Services.AddSingleton<IStringLocalizer<DxAlert>>(new FakeStringLocalizer<DxAlert>());
+
+        IRenderedComponent<DxAlert> alert = RenderComponent<DxAlert>(p => p
+            .Add(a => a.Severity, "error")
+            .Add(a => a.Dismissible, true)
+            .Add(a => a.OnDismiss, EventCallback.Factory.Create(this, () => { })));
+
+        IElement button = alert.Find("button.dx-alert-close");
+        Assert.Equal("§§DISMISS§§", button.GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void Dismiss_falls_back_to_the_invariant_resource_when_no_translation_is_registered()
+    {
+        // The real IStringLocalizerFactory (not a fake) -- proves DxAlert.resx's own
+        // invariant-culture value round-trips through the actual resource pipeline,
+        // not just that a registered fake happens to return "Dismiss".
+        Services.AddLocalization();
+
+        IRenderedComponent<DxAlert> alert = RenderComponent<DxAlert>(p => p
+            .Add(a => a.Severity, "error")
+            .Add(a => a.Dismissible, true)
+            .Add(a => a.OnDismiss, EventCallback.Factory.Create(this, () => { })));
+
+        IElement button = alert.Find("button.dx-alert-close");
+        Assert.Equal("Dismiss", button.GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void OnDismiss_fires_on_click()
+    {
+        Services.AddLocalization();
+        bool dismissed = false;
+        IRenderedComponent<DxAlert> alert = RenderComponent<DxAlert>(p => p
+            .Add(a => a.Severity, "warning")
+            .Add(a => a.Dismissible, true)
+            .Add(a => a.OnDismiss, EventCallback.Factory.Create(this, () => dismissed = true)));
+
+        alert.Find("button.dx-alert-close").Click();
+        Assert.True(dismissed);
+    }
+}

--- a/tests/BlazorDX.Components.Tests/DxDataGridChooserTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridChooserTests.cs
@@ -14,6 +14,7 @@ public sealed class DxDataGridChooserTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
+        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridDetailTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridDetailTests.cs
@@ -15,6 +15,7 @@ public sealed class DxDataGridDetailTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
+        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridExportTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridExportTests.cs
@@ -91,6 +91,7 @@ public sealed class DxDataGridExportTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop>(_ => dom);
+        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridFilterMenuTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridFilterMenuTests.cs
@@ -14,6 +14,7 @@ public sealed class DxDataGridFilterMenuTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
+        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridKeyboardTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridKeyboardTests.cs
@@ -18,6 +18,7 @@ public sealed class DxDataGridKeyboardTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
+        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridMultiSortTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridMultiSortTests.cs
@@ -15,6 +15,7 @@ public sealed class DxDataGridMultiSortTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
+        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridTests.cs
@@ -1,9 +1,11 @@
+using AngleSharp.Dom;
 using BlazorDX.Components;
 using BlazorDX.Compute;
 using BlazorDX.Interop;
 using BlazorDX.Primitives.Grid;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Xunit;
 
 namespace BlazorDX.Components.Tests;
@@ -37,6 +39,7 @@ public sealed class DxDataGridTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
+        Services.AddLocalization();
     }
 
     [Fact]
@@ -61,6 +64,39 @@ public sealed class DxDataGridTests : TestContext
             .Add(g => g.Accessor, new WidgetRowGridAccessor()));
 
         Assert.Contains("aria-rowcount=\"3\"", grid.Markup);
+    }
+
+    [Fact]
+    public void Select_all_aria_label_is_wired_through_the_localizer_not_hardcoded()
+    {
+        // Same reasoning as DxAlertTests's sentinel test: the real English resource value is
+        // also "Select all rows", so only a sentinel distinguishes "wired to
+        // IStringLocalizer<DxDataGridResources>" from "still a hardcoded literal." Registered
+        // against the non-generic marker type, not IStringLocalizer<DxDataGrid<WidgetRow>> --
+        // see the doc comment on DxDataGrid<TRow>'s own L field for why.
+        Services.AddSingleton<IStringLocalizer<DxDataGridResources>>(new FakeStringLocalizer<DxDataGridResources>());
+
+        IRenderedComponent<DxDataGrid<WidgetRow>> grid = RenderComponent<DxDataGrid<WidgetRow>>(parameters => parameters
+            .Add(g => g.Items, Rows)
+            .Add(g => g.Accessor, new WidgetRowGridAccessor())
+            .Add(g => g.Selectable, true));
+
+        IElement checkbox = grid.Find("input.dx-grid-select");
+        Assert.Equal("§§SELECTALLROWS§§", checkbox.GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void Select_all_falls_back_to_the_invariant_resource_when_no_translation_is_registered()
+    {
+        // Services.AddLocalization() is already called in the constructor -- this proves
+        // DxDataGridResources.resx's own real value round-trips, not a registered fake.
+        IRenderedComponent<DxDataGrid<WidgetRow>> grid = RenderComponent<DxDataGrid<WidgetRow>>(parameters => parameters
+            .Add(g => g.Items, Rows)
+            .Add(g => g.Accessor, new WidgetRowGridAccessor())
+            .Add(g => g.Selectable, true));
+
+        IElement checkbox = grid.Find("input.dx-grid-select");
+        Assert.Equal("Select all rows", checkbox.GetAttribute("aria-label"));
     }
 
     private static readonly List<WidgetRow> Grouped =

--- a/tests/BlazorDX.Components.Tests/DxFeedbackTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxFeedbackTests.cs
@@ -9,6 +9,11 @@ namespace BlazorDX.Components.Tests;
 /// <summary>Toast service/host, alert, progress, spinner.</summary>
 public sealed class DxFeedbackTests : TestContext
 {
+    public DxFeedbackTests()
+    {
+        Services.AddLocalization();
+    }
+
     [Fact]
     public void Toast_service_adds_and_removes_with_change_events()
     {

--- a/tests/BlazorDX.Components.Tests/FakeStringLocalizer.cs
+++ b/tests/BlazorDX.Components.Tests/FakeStringLocalizer.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Localization;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// Test double for <see cref="IStringLocalizer{T}"/> (ADR 0016's localization spike).
+/// Returns a caller-supplied sentinel for every key instead of a real translation, so a
+/// test asserting the sentinel appears in the DOM proves the component's string is
+/// actually wired through the localizer -- unlike asserting the real English string,
+/// which would pass identically whether the component still had it hardcoded.
+/// </summary>
+internal sealed class FakeStringLocalizer<T> : IStringLocalizer<T>
+{
+    private readonly Func<string, string> map;
+
+    /// <param name="map">Given a resource key, returns the string to substitute. Defaults to
+    /// prefixing the key with "§§" and uppercasing it (e.g. "Dismiss" -> "§§DISMISS§§") when
+    /// no custom mapping is supplied.</param>
+    public FakeStringLocalizer(Func<string, string>? map = null) =>
+        this.map = map ?? (key => $"§§{key.ToUpperInvariant()}§§");
+
+    public LocalizedString this[string name] => new(name, map(name));
+
+    public LocalizedString this[string name, params object[] arguments] =>
+        new(name, string.Format(map(name), arguments));
+
+    public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) =>
+        throw new NotSupportedException("Not needed by any test using this fake.");
+}

--- a/tests/BlazorDX.Components.Tests/GridStateTests.cs
+++ b/tests/BlazorDX.Components.Tests/GridStateTests.cs
@@ -20,6 +20,7 @@ public sealed class GridStateTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
+        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/ObservabilityTests.cs
+++ b/tests/BlazorDX.Components.Tests/ObservabilityTests.cs
@@ -47,6 +47,7 @@ public sealed class ObservabilityTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
+        Services.AddLocalization();
     }
 
     // ---- Diagnostics sink ----

--- a/tests/BlazorDX.Components.Tests/RemoteGridTests.cs
+++ b/tests/BlazorDX.Components.Tests/RemoteGridTests.cs
@@ -19,6 +19,7 @@ public sealed class RemoteGridTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
+        Services.AddLocalization();
     }
 
     // Records the last request and serves an in-memory dataset as if it were a server.

--- a/tests/BlazorDX.Components.Tests/RemoteGroupGridTests.cs
+++ b/tests/BlazorDX.Components.Tests/RemoteGroupGridTests.cs
@@ -20,6 +20,7 @@ public sealed class RemoteGroupGridTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
+        Services.AddLocalization();
     }
 
     // An in-memory dataset answering both group-summary and per-group row queries like a server.

--- a/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
+++ b/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
@@ -38,6 +38,8 @@ public sealed class AccessibilityE2ETests(PlaywrightFixture fx)
     [InlineData("/reports")]             // static-SSR + HTMX SSRS report viewer (embed + parameter form)
     [InlineData("/powerbi")]             // interactive Power BI embed (wrapper container, loading/error)
     [InlineData("/charts")]              // all 25 chart types, incl. interactive selection (Bar/Treemap/Network graph)
+    [InlineData("/dialog")]              // Overlays family (dx-overlay.css): Dialog, backed by DxDialog/DialogPrimitive
+    [InlineData("/dialog?dir=rtl")]      // same route under dir="rtl" — ADR 0016's RTL pilot (logical-property CSS)
     public async Task Page_has_no_serious_axe_violations(string route)
     {
         Skip.IfNot(fx.Ready, fx.SkipReason);


### PR DESCRIPTION
## Summary

The audit's largest remaining item, scoped to a committed Phase 0 only: prove a string-externalization + RTL mechanism end to end, verified against the real AOT-publish CI gate rather than assumed. The other ~130 components are a separate, later, multi-phase rollout (tracked in [ADR 0016](docs/adr/0016-localization-rtl-strategy.md), not started here).

- **`IStringLocalizer<T>` + `.resx` confirmed AOT/trim-safe**: the exact `aot-publish` CI command ran clean, zero warnings, on a build that treats every trim warning as an error. Resolved the fork against a source-generated alternative empirically, not by assumption.
- **Caught and fixed a real, reproducible resource-naming bug** before it could propagate across 130 more components — see ADR 0016 for the full story. A `ResourcesPath` subfolder convention *appeared* to work on the first pilot only because its one string's key coincidentally equals its value, masking a broken lookup silently falling back to the raw key. Fixed by moving `.resx` to each component's project root, eliminating the whole bug class.
- **Two pilots**: `DxAlert` (leaf) and `DxDataGrid` (hard case — 20 strings, stayed under the 1000-line cap). Both proven with a two-part test technique a naive test can't replace: a sentinel-value test + a real-resource fallback test.
- **A real non-CSS RTL finding, documented not guessed at**: `DxDataGrid`'s column reorder buttons describe physical left/right, and it's unverified whether the grid's column order actually reverses under `dir="rtl"` — flagged as a tracked open item.
- **CSS pilot**: `dx-overlay.css` converted to logical properties, verified visually correct in real RTL rendering.
- **A live culture-switch browser demo was attempted and deliberately dropped**, not shipped half-working — documented honestly in the ADR rather than papered over.

## Test plan

- [x] Full solution build: 0 warnings, 0 errors
- [x] Real `aot-publish` CI command run locally: 0 warnings, 0 errors, French satellite resources present in the trimmed/AOT-compiled WASM output
- [x] 1049/1049 component tests (including new sentinel/fallback pairs)
- [x] 44/44 E2E tests (including the new axe-core RTL route pair on `/dialog`)
- [x] Live visual RTL check via browser (nav mirrors, text aligns, dialog buttons reorder via native flex `dir` support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)