### PR TITLE
Bump CI/Docker Node.js from 20 to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node (esbuild for the TypeScript bridge)
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Add the wasm Rust target (dx_grid)
         run: rustup target add wasm32-unknown-unknown
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Node (esbuild for the TypeScript bridge)
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Add the wasm Rust target (dx_grid)
         run: rustup target add wasm32-unknown-unknown
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Node (esbuild for the TypeScript bridge)
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Add the wasm Rust target (dx_grid)
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Node (esbuild for the TypeScript bridge)
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Add the wasm Rust target (dx_grid)
         run: rustup target add wasm32-unknown-unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,17 @@
 # ---- Build stage ------------------------------------------------------------
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
-# Node.js 20 (esbuild bundling) + Rust (wasm32 compute kernel). build-essential (gcc + a
+# Node.js 22 (esbuild bundling) + Rust (wasm32 compute kernel). build-essential (gcc + a
 # linker) is needed to build/link Rust *build scripts* on the host triple — GitHub Actions'
 # ubuntu-latest runner ships gcc preinstalled, which is why a missing one never showed up in
 # CI, only in a `docker build` from this minimal SDK base image.
+# Node 22, not 20: jsdom (a devDependency of the TS interop bridge) requires Node
+# ^22.22.2 || ^24.15.0 || >=26.0.0 as of jsdom 30 — Node 20 only produced non-fatal
+# EBADENGINE warnings, not a hard failure, but that's an unenforced coincidence, not a
+# supported combination.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates build-essential \
- && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
  && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
jsdom 30 (merged in #25) requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`. CI was running
on Node 20 the whole time — confirmed via the actual `npm ci` logs, which emit `EBADENGINE`
warnings for jsdom and three of its transitive deps (`@asamuzakjp/css-color`,
`@asamuzakjp/dom-selector`, `undici`) rather than a hard failure, so it never surfaced as a
build break:

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'jsdom@30.0.1',
npm warn EBADENGINE   required: { node: '^22.22.2 || ^24.15.0 || >=26.0.0' },
npm warn EBADENGINE   current: { node: 'v20.20.2', npm: '10.8.2' }
npm warn EBADENGINE }
```

Bumps `node-version: '20'` → `'22'` in `ci.yml` (×3 jobs) and `release.yml`, and the
NodeSource setup script in the root `Dockerfile` from `setup_20.x` → `setup_22.x`. This
closes the gap instead of relying on npm's non-strict engine checking indefinitely.

No functional change to what gets built — Node here only runs esbuild bundling and vitest
for the TS interop bridge, never ships in the AOT-published app.