### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to BlazorDX are documented here. The format is loosely based
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-09-02
+
 ### Removed
 
 - **The Zero-Trust, Ephemeral AI Chat Conduit moved to its own repository, [AIEphemeral](https://github.com/logixrcorp/AIEphemeral).**
@@ -599,12 +601,45 @@ All notable changes to BlazorDX are documented here. The format is loosely based
   upstream playground backend host was retired. Repointed at the playground's current
   `GenerateToken` endpoint and fixed the (now lowercase) JSON key parsing.
 
-> **A note on 0.5.0:** `artifacts/releases/0.5.0/` holds a real local pack (built
-> 2026-07-17 from `feat/extended-document-handling` at commit `c4a95e2`), but it was
-> never tagged and `Directory.Build.props`'s declared `<Version>` was never bumped past
-> `0.4.4` — so it isn't a release in the sense every other entry here is. Left out of
-> this changelog rather than backfilled with an invented entry; the 0.3.8–0.4.4 entries
-> below are reconstructed from real tagged commits, this one deliberately isn't.
+### Added
+
+- **Localization & RTL, Phase 0.** The completion audit's largest remaining item: BlazorDX had
+  zero localization infrastructure (no `IStringLocalizer`, no `.resx`) and 100% physical
+  directional CSS. This phase proves the mechanism end to end on a real pilot slice rather than
+  assuming one, and leaves the other ~130 components as a separate, later effort — see
+  [ADR 0016](docs/adr/0016-localization-rtl-strategy.md) for the full decision record.
+  `IStringLocalizer<T>` + root-level `.resx` was validated empirically against this repo's actual
+  AOT-publish CI gate before committing to it (clean, zero trim/AOT warnings) rather than assumed
+  safe. Piloted on `DxAlert` (a single-literal leaf case) and `DxDataGrid` (~20 literals; generic
+  components need a non-generic marker type — `DxDataGridResources` — since
+  `IStringLocalizer<DxDataGrid<TRow>>` would otherwise vary its resource name per closed `TRow`).
+  A real resource-manifest-naming bug was caught and fixed during the pilot (root-level `.resx`
+  instead of a `ResourcesPath` subfolder) before it could propagate across the other 130
+  components — see the ADR for the root cause. New tests follow a sentinel + real-fallback pattern
+  (`DxAlertTests.cs`, plus additions to `DxDataGridTests.cs`) that specifically catches this class
+  of bug, since a naive "does the English string render" test can pass even when localization is
+  silently broken. `dx-overlay.css` (backing `DxDialog`) converted from physical to logical CSS
+  properties (`margin-inline-start`, `text-align: start`, etc.) as the RTL pilot — the standard
+  browser-native fix that needs no `[dir="rtl"]` override for the common case — and the demo app
+  gained a working `?dir=rtl` toggle (`App.razor`). A live in-browser culture-switch demo was
+  attempted and deliberately not shipped; see the ADR's Consequences section for why, and what a
+  future attempt should try instead.
+
+### Fixed
+
+- **Docker builds failed at the wasm-compile step** (`error: manifest path
+  'src/BlazorDX.Security.Rust/Cargo.toml' does not exist`) since the Zero-Trust Ephemeral Chat
+  Conduit's extraction to its own repo (AIEphemeral, see above): every reference to
+  `BlazorDX.Security.Rust` in the C#/TS build chain was cleaned up at the time, but the root
+  `Dockerfile` lives outside that file list and was missed. Dropped the dead `cargo build`/`cp`
+  step and the `dx_security.wasm` publish-output gate; nothing downstream expects that file
+  anymore.
+- **CI silently ran on an unsupported Node version.** jsdom 30 (a `devDependency` of the TS
+  interop bridge's test suite) requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`; CI and the
+  Dockerfile were still pinned to Node 20. This never surfaced as a build failure — `npm ci` only
+  emits non-fatal `EBADENGINE` warnings for jsdom and three of its transitive deps rather than
+  refusing to install — but it was never a supported combination. Bumped Node 20 → 22 across
+  `ci.yml` (all 3 jobs), `release.yml`, and the Dockerfile's NodeSource setup script.
 
 ## [0.4.4] — 2026-06-28
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,7 +52,7 @@
     <RepositoryUrl>https://github.com/logixrcorp/BlazorDX.git</RepositoryUrl>
     <PackageProjectUrl>https://blazordx.com</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.4.4</Version>
+    <Version>0.5.0</Version>
     <Description>BlazorDX — a secure-by-default, AOT-safe, headless Blazor component system for .NET 10. Zero runtime reflection; C# + Rust + TypeScript. Beta / AI-generated; not for production use.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>blazor;components;datagrid;headless;aot;trimming;wasm;rust;ui;dotnet</PackageTags>

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -5,7 +5,7 @@ makes a handful of strong claims; below, each one is paired with where it lives,
 to verify it, and what would *falsify* it. Please try to break them — a review that
 only confirms what we believe is worth little.
 
-The library is young (v0.4.4, single author, no production deployments yet). We are
+The library is young (v0.5.0, single author, no production deployments yet). We are
 not asking "is this as mature as Telerik" — it isn't. We are asking: **is the
 architecture sound, are the differentiating claims actually true across the whole
 catalog (not just the demo), and is the public surface safe to freeze at 1.0?**


### PR DESCRIPTION
Bumps `Directory.Build.props`'s `<Version>` from `0.4.4` to `0.5.0` and backfills the
CHANGELOG's `Unreleased` section into a dated `0.5.0` entry, adding the three items that
hadn't been logged yet:

- **Localization & RTL, Phase 0** (`feat/localization-rtl-phase0`, #33/Gitea#4) — the
  `IStringLocalizer<T>` + root-level `.resx` pilot, empirically validated against the real
  AOT-publish CI gate, plus the `dx-overlay.css` RTL logical-properties pilot. See
  [ADR 0016](docs/adr/0016-localization-rtl-strategy.md).
- **Dockerfile fix** (#34) — dropped the dead `BlazorDX.Security.Rust` build step left over
  from the AIEphemeral extraction, which broke every `docker build`.
  ​- **Node 20→22** (#35) — jsdom 30 requires Node ≥22.22.2; CI was silently running on Node
  20 with only non-fatal `EBADENGINE` warnings.

Also fixes `docs/REVIEW.md`'s stale `v0.4.4` version reference, and removes a changelog note
about an old untagged local `0.5.0` pack (`artifacts/releases/0.5.0/`, gitignored, never
released) that would otherwise read as contradicting this real, tagged 0.5.0.

Once this merges I'll tag `v0.5.0`, which triggers `release.yml` to pack + upload the NuGet
artifacts (no auto-publish to nuget.org, per that workflow's existing design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)