### PR TITLE
Make localization optional, and add the guardrails the rollout needs

### DIFF
--- a/analyzers/BlazorDX.Analyzers/DiagnosticDescriptors.cs
+++ b/analyzers/BlazorDX.Analyzers/DiagnosticDescriptors.cs
@@ -11,6 +11,7 @@ internal static class DiagnosticDescriptors
 {
     private const string ReadabilityCategory = "BlazorDX.Readability";
     private const string SecurityCategory = "BlazorDX.Security";
+    private const string GlobalizationCategory = "BlazorDX.Globalization";
 
     /// <summary>DX1000 — a source file exceeds the 1000-line cap.</summary>
     public static readonly DiagnosticDescriptor FileTooLong = new(
@@ -41,4 +42,16 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Singleton UI state is shared across every connected circuit on Blazor Server, leaking data between users.");
+
+    /// <summary>DX1003 — a hardcoded user-facing string in an already-localized component.</summary>
+    public static readonly DiagnosticDescriptor HardcodedUserFacingString = new(
+        id: "DX1003",
+        title: "User-facing text must go through the component's localizer",
+        messageFormat: "\"{0}\" is user-facing text in a localized component; route it through this component's DxStrings field (S[\"Key\", \"{0}\"])",
+        category: GlobalizationCategory,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A component that already localizes some of its text should not leave other user-facing "
+            + "text hardcoded, or translations are silently partial. Only components holding a DxStrings<T> "
+            + "field are checked, so localizing a component is what switches this rule on for it.");
 }

--- a/analyzers/BlazorDX.Analyzers/HardcodedStringAnalyzer.cs
+++ b/analyzers/BlazorDX.Analyzers/HardcodedStringAnalyzer.cs
@@ -9,7 +9,8 @@ namespace BlazorDX.Analyzers;
 
 /// <summary>
 /// DX1003: flags hardcoded user-facing text in a component that already localizes — visible
-/// content, the accessible-name attributes, and defaulted <c>[Parameter]</c> strings.
+/// content, the accessible-name attributes, and defaulted <c>[Parameter]</c> strings on
+/// text-carrying parameters.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -46,6 +47,25 @@ public sealed class HardcodedStringAnalyzer : DiagnosticAnalyzer
         "alt",
         "placeholder",
         "title");
+
+    // Suffixes that make a [Parameter] property's default *text* rather than a token. The
+    // distinction is real and this rule originally missed it: DxAlert's
+    // `[Parameter] public string Severity { get; set; } = "info"` is a variant name that ends up
+    // in a CSS class, not something a user reads — flagging it (as the first CI run did) would
+    // have forced a localizer call on a machine-facing value. Matching on the name is the same
+    // shape as UserFacingAttributes above: an allow-list, wrong only by omission.
+    private static readonly ImmutableArray<string> UserFacingParameterSuffixes = ImmutableArray.Create(
+        "Label",
+        "Text",
+        "Title",
+        "Message",
+        "Placeholder",
+        "Description",
+        "Caption",
+        "Heading",
+        "Hint",
+        "Tooltip",
+        "Prompt");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(DiagnosticDescriptors.HardcodedUserFacingString);
@@ -101,8 +121,12 @@ public sealed class HardcodedStringAnalyzer : DiagnosticAnalyzer
     {
         var property = (PropertyDeclarationSyntax)context.Node;
 
-        // A defaulted [Parameter] string is the component's own text until a caller overrides it.
-        if (property.Initializer is null || !IsInLocalizedType(property) || !HasParameterAttribute(property))
+        // A defaulted [Parameter] string is the component's own text until a caller overrides it --
+        // but only when the parameter names text at all. See UserFacingParameterSuffixes.
+        if (property.Initializer is null
+            || !IsInLocalizedType(property)
+            || !HasParameterAttribute(property)
+            || !NamesUserFacingText(property.Identifier.ValueText))
         {
             return;
         }
@@ -114,6 +138,9 @@ public sealed class HardcodedStringAnalyzer : DiagnosticAnalyzer
         property.AttributeLists
             .SelectMany(list => list.Attributes)
             .Any(attribute => attribute.Name.ToString() is ParameterAttributeName or ParameterAttributeName + "Attribute");
+
+    private static bool NamesUserFacingText(string propertyName) =>
+        UserFacingParameterSuffixes.Any(suffix => propertyName.EndsWith(suffix, StringComparison.Ordinal));
 
     private static void ReportIfUserFacingText(SyntaxNodeAnalysisContext context, ExpressionSyntax expression)
     {

--- a/analyzers/BlazorDX.Analyzers/HardcodedStringAnalyzer.cs
+++ b/analyzers/BlazorDX.Analyzers/HardcodedStringAnalyzer.cs
@@ -1,0 +1,171 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace BlazorDX.Analyzers;
+
+/// <summary>
+/// DX1003: flags hardcoded user-facing text in a component that already localizes — visible
+/// content, the accessible-name attributes, and defaulted <c>[Parameter]</c> strings.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The ratchet.</b> This only inspects types that hold a <c>DxStrings&lt;T&gt;</c> member, so
+/// localizing a component is what switches the rule on for it. Firing on every component instead
+/// would report the entire not-yet-localized backlog at once — and since the repo builds with
+/// <c>TreatWarningsAsErrors</c>, even a Warning severity would break the build. Scoping it this
+/// way means each rollout batch extends coverage automatically and the rule is silent until then.
+/// </para>
+/// <para>
+/// Known hole, deliberate: a brand-new component with no localizer at all is unguarded. Closing it
+/// is the rollout's completion criterion — once every component is localized, this check can widen
+/// to all of them. See docs/adr/0021-optional-localization-and-rollout-guardrails.md.
+/// </para>
+/// <para>
+/// Glyph-only literals ("✓", "▾", "×", " *") are never flagged: they carry no language. The test
+/// is simply whether the text contains a letter.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class HardcodedStringAnalyzer : DiagnosticAnalyzer
+{
+    private const string LocalizerTypeName = "DxStrings";
+    private const string RenderTreeBuilderTypeName = "RenderTreeBuilder";
+    private const string ParameterAttributeName = "Parameter";
+
+    // Attributes whose value a user reads or hears. "class"/"style"/"role"/"type"/"id" and the
+    // rest are machine-facing and must never be flagged.
+    private static readonly ImmutableHashSet<string> UserFacingAttributes = ImmutableHashSet.Create(
+        "aria-label",
+        "aria-description",
+        "aria-roledescription",
+        "aria-valuetext",
+        "alt",
+        "placeholder",
+        "title");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(DiagnosticDescriptors.HardcodedUserFacingString);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        context.RegisterSyntaxNodeAction(AnalyzeParameterProperty, SyntaxKind.PropertyDeclaration);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax member)
+        {
+            return;
+        }
+
+        string method = member.Name.Identifier.ValueText;
+        if (method is not ("AddContent" or "AddAttribute"))
+        {
+            return;
+        }
+
+        if (!IsInLocalizedType(invocation) || !IsRenderTreeBuilder(context, member.Expression))
+        {
+            return;
+        }
+
+        SeparatedSyntaxList<ArgumentSyntax> args = invocation.ArgumentList.Arguments;
+
+        // AddContent(sequence, value) — the value is rendered text.
+        if (method == "AddContent" && args.Count == 2)
+        {
+            ReportIfUserFacingText(context, args[1].Expression);
+            return;
+        }
+
+        // AddAttribute(sequence, name, value) — only the accessible-name attributes carry text.
+        if (method == "AddAttribute"
+            && args.Count == 3
+            && args[1].Expression is LiteralExpressionSyntax { Token.ValueText: { } attribute }
+            && UserFacingAttributes.Contains(attribute))
+        {
+            ReportIfUserFacingText(context, args[2].Expression);
+        }
+    }
+
+    private static void AnalyzeParameterProperty(SyntaxNodeAnalysisContext context)
+    {
+        var property = (PropertyDeclarationSyntax)context.Node;
+
+        // A defaulted [Parameter] string is the component's own text until a caller overrides it.
+        if (property.Initializer is null || !IsInLocalizedType(property) || !HasParameterAttribute(property))
+        {
+            return;
+        }
+
+        ReportIfUserFacingText(context, property.Initializer.Value);
+    }
+
+    private static bool HasParameterAttribute(PropertyDeclarationSyntax property) =>
+        property.AttributeLists
+            .SelectMany(list => list.Attributes)
+            .Any(attribute => attribute.Name.ToString() is ParameterAttributeName or ParameterAttributeName + "Attribute");
+
+    private static void ReportIfUserFacingText(SyntaxNodeAnalysisContext context, ExpressionSyntax expression)
+    {
+        string? text = expression switch
+        {
+            LiteralExpressionSyntax literal when literal.IsKind(SyntaxKind.StringLiteralExpression) =>
+                literal.Token.ValueText,
+
+            // An interpolated string is user-facing if its *literal* segments carry words — the
+            // interpolated holes are data. $"{Count} ▾" is fine; $"Chart of {Count} points" is not.
+            InterpolatedStringExpressionSyntax interpolated =>
+                string.Concat(interpolated.Contents.OfType<InterpolatedStringTextSyntax>()
+                    .Select(part => part.TextToken.ValueText)),
+
+            _ => null,
+        };
+
+        if (text is null || !ContainsLetter(text))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.HardcodedUserFacingString, expression.GetLocation(), text.Trim()));
+    }
+
+    private static bool ContainsLetter(string text) => text.Any(char.IsLetter);
+
+    // Syntactic on purpose: the check is "does this type localize at all", and a member typed
+    // DxStrings<...> answers that without needing the symbol resolved.
+    private static bool IsInLocalizedType(SyntaxNode node)
+    {
+        TypeDeclarationSyntax? type = node.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+        if (type is null)
+        {
+            return false;
+        }
+
+        return type.Members.Any(member => member switch
+        {
+            FieldDeclarationSyntax field => MentionsLocalizer(field.Declaration.Type),
+            PropertyDeclarationSyntax property => MentionsLocalizer(property.Type),
+            _ => false,
+        });
+    }
+
+    private static bool MentionsLocalizer(TypeSyntax type) =>
+        type.DescendantNodesAndSelf()
+            .OfType<GenericNameSyntax>()
+            .Any(generic => generic.Identifier.ValueText == LocalizerTypeName);
+
+    private static bool IsRenderTreeBuilder(SyntaxNodeAnalysisContext context, ExpressionSyntax receiver) =>
+        context.SemanticModel.GetTypeInfo(receiver, context.CancellationToken).Type?.Name
+            == RenderTreeBuilderTypeName;
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,9 +88,19 @@ enhancements. None of this should be read as "ready"; it is a beta with work ahe
   root-level `.resx` mechanism is proven end to end against the real AOT-publish CI gate
   (not assumed), piloted on `DxAlert` and `DxDataGrid`, with a working RTL CSS pilot
   (`dx-overlay.css` converted to logical properties) and a `?dir=rtl` demo toggle — see
-  [ADR 0016](adr/0016-localization-rtl-strategy.md). *Remaining: roll the proven pattern
-  out across the other ~130 components — still the single largest item on this list, and
-  a hard requirement for many enterprise and international buyers.*
+  [ADR 0016](adr/0016-localization-rtl-strategy.md). **Foundation done**: localization is
+  now **opt-in for consumers** (`AddLocalization()` is no longer required to render a
+  BlazorDX component — the pilot's `[Inject] IStringLocalizer<T>` would have made it
+  mandatory library-wide), a broken resource lookup falls back to English instead of
+  showing the raw key, and two ratchets keep the rollout from regressing: analyzer DX1003
+  bans hardcoded user-facing strings in any component already localized, and
+  `RtlLogicalPropertyTests` bans physical directional CSS in any stylesheet marked
+  converted — see [ADR 0021](adr/0021-optional-localization-and-rollout-guardrails.md) and
+  the runbook at [docs/localization.md](localization.md). *Remaining: the rollout itself —
+  **83 components** carrying ~250–270 strings (the "~130" here previously counted every
+  file; 57 have no user-facing text at all) and 24 stylesheets, ~131 declarations. Still
+  the single largest item on this list, and a hard requirement for many enterprise and
+  international buyers.*
 - **Formal accessibility audit + VPAT** — automated **axe-core checks now run in CI**
   (`AccessibilityE2ETests`, across Chromium/Firefox/WebKit) over the showcase and the
   TicketDesk demo app, with zero serious/critical violations; wiring this up already caught

--- a/docs/adr/0021-optional-localization-and-rollout-guardrails.md
+++ b/docs/adr/0021-optional-localization-and-rollout-guardrails.md
@@ -1,0 +1,168 @@
+# ADR 0021 — Optional localization, and the guardrails the rollout runs behind
+
+**Status:** Accepted
+**Extends:** [ADR 0016](0016-localization-rtl-strategy.md) (which stays accepted — the
+mechanism it chose is unchanged; this record changes how components *consume* it, and adds
+the enforcement 0016 named as future work)
+
+## Context
+
+ADR 0016 proved the mechanism on two pilots and deliberately deferred the rest: "the other
+~130 components are a separate, later, multi-phase effort." Before starting that effort,
+three research passes measured what it actually consists of. Two findings changed the plan.
+
+**The roadmap's component count was wrong.** Of 142 `.cs` files in `BlazorDX.Components`,
+57 have zero user-facing strings (headless wrappers, or parameter-driven components whose
+text comes from the consumer). The real backlog is **83 components, ~250–270 unique
+strings**, and it is extremely lopsided: 60 of the 83 have one to three strings each,
+while 6 heavy hitters hold roughly 40% of all the text. RTL is 24 unconverted stylesheets
+— 104 mechanical declarations plus 27 that need a judgment call, about half of which
+should stay physical.
+
+**The pilot's injection pattern does not survive being applied 83 times.** This is the
+finding that forced a decision before any rollout batch, and it is the substance of this
+ADR.
+
+## Decision 1 — the localizer is resolved optionally, with English at the call site
+
+ADR 0016's pilot injects the localizer directly:
+
+```csharp
+[Inject] private IStringLocalizer<DxAlert> L { get; set; } = default!;
+```
+
+Blazor resolves `[Inject]` properties **unconditionally at component activation**, before
+any component logic runs and regardless of whether the string is ever read. A consumer who
+has not called `AddLocalization()` therefore gets an `InvalidOperationException` when the
+component is *created* — not English text, and not a message that names localization as the
+cause.
+
+With two components localized that is an obscure edge case. Across 83 it is a **mandatory
+`AddLocalization()` call for the entire library**, introduced silently, one component at a
+time, and documented nowhere outside an ADR. The friction was already measurable in this
+repo's own test suite before the rollout even began: `GridStateTests`, `RemoteGridTests`,
+`ObservabilityTests`, `RemoteGroupGridTests` and `DxFeedbackTests` had each added
+`Services.AddLocalization()` while asserting nothing whatsoever about localization. Those
+five were paying the tax for two localized components; every other consumer would have
+paid it for 83.
+
+So components no longer inject `IStringLocalizer<T>`. They hold a `DxStrings<T>`
+(`src/BlazorDX.Components/DxStrings.cs`), which resolves the localizer **lazily and
+optionally** through `IServiceProvider.GetService<T>()` — Blazor offers no optional-inject
+attribute, so the service provider is the escape hatch — and falls back to English supplied
+at the call site:
+
+```csharp
+[Inject] private IServiceProvider Services { get; set; } = default!;
+private DxStrings<DxAlert>? s;
+private DxStrings<DxAlert> S => s ??= new(Services);
+
+// ...
+builder.AddAttribute(16, "aria-label", S["Dismiss", "Dismiss"]);
+builder.AddContent(147, S["ColumnsToggle", "Columns ({0}/{1})", VisibleColumnCount, Columns.Count]);
+```
+
+`AddLocalization()` becomes what it should have been from the start: **opt-in, and only for
+consumers who want translations.** Registering nothing yields an English library that works.
+
+### The fallback also fires on a missing resource, not just a missing localizer
+
+ADR 0016 recorded a hazard it could not fix from inside the pilot: `IStringLocalizer`
+returns *the key itself* when a lookup fails, so a typo or a missing `.resx` entry ships a
+raw key into the UI — visible to end users, and invisible to every test that asserts
+against the same key. `DxStrings` checks `LocalizedString.ResourceNotFound` and falls back
+to the English argument, which converts that failure mode from "user sees `ColumnsToggle`"
+into "user sees English." Across 250+ strings that is the difference between a broken
+lookup being a defect and being a non-event.
+
+### The trade-off, stated plainly
+
+English now lives in two places: the call site and the invariant `.resx`. That duplication
+is **inherent to having a code-level fallback at all** — a fallback that cannot be reached
+without the resource system is not a fallback.
+
+The alternative considered was reading the invariant `.resx` directly through
+`ResourceManager` when no localizer is registered: one source of English, no duplication,
+no DI. It was rejected because it introduces new runtime resource-loading machinery (and a
+second, differently-behaving lookup path to keep AOT-safe) to remove a duplication whose
+practical cost is low, and because inline English is *readable* — a reviewer sees what a
+call site says without opening a `.resx` in another window. If the duplication ever drifts,
+`DxStrings` fails safe: the `.resx` wins whenever it resolves.
+
+## Decision 2 — DX1003 bans hardcoded user-facing strings, behind a ratchet
+
+ADR 0016 named this analyzer as future work and sequenced it "after Phase 0, before the
+multi-component rollout." Without it the rollout is a treadmill: unrelated feature work
+adds unlocalized strings faster than batches remove them — demonstrably so, since the
+scatter/bubble zoom work in [ADR 0020](0020-scatter-bubble-2d-zoom-strategy.md) added
+about five new hardcoded strings while this plan was being written.
+
+`HardcodedStringAnalyzer` (DX1003, Error) flags string literals reaching the user:
+`builder.AddContent(n, "…")`, `builder.AddAttribute(n, "<user-facing attribute>", "…")`
+for `aria-label`, `aria-description`, `aria-roledescription`, `aria-valuetext`, `alt`,
+`placeholder` and `title`, and defaulted `[Parameter] string` properties. It ignores
+literals with no letters (`"✓"`, `"▾"`, `"×"`), format strings, and every
+machine-facing attribute (`class`, `role`, `type`, …).
+
+**The ratchet.** DX1003 fires **only inside types that already hold a `DxStrings<…>`
+member.** `TreatWarningsAsErrors` is repo-wide, so `Warning` severity is not an escape
+hatch — an analyzer that fired everywhere would break the build on 83 components at once.
+Localizing a component is therefore what switches its own guard on, each batch extends
+coverage automatically, and the diagnostic count on the current tree is zero by
+construction.
+
+**The hole this leaves, stated rather than discovered later:** a brand-new component that
+has never been localized is unguarded. The rollout's completion criterion is flipping
+DX1003 to fire on every component file in `BlazorDX.Components`, which closes it.
+
+## Decision 3 — RTL is verified statically, by the same ratchet
+
+Before this ADR, RTL was verified by exactly one check: `/dialog?dir=rtl` in
+`AccessibilityE2ETests`. It runs axe, which is direction-agnostic — it asserts no serious
+accessibility violations and **nothing about layout**. A stylesheet could be 100%
+unconverted and pass it. Landing a 104-declaration sweep against that is unverified by
+construction.
+
+`RtlLogicalPropertyTests` scans shipped `wwwroot/*.css` for physical directional
+properties (`margin-left`, `padding-right`, `border-left*`, `text-align: left|right`,
+`float: left|right`, a bare `left:`/`right:`) and fails on any it finds — in files marked
+`/* rtl-clean */`, and only those. Same ratchet as DX1003: each conversion batch adds the
+marker to what it converts; the end state is every stylesheet marked.
+
+A line carrying `/* rtl-exempt: <reason> */` is allowed, because **some physical usage is
+correct**. `DxSheet`'s `Side="left"/"right"` names a physical screen edge; converting it
+would make `Side="right"` dock on the left under RTL, contradicting the parameter its
+consumer wrote. This formalizes, as an enforced convention, the carve-out ADR 0016's pilot
+had written as prose in `dx-overlay.css`.
+
+Two things the static guard cannot do are covered separately: `?dir=rtl` axe variants for
+`/scheduler`, `/app/records` and `/charts` (the densest directional layouts), and one
+end-to-end assertion that a browser really mirrors — `DxSelect`'s caret sits after its
+value in LTR and before it in RTL, with the computed `direction` asserted on both pages so
+the comparison cannot pass vacuously.
+
+**Also closed:** no test anywhere set `CultureInfo.CurrentUICulture`, so the `.fr.resx`
+files were validated only by the AOT job noticing a satellite assembly existed. A test now
+renders under `fr` and asserts the French value, which is what actually proves the
+`fr-FR` → `fr` → invariant chain resolves.
+
+## Consequences
+
+- New `DxStrings<T>` in `BlazorDX.Components`; `DxAlert` and `DxDataGrid` retrofitted
+  (23 call sites). The `.resx` files are unchanged, and `DxDataGridResources` remains as
+  the non-generic marker type — the default factory derives a resource name from the
+  *closed* generic type, so `DxStrings<DxDataGrid<TRow>>` would look for a different
+  resource per `TRow`.
+- **`AddLocalization()` is no longer required to use BlazorDX.** Eleven test classes that
+  had added it purely to keep components activating no longer call it; that removal is the
+  regression test for this ADR.
+- New analyzer DX1003 and new `RtlLogicalPropertyTests`, both scoped by an opt-in marker,
+  both reporting zero on the current tree.
+- New rollout runbook at [docs/localization.md](../localization.md), carrying the measured
+  backlog and the batch order.
+- Not covered here, and each needing its own mechanism: `FormModelGenerator` bakes English
+  validation messages into generated C#; four Tier-1 primitives carry English defaults;
+  `DxScheduler`'s weekday abbreviations and `DxFileManager`/`DxDatePicker`'s use of
+  `InvariantCulture` for user-visible dates are a date-formatting defect that exists
+  independently of localization; and chart RTL is unreviewed rather than done, since chart
+  geometry is computed in C# render trees and never appears in `dx-chart.css`.

--- a/docs/adr/0021-optional-localization-and-rollout-guardrails.md
+++ b/docs/adr/0021-optional-localization-and-rollout-guardrails.md
@@ -100,9 +100,17 @@ about five new hardcoded strings while this plan was being written.
 `HardcodedStringAnalyzer` (DX1003, Error) flags string literals reaching the user:
 `builder.AddContent(n, "…")`, `builder.AddAttribute(n, "<user-facing attribute>", "…")`
 for `aria-label`, `aria-description`, `aria-roledescription`, `aria-valuetext`, `alt`,
-`placeholder` and `title`, and defaulted `[Parameter] string` properties. It ignores
-literals with no letters (`"✓"`, `"▾"`, `"×"`), format strings, and every
-machine-facing attribute (`class`, `role`, `type`, …).
+`placeholder` and `title`, and defaulted `[Parameter] string` properties **whose name says
+they carry text** (`…Label`, `…Text`, `…Title`, `…Message`, `…Placeholder`, `…Description`,
+`…Caption`, `…Heading`, `…Hint`, `…Tooltip`, `…Prompt`). It ignores literals with no
+letters (`"✓"`, `"▾"`, `"×"`), format strings, and every machine-facing attribute
+(`class`, `role`, `type`, …).
+
+That last qualifier was not in the first draft, and CI caught the omission immediately:
+flagging *every* defaulted parameter reported `DxAlert`'s own
+`[Parameter] public string Severity { get; set; } = "info"` — a variant token that ends up
+in a CSS class, not something a user reads. Matching on the parameter name is the same
+shape as the attribute allow-list: wrong only by omission, never by false alarm.
 
 **The ratchet.** DX1003 fires **only inside types that already hold a `DxStrings<…>`
 member.** `TreatWarningsAsErrors` is repo-wide, so `Warning` severity is not an escape

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -95,8 +95,15 @@ has reintroduced the hard dependency — fix that instead.
 Once a type holds a `DxStrings<…>` member, the `HardcodedStringAnalyzer` starts flagging
 hardcoded user-facing literals **in that type**: `AddContent`, the user-facing attributes
 (`aria-label`, `aria-description`, `aria-roledescription`, `aria-valuetext`, `alt`,
-`placeholder`, `title`), and defaulted `[Parameter] string` properties. It ignores
-letter-free glyphs (`"✓"`, `"▾"`), format strings, and machine-facing attributes.
+`placeholder`, `title`), and defaulted `[Parameter] string` properties whose name ends in
+`Label`, `Text`, `Title`, `Message`, `Placeholder`, `Description`, `Caption`, `Heading`,
+`Hint`, `Tooltip` or `Prompt`. It ignores letter-free glyphs (`"✓"`, `"▾"`), format
+strings, and machine-facing attributes.
+
+The parameter-name test is deliberate: `[Parameter] public string DismissLabel = "Dismiss"`
+is text a user reads, while `[Parameter] public string Severity = "info"` is a variant token
+that ends up in a CSS class. If you add a text-carrying parameter with a name outside that
+list, add the suffix to `UserFacingParameterSuffixes` rather than working around the rule.
 
 So a half-localized component fails the build. That is the intent: the analyzer's coverage
 is exactly the set of components already converted, and it grows with each batch.

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,0 +1,185 @@
+# Localization & RTL — rollout runbook
+
+How to localize a BlazorDX component and convert its stylesheet, and what is left to do.
+
+The decisions behind all of this are in [ADR 0016](adr/0016-localization-rtl-strategy.md)
+(the mechanism) and [ADR 0021](adr/0021-optional-localization-and-rollout-guardrails.md)
+(optional resolution, DX1003, the RTL guard). This document is the procedure.
+
+**Ground rule:** localization is **opt-in for consumers**. A consumer who never calls
+`AddLocalization()` gets an English library that works. Nothing in this runbook may
+reintroduce a hard dependency on the localization services.
+
+---
+
+## 1. Localizing a component
+
+### The pattern
+
+Three lines of boilerplate, then read strings through `S`:
+
+```csharp
+[Inject] private IServiceProvider Services { get; set; } = default!;
+private DxStrings<DxAlert>? s;
+private DxStrings<DxAlert> S => s ??= new(Services);
+```
+
+```csharp
+// key, English fallback
+builder.AddAttribute(16, "aria-label", S["Dismiss", "Dismiss"]);
+
+// key, English fallback, composite-format arguments
+builder.AddContent(147, S["ColumnsToggle", "Columns ({0}/{1})", VisibleColumnCount, Columns.Count]);
+```
+
+Do **not** inject `IStringLocalizer<T>` directly. It resolves at component activation
+whether or not the string is read, so it makes `AddLocalization()` mandatory for anyone
+rendering the component — see ADR 0021, decision 1.
+
+The English text at the call site is the fallback used when no localizer is registered
+**and** when the key has no resource entry. That second case matters: a bare
+`IStringLocalizer` returns the key itself on a failed lookup, so a typo ships `ColumnsToggle`
+into the UI. `DxStrings` returns the English instead.
+
+### The `.resx` files
+
+Put them at the **project root**, next to the `.cs` file, named for the type:
+
+```
+src/BlazorDX.Components/DxAlert.resx      # invariant (English)
+src/BlazorDX.Components/DxAlert.fr.resx   # French
+```
+
+**Never set `ResourcesPath`.** ADR 0016 lost time to this: with `ResourcesPath` set, the
+default factory looks for a resource name that the compiler does not emit, every lookup
+misses, and — because a miss returns the key — the UI shows key names while every test
+still passes. Root-level placement is the configuration that works.
+
+### Generic components need a non-generic marker type
+
+The default factory derives the resource name from the **closed** generic type, so
+`DxStrings<DxDataGrid<TRow>>` would look for `DxDataGrid'1[[Widget]]` — a different
+resource for every `TRow`. Declare a marker type and localize against that:
+
+```csharp
+// One .resx shared by every TRow.
+public sealed class DxDataGridResources;
+
+private DxStrings<DxDataGridResources> S => s ??= new(Services);
+```
+
+The `.resx` is then `DxDataGridResources.resx`.
+
+### The two tests
+
+Every localized component gets both, because each catches what the other cannot:
+
+1. **A sentinel test** — register `FakeStringLocalizer<T>` (returns `§§KEY§§`) and assert
+   the sentinel. This is the only assertion that distinguishes "routed through the
+   localizer" from "still a hardcoded literal that happens to match", since the English
+   fallback usually equals the English resource value.
+2. **A real-resource test** — `Services.AddLocalization()`, assert the English value.
+   This proves the actual `.resx` round-trips through the real factory rather than a fake.
+
+`tests/BlazorDX.Components.Tests/DxAlertTests.cs` is the worked example, and adds the two
+cases that only need to exist once: rendering with **no** localizer registered at all, and
+rendering under `CultureInfo.CurrentUICulture = new("fr")` to prove the
+`fr-FR` → `fr` → invariant chain resolves.
+
+Only register a localizer in tests that assert something about localization. If you find
+yourself adding `Services.AddLocalization()` to make an unrelated test render, something
+has reintroduced the hard dependency — fix that instead.
+
+### DX1003 turns itself on
+
+Once a type holds a `DxStrings<…>` member, the `HardcodedStringAnalyzer` starts flagging
+hardcoded user-facing literals **in that type**: `AddContent`, the user-facing attributes
+(`aria-label`, `aria-description`, `aria-roledescription`, `aria-valuetext`, `alt`,
+`placeholder`, `title`), and defaulted `[Parameter] string` properties. It ignores
+letter-free glyphs (`"✓"`, `"▾"`), format strings, and machine-facing attributes.
+
+So a half-localized component fails the build. That is the intent: the analyzer's coverage
+is exactly the set of components already converted, and it grows with each batch.
+
+---
+
+## 2. Converting a stylesheet
+
+Replace physical directional properties with logical ones:
+
+| Physical | Logical |
+|---|---|
+| `margin-left` / `margin-right` | `margin-inline-start` / `margin-inline-end` |
+| `padding-left` / `padding-right` | `padding-inline-start` / `padding-inline-end` |
+| `border-left` / `border-right` | `border-inline-start` / `border-inline-end` |
+| `border-top-left-radius` | `border-start-start-radius` |
+| `text-align: left` / `right` | `text-align: start` / `end` |
+| `left:` / `right:` (positioning) | `inset-inline-start` / `inset-inline-end` |
+
+Then add the marker to the file header, which is what enables enforcement:
+
+```css
+/* rtl-clean — converted to logical properties; see docs/localization.md */
+```
+
+`RtlLogicalPropertyTests` checks **only** marked files. An unmarked stylesheet is not
+failing, it is simply not converted yet.
+
+### When physical is correct
+
+Some directional CSS should stay physical, and the guard has an escape hatch for it:
+
+```css
+inset-inline-start: 0;
+right: 0; /* rtl-exempt: DxSheet Side="right" names a physical screen edge — flipping it
+             would dock the sheet left under RTL, contradicting the parameter */
+```
+
+`src/BlazorDX.Components/wwwroot/dx-overlay.css` is the worked example: converted, marked,
+and with every deliberately-physical line carrying a reason. The two categories that
+legitimately stay physical are **APIs that name a screen edge** (`DxSheet`'s `Side`) and
+**symmetric boxes** pinned to both edges.
+
+Flip the showcase with `?dir=rtl` on any route to check the result by eye.
+
+---
+
+## 3. What is left
+
+Measured, not estimated. (The roadmap previously said "~130 components"; that counted every
+file rather than the ones with user-facing text.)
+
+| | Count |
+|---|---|
+| `.cs` files in `BlazorDX.Components` | 142 |
+| …with zero user-facing strings (headless / parameter-driven) | 57 |
+| **Components to localize** | **83** (~250–270 unique strings) |
+| …with 1–3 strings each | 60 |
+| …heavy hitters (>10 strings) | 6, holding ~40% of all text |
+| Stylesheets converted | 1 of 25 |
+| RTL declarations remaining | 104 mechanical + 27 judgment calls |
+
+### Batch order
+
+**Strings** — the 6 heavy hitters individually (`DxRichTextEditor` ~30, `DxScheduler` ~25,
+then `DxDocumentViewer` / `DxFileManager` / `DxKbd` / `DxImageEditor` ~18 each) → the 4
+near-identical zoomable charts as one batch → the ~20 remaining charts sharing one
+`DxChartResources.resx` → 11 editorial components → ~28 stragglers alphabetically.
+
+**CSS** — 12 trivial files (≤4 hits each) → `dx-datagrid` → the four heavy files
+individually → `dx-layout` last, since 7 of its 10 declarations are judgment calls.
+
+**Completion criterion:** DX1003 fires on every file in `BlazorDX.Components`, and every
+stylesheet carries `rtl-clean`. Both ratchets exist to be removed.
+
+### Separate tracks, each needing a different mechanism
+
+- **`FormModelGenerator`'s validation messages** bake English into generated C#; a
+  localizer is not reachable from where they are emitted.
+- **Tier-1 primitive English defaults** — four primitives carry user-visible English even
+  though ADR 0001 says primitives are unlabeled.
+- **Date and number formatting** — `DxScheduler` hardcodes weekday abbreviations, and
+  `DxFileManager` / `DxDatePicker` format user-visible dates with `InvariantCulture`. This
+  is a defect on its own terms, independent of translation.
+- **Chart RTL** — `dx-chart.css` scores zero physical properties because chart geometry is
+  computed in C# render trees. That means unreviewed, not done.

--- a/src/BlazorDX.Components/DxAlert.cs
+++ b/src/BlazorDX.Components/DxAlert.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
-using Microsoft.Extensions.Localization;
 
 namespace BlazorDX.Components;
 
@@ -10,7 +9,13 @@ namespace BlazorDX.Components;
 /// </summary>
 public sealed class DxAlert : ComponentBase
 {
-    [Inject] private IStringLocalizer<DxAlert> L { get; set; } = default!;
+    // Localization is optional: with no IStringLocalizer registered, the English text at each
+    // call site renders. See DxStrings<T> and docs/localization.md.
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxAlert>? s;
+
+    private DxStrings<DxAlert> S => s ??= new(Services);
 
     [Parameter] public string Severity { get; set; } = "info";
 
@@ -62,7 +67,7 @@ public sealed class DxAlert : ComponentBase
             builder.OpenElement(13, "button");
             builder.AddAttribute(14, "type", "button");
             builder.AddAttribute(15, "class", "dx-alert-close");
-            builder.AddAttribute(16, "aria-label", L["Dismiss"].Value);
+            builder.AddAttribute(16, "aria-label", S["Dismiss", "Dismiss"]);
             builder.AddAttribute(17, "onclick", OnDismiss);
             builder.AddContent(18, "✕");
             builder.CloseElement();

--- a/src/BlazorDX.Components/DxDataGrid.cs
+++ b/src/BlazorDX.Components/DxDataGrid.cs
@@ -18,13 +18,21 @@ namespace BlazorDX.Components;
 /// <typeparam name="TRow">The row type, bound via a generated accessor.</typeparam>
 public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
 {
-    // Not IStringLocalizer<DxDataGrid<TRow>>: the default ResourceManagerStringLocalizerFactory
-    // computes a resource-manifest name from the injected type's *closed* generic identity, which
-    // would vary per TRow instantiation (DxDataGrid<Person> and DxDataGrid<Order> would each look
-    // for a differently-named resource) even though DxDataGrid.resx is one file shared by every
-    // TRow. DxDataGridResources is a non-generic marker type solely so the resource lookup has one
-    // stable name -- the standard workaround for localizing a generic type (see ADR 0016).
-    [Inject] private IStringLocalizer<DxDataGridResources> L { get; set; } = default!;
+    // Localization is optional: with no IStringLocalizer registered, the English text at each
+    // call site renders (see DxStrings<T> and docs/localization.md).
+    //
+    // DxStrings<DxDataGridResources>, not DxStrings<DxDataGrid<TRow>>: the default
+    // ResourceManagerStringLocalizerFactory computes a resource-manifest name from the type's
+    // *closed* generic identity, which would vary per TRow instantiation (DxDataGrid<Person> and
+    // DxDataGrid<Order> would each look for a differently-named resource) even though
+    // DxDataGridResources.resx is one file shared by every TRow. DxDataGridResources is a
+    // non-generic marker type solely so the resource lookup has one stable name -- the standard
+    // workaround for localizing a generic type (see ADR 0016).
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxDataGridResources>? s;
+
+    private DxStrings<DxDataGridResources> S => s ??= new(Services);
 
     /// <summary>Optional extra CSS classes appended to the grid container.</summary>
     [Parameter] public string? Class { get; set; }
@@ -47,7 +55,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
         builder.AddAttribute(144, "class", "dx-grid-chooser-toggle");
         builder.AddAttribute(145, "aria-expanded", chooserOpen ? "true" : "false");
         builder.AddAttribute(146, "onclick", EventCallback.Factory.Create(this, () => chooserOpen = !chooserOpen));
-        builder.AddContent(147, $"{L["ColumnsToggle", VisibleColumnCount, Columns.Count]} ▾");
+        builder.AddContent(147, $"{S["ColumnsToggle", "Columns ({0}/{1})", VisibleColumnCount, Columns.Count]} ▾");
         builder.CloseElement();
 
         if (chooserOpen)
@@ -95,7 +103,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.OpenElement(161, "button");
                 builder.AddAttribute(162, "type", "button");
                 builder.AddAttribute(163, "class", "dx-grid-chooser-move");
-                builder.AddAttribute(164, "aria-label", L["MoveColumnLeft", header].Value);
+                builder.AddAttribute(164, "aria-label", S["MoveColumnLeft", "Move {0} left", header]);
                 builder.AddAttribute(165, "disabled", capturedDisplay == 0);
                 builder.AddAttribute(166, "onclick", EventCallback.Factory.Create(this, () => MoveColumn(capturedDisplay, capturedDisplay - 1)));
                 builder.AddContent(167, "◀");
@@ -104,7 +112,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.OpenElement(168, "button");
                 builder.AddAttribute(169, "type", "button");
                 builder.AddAttribute(170, "class", "dx-grid-chooser-move");
-                builder.AddAttribute(171, "aria-label", L["MoveColumnRight", header].Value);
+                builder.AddAttribute(171, "aria-label", S["MoveColumnRight", "Move {0} right", header]);
                 builder.AddAttribute(172, "disabled", capturedDisplay == Columns.Count - 1);
                 builder.AddAttribute(173, "onclick", EventCallback.Factory.Create(this, () => MoveColumn(capturedDisplay, capturedDisplay + 1)));
                 builder.AddContent(174, "▶");
@@ -139,7 +147,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.AddAttribute(138, "type", "button");
                 builder.AddAttribute(139, "class", "dx-grid-export");
                 builder.AddAttribute(190, "onclick", EventCallback.Factory.Create(this, CopySelectionAsync));
-                builder.AddContent(191, $"⧉ {L["Copy"]}");
+                builder.AddContent(191, $"⧉ {S["Copy", "Copy"]}");
                 builder.CloseElement();
             }
 
@@ -149,7 +157,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.AddAttribute(133, "type", "button");
                 builder.AddAttribute(134, "class", "dx-grid-export");
                 builder.AddAttribute(135, "onclick", EventCallback.Factory.Create(this, ExportCsvAsync));
-                builder.AddContent(136, $"⭳ {L["ExportCsv"]}");
+                builder.AddContent(136, $"⭳ {S["ExportCsv", "Export CSV"]}");
                 builder.CloseElement();
             }
 
@@ -159,7 +167,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.AddAttribute(193, "type", "button");
                 builder.AddAttribute(194, "class", "dx-grid-export");
                 builder.AddAttribute(195, "onclick", EventCallback.Factory.Create(this, ExportXlsxAsync));
-                builder.AddContent(196, $"⭳ {L["ExportExcel"]}");
+                builder.AddContent(196, $"⭳ {S["ExportExcel", "Export Excel"]}");
                 builder.CloseElement();
             }
 
@@ -169,7 +177,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.AddAttribute(198, "type", "button");
                 builder.AddAttribute(199, "class", "dx-grid-export");
                 builder.AddAttribute(200, "onclick", EventCallback.Factory.Create(this, ExportPdfAsync));
-                builder.AddContent(201, $"⭳ {L["ExportPdf"]}");
+                builder.AddContent(201, $"⭳ {S["ExportPdf", "Export PDF"]}");
                 builder.CloseElement();
             }
 
@@ -313,8 +321,8 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.OpenElement(69, "input");
             builder.AddAttribute(70, "class", "dx-grid-filter-input");
             builder.AddAttribute(71, "type", "text");
-            builder.AddAttribute(72, "placeholder", L["FilterPlaceholder"].Value);
-            builder.AddAttribute(73, "aria-label", L["FilterColumn", Columns[actual].Header].Value);
+            builder.AddAttribute(72, "placeholder", S["FilterPlaceholder", "Filter…"]);
+            builder.AddAttribute(73, "aria-label", S["FilterColumn", "Filter {0}", Columns[actual].Header]);
             builder.AddAttribute(74, "value", ColumnFilter(actual));
             builder.AddAttribute(75, "oninput",
                 EventCallback.Factory.Create<ChangeEventArgs>(this, e => SetFilter(actual, e.Value as string)));
@@ -408,7 +416,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.OpenElement(79, "input");
             builder.AddAttribute(80, "type", "checkbox");
             builder.AddAttribute(81, "class", "dx-grid-select");
-            builder.AddAttribute(82, "aria-label", L["SelectAllRows"].Value);
+            builder.AddAttribute(82, "aria-label", S["SelectAllRows", "Select all rows"]);
             builder.AddAttribute(83, "checked", AllVisibleSelected);
             builder.AddAttribute(84, "indeterminate", SomeVisibleSelected);
             builder.AddAttribute(85, "onchange", EventCallback.Factory.Create(this, ToggleSelectAll));
@@ -437,7 +445,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.AddAttribute(14, "aria-sort", AriaSortFor(actual));
             // Don't make the header draggable mid-resize, or the browser starts a drag.
             builder.AddAttribute(15, "draggable", IsResizing ? "false" : "true");
-            builder.AddAttribute(16, "title", L["DragToReorder"].Value);
+            builder.AddAttribute(16, "title", S["DragToReorder", "Drag, or Ctrl+Arrow, to reorder"]);
             builder.AddAttribute(18, "ondragstart", EventCallback.Factory.Create(this, () => dragColumn = capturedDisplay));
             builder.AddAttribute(19, "ondragover", EventCallback.Factory.Create(this, () => { }));
             builder.AddEventPreventDefaultAttribute(20, "ondragover", true);
@@ -449,7 +457,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.OpenElement(25, "button");
             builder.AddAttribute(26, "type", "button");
             builder.AddAttribute(27, "class", "dx-grid-th-label");
-            builder.AddAttribute(28, "title", L["SortTitle"].Value);
+            builder.AddAttribute(28, "title", S["SortTitle", "Click to sort; Shift+Click for multi-column sort"]);
             builder.AddAttribute(48, "onclick", EventCallback.Factory.Create<MouseEventArgs>(this, e => SortByAsync(actual, e.ShiftKey)));
             builder.AddContent(29, column.Header);
             builder.AddContent(30, SortIndicatorFor(actual));
@@ -458,7 +466,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.OpenElement(31, "span");
             builder.AddAttribute(32, "class", "dx-grid-resize");
             builder.AddAttribute(33, "aria-hidden", "true");
-            builder.AddAttribute(34, "title", L["DragToResize"].Value);
+            builder.AddAttribute(34, "title", S["DragToResize", "Drag to resize"]);
             builder.AddAttribute(35, "onpointerdown",
                 EventCallback.Factory.Create<PointerEventArgs>(this, e => StartColumnResize(actual, e.ClientX)));
             builder.AddEventStopPropagationAttribute(36, "onpointerdown", true);
@@ -484,7 +492,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
         builder.OpenElement(160, "button");
         builder.AddAttribute(161, "type", "button");
         builder.AddAttribute(162, "class", active ? "dx-grid-funnel dx-grid-funnel-active" : "dx-grid-funnel");
-        builder.AddAttribute(163, "aria-label", L["FilterColumn", header].Value);
+        builder.AddAttribute(163, "aria-label", S["FilterColumn", "Filter {0}", header]);
         builder.AddAttribute(164, "aria-expanded", openMenuColumn == actual ? "true" : "false");
         builder.AddAttribute(165, "onclick",
             EventCallback.Factory.Create(this, () => openMenuColumn = openMenuColumn == actual ? -1 : actual));
@@ -513,7 +521,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.AddAttribute(175, "onchange", EventCallback.Factory.Create(this, () => ToggleValueFilter(actual, captured)));
             builder.CloseElement();
 
-            builder.AddContent(176, value.Length == 0 ? L["BlankValue"].Value : value);
+            builder.AddContent(176, value.Length == 0 ? S["BlankValue", "(blank)"] : value);
             builder.CloseElement();
         }
 
@@ -522,7 +530,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
         builder.AddAttribute(179, "class", "dx-grid-valuemenu-clear");
         builder.AddAttribute(180, "disabled", !active);
         builder.AddAttribute(181, "onclick", EventCallback.Factory.Create(this, () => ClearValueFilter(actual)));
-        builder.AddContent(182, L["ClearFilter"].Value);
+        builder.AddContent(182, S["ClearFilter", "Clear filter"]);
         builder.CloseElement();
 
         builder.CloseElement();
@@ -627,7 +635,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             builder.OpenElement(89, "input");
             builder.AddAttribute(90, "type", "checkbox");
             builder.AddAttribute(91, "class", "dx-grid-select");
-            builder.AddAttribute(92, "aria-label", L["SelectRow"].Value);
+            builder.AddAttribute(92, "aria-label", S["SelectRow", "Select row"]);
             builder.AddAttribute(93, "checked", selected);
             builder.AddAttribute(94, "onchange", EventCallback.Factory.Create(this, () => ToggleRow(capturedRow)));
             builder.CloseElement();
@@ -669,7 +677,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
             if (editable && !editing)
             {
                 builder.AddAttribute(103, "ondblclick", EventCallback.Factory.Create(this, () => BeginEdit(capturedRow, actual)));
-                builder.AddAttribute(104, "title", L["DoubleClickToEdit"].Value);
+                builder.AddAttribute(104, "title", S["DoubleClickToEdit", "Double-click to edit"]);
             }
 
             // The expand twisty lives in the first visible cell when a detail is set.
@@ -679,7 +687,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
                 builder.OpenElement(107, "button");
                 builder.AddAttribute(108, "type", "button");
                 builder.AddAttribute(109, "class", "dx-grid-detail-toggle");
-                builder.AddAttribute(110, "aria-label", (expanded ? L["CollapseDetails"] : L["ExpandDetails"]).Value);
+                builder.AddAttribute(110, "aria-label", expanded ? S["CollapseDetails", "Collapse details"] : S["ExpandDetails", "Expand details"]);
                 builder.AddAttribute(111, "aria-expanded", expanded ? "true" : "false");
                 builder.AddAttribute(112, "onclick", EventCallback.Factory.Create(this, () => ToggleRowExpanded(capturedRow)));
                 builder.AddContent(113, expanded ? "▾" : "▸");
@@ -748,7 +756,7 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
         builder.AddAttribute(111, "class", "dx-grid-edit-input");
         builder.AddAttribute(112, "type", "text");
         builder.AddAttribute(113, "value", EditDraft);
-        builder.AddAttribute(114, "aria-label", L["EditColumn", Columns[actual].Header].Value);
+        builder.AddAttribute(114, "aria-label", S["EditColumn", "Edit {0}", Columns[actual].Header]);
         builder.AddAttribute(115, "oninput", EventCallback.Factory.Create<ChangeEventArgs>(this, e => SetEditDraft(e.Value as string)));
         builder.AddAttribute(116, "onchange", EventCallback.Factory.Create(this, CommitEditAsync));
         builder.AddAttribute(117, "onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(this, OnEditKeyDownAsync));
@@ -847,9 +855,9 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
 }
 
 /// <summary>
-/// Non-generic marker type <see cref="DxDataGrid{TRow}"/> injects <see cref="IStringLocalizer{T}"/>
-/// against, so its resource lookup has one stable name shared across every <c>TRow</c>
-/// instantiation instead of one that varies per closed generic type. See the doc comment on
-/// <see cref="DxDataGrid{TRow}"/>'s own <c>L</c> field.
+/// Non-generic marker type <see cref="DxDataGrid{TRow}"/> localizes against, so its resource
+/// lookup has one stable name shared across every <c>TRow</c> instantiation instead of one that
+/// varies per closed generic type. See the comment on <see cref="DxDataGrid{TRow}"/>'s own
+/// <c>S</c> field.
 /// </summary>
 public sealed class DxDataGridResources;

--- a/src/BlazorDX.Components/DxStrings.cs
+++ b/src/BlazorDX.Components/DxStrings.cs
@@ -1,0 +1,101 @@
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace BlazorDX.Components;
+
+/// <summary>
+/// Per-component localized-string lookup where localization is <b>optional</b>: every call site
+/// supplies the English text, and that text is what renders when no <see cref="IStringLocalizer{T}"/>
+/// is registered. A consumer who never localizes needs no <c>AddLocalization()</c> call and sees
+/// no behavior change — which is the whole point.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The alternative — <c>[Inject] IStringLocalizer&lt;T&gt;</c> directly, as ADR 0016's two pilots
+/// originally did — resolves <b>unconditionally at component activation</b>, so a consumer who
+/// hasn't called <c>AddLocalization()</c> gets an <see cref="InvalidOperationException"/> rather
+/// than English. At two components that was an obscure edge; across the ~83 components carrying
+/// user-facing text it would silently become a mandatory registration for the entire library.
+/// See docs/adr/0021-optional-localization-and-rollout-guardrails.md and docs/localization.md.
+/// </para>
+/// <para>
+/// The fallback also covers a <i>registered but incomplete</i> localizer:
+/// <see cref="LocalizedString.ResourceNotFound"/> means the key had no resource entry, in which
+/// case <see cref="IStringLocalizer"/> returns the raw <i>key</i> as its value. Rendering
+/// "SelectAllRows" to a user is worse than rendering "Select all rows", so a not-found lookup
+/// falls back too — this is the same class of bug ADR 0016 hit during Phase 0, where a broken
+/// lookup returning the key was indistinguishable from a correct one.
+/// </para>
+/// <para>
+/// Resolution is deferred and cached: the service lookup happens on first use, not at activation,
+/// so a component that never renders a localized string never touches DI at all.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">
+/// The type naming the resource file — normally the component itself (<c>DxAlert</c> →
+/// <c>DxAlert.resx</c>). A generic component must use a non-generic marker type instead (see
+/// <c>DxDataGridResources</c>): the default factory derives the resource name from the
+/// <i>closed</i> generic type, so <c>DxDataGrid&lt;Person&gt;</c> and <c>DxDataGrid&lt;Order&gt;</c>
+/// would each look for a differently-named resource.
+/// </typeparam>
+internal sealed class DxStrings<T>(IServiceProvider services)
+{
+    private IStringLocalizer<T>? localizer;
+    private bool resolved;
+
+    private IStringLocalizer<T>? Localizer
+    {
+        get
+        {
+            if (!resolved)
+            {
+                // GetService, not GetRequiredService: absent registration is the supported
+                // "this consumer doesn't localize" case, not a configuration error.
+                localizer = services.GetService<IStringLocalizer<T>>();
+                resolved = true;
+            }
+
+            return localizer;
+        }
+    }
+
+    /// <summary>
+    /// The localized text for <paramref name="key"/>, falling back to <paramref name="english"/>
+    /// when no localizer is registered or the key has no resource entry.
+    /// </summary>
+    public string this[string key, string english]
+    {
+        get
+        {
+            if (Localizer is not { } l)
+            {
+                return english;
+            }
+
+            LocalizedString localized = l[key];
+            return localized.ResourceNotFound ? english : localized.Value;
+        }
+    }
+
+    /// <summary>
+    /// Composite-formatting overload: <paramref name="english"/> is a composite format string
+    /// (<c>"{0} of {1} columns"</c>) used both as the fallback and — deliberately — with the same
+    /// argument order the resource entry must use, so a translator sees the same placeholders.
+    /// </summary>
+    public string this[string key, string english, params object[] args]
+    {
+        get
+        {
+            if (Localizer is not { } l)
+            {
+                return string.Format(CultureInfo.CurrentCulture, english, args);
+            }
+
+            LocalizedString localized = l[key, args];
+            return localized.ResourceNotFound
+                ? string.Format(CultureInfo.CurrentCulture, english, args)
+                : localized.Value;
+        }
+    }
+}

--- a/src/BlazorDX.Components/wwwroot/dx-overlay.css
+++ b/src/BlazorDX.Components/wwwroot/dx-overlay.css
@@ -2,6 +2,14 @@
   Overlay theme (Dialog and future Sheet/Popover). CSS-variable driven so consumers
   retheme without overriding selectors. The .dx-dialog wrapper is produced by the
   PresenceBoundary; -enter / -leave classes drive the entrance and exit transitions.
+
+  rtl-clean
+
+  ^ That marker opts this file into RtlLogicalPropertyTests, which fails the build if a
+  physical directional property (margin-left, text-align: right, a bare left:/right:, ...)
+  appears without an `rtl-exempt:` justification on the same line. Add it to a stylesheet
+  once its conversion to logical properties is done; the end state is every stylesheet
+  carrying it. See docs/localization.md.
 */
 .dx-dialog {
   --dx-overlay-backdrop: rgba(15, 23, 42, 0.55);
@@ -294,10 +302,10 @@
    Side="right" dock to the visual left under dir="rtl", contradicting the parameter's own
    name. RTL support here means the sheet's *content* reads correctly, not that the sheet
    silently swaps sides. */
-.dx-sheet-panel-right { top: 0; right: 0; bottom: 0; width: min(90vw, 22rem); }
-.dx-sheet-panel-left { top: 0; left: 0; bottom: 0; width: min(90vw, 22rem); }
-.dx-sheet-panel-top { top: 0; left: 0; right: 0; height: min(90vh, 18rem); }
-.dx-sheet-panel-bottom { bottom: 0; left: 0; right: 0; height: min(90vh, 18rem); }
+.dx-sheet-panel-right { top: 0; right: 0; bottom: 0; width: min(90vw, 22rem); } /* rtl-exempt: Side="right" is a physical screen edge */
+.dx-sheet-panel-left { top: 0; left: 0; bottom: 0; width: min(90vw, 22rem); } /* rtl-exempt: Side="left" is a physical screen edge */
+.dx-sheet-panel-top { top: 0; left: 0; right: 0; height: min(90vh, 18rem); } /* rtl-exempt: pinned to both edges, symmetric */
+.dx-sheet-panel-bottom { bottom: 0; left: 0; right: 0; height: min(90vh, 18rem); } /* rtl-exempt: pinned to both edges, symmetric */
 
 .dx-sheet-enter .dx-sheet-backdrop { animation: dx-backdrop-in 160ms ease-out; }
 .dx-sheet-leave .dx-sheet-backdrop { animation: dx-backdrop-out 160ms ease-in forwards; }
@@ -312,10 +320,13 @@
 .dx-sheet-top .dx-sheet-panel { --dx-from: -100%; }
 .dx-sheet-bottom .dx-sheet-panel { --dx-from: 100%; }
 
-@keyframes dx-slide-x-in { from { transform: translateX(var(--dx-from)); } to { transform: translateX(0); } }
+/* The slide direction has to match which physical edge the sheet is docked to (above), or a
+   right-docked sheet would slide in from the wrong side. Direction comes from --dx-from, set
+   per side, so these keyframes stay physical by construction. */
+@keyframes dx-slide-x-in { from { transform: translateX(var(--dx-from)); } to { transform: translateX(0); } } /* rtl-exempt: matches the physical dock edge */
 @keyframes dx-slide-y-in { from { transform: translateY(var(--dx-from)); } to { transform: translateY(0); } }
-@keyframes dx-slide-right-out { from { transform: translateX(0); } to { transform: translateX(100%); } }
-@keyframes dx-slide-left-out { from { transform: translateX(0); } to { transform: translateX(-100%); } }
+@keyframes dx-slide-right-out { from { transform: translateX(0); } to { transform: translateX(100%); } } /* rtl-exempt: matches the physical dock edge */
+@keyframes dx-slide-left-out { from { transform: translateX(0); } to { transform: translateX(-100%); } } /* rtl-exempt: matches the physical dock edge */
 
 @media (prefers-reduced-motion: reduce) {
   .dx-sheet-enter .dx-sheet-panel, .dx-sheet-leave .dx-sheet-panel,

--- a/tests/BlazorDX.Analyzers.Tests/GovernanceAnalyzerTests.cs
+++ b/tests/BlazorDX.Analyzers.Tests/GovernanceAnalyzerTests.cs
@@ -168,6 +168,24 @@ public sealed class GovernanceAnalyzerTests
     }
 
     [Fact]
+    public async Task DX1003_ignores_a_defaulted_Parameter_that_names_a_variant_not_text()
+    {
+        // The regression this locks in: the rule originally flagged every defaulted [Parameter]
+        // string, so DxAlert's own `Severity = "info"` -- a token that ends up in a CSS class --
+        // broke the build. A variant, a size and a format are all machine-facing; only a parameter
+        // whose name says it carries text ("...Label", "...Text", ...) is the component's own prose.
+        string source = LocalizedComponent("""
+                [Parameter] public string Severity { get; set; } = "info";
+                [Parameter] public string Size { get; set; } = "md";
+                [Parameter] public string DateFormat { get; set; } = "yyyy-MM-dd";
+        """);
+
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(source, new HardcodedStringAnalyzer());
+
+        Assert.Empty(diagnostics.Where(d => d.Id == "DX1003"));
+    }
+
+    [Fact]
     public async Task DX1003_stays_silent_for_text_routed_through_the_localizer()
     {
         string source = LocalizedComponent("""

--- a/tests/BlazorDX.Analyzers.Tests/GovernanceAnalyzerTests.cs
+++ b/tests/BlazorDX.Analyzers.Tests/GovernanceAnalyzerTests.cs
@@ -81,4 +81,151 @@ public sealed class GovernanceAnalyzerTests
 
         Assert.Contains(diagnostics, d => d.Id == "DX1002");
     }
+
+    // ---- DX1003: hardcoded user-facing text in an already-localized component ----
+
+    // Enough of the Blazor / DxStrings surface for the analyzer's semantic checks to bind.
+    private const string LocalizationPreamble = """
+        namespace Microsoft.AspNetCore.Components.Rendering
+        {
+            public sealed class RenderTreeBuilder
+            {
+                public void AddContent(int sequence, object? value) { }
+                public void AddAttribute(int sequence, string name, object? value) { }
+            }
+        }
+
+        namespace Microsoft.AspNetCore.Components
+        {
+            public sealed class ParameterAttribute : System.Attribute { }
+        }
+
+        namespace BlazorDX.Components
+        {
+            internal sealed class DxStrings<T>
+            {
+                public string this[string key, string english] => english;
+            }
+        }
+        """;
+
+    private static string LocalizedComponent(string body) => $$"""
+        {{LocalizationPreamble}}
+
+        namespace Test
+        {
+            using Microsoft.AspNetCore.Components;
+            using Microsoft.AspNetCore.Components.Rendering;
+            using BlazorDX.Components;
+
+            public sealed class DxThing
+            {
+                private DxStrings<DxThing> S = new();
+        {{body}}
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task DX1003_fires_for_a_hardcoded_aria_label_in_a_localized_component()
+    {
+        string source = LocalizedComponent("""
+                public void Render(RenderTreeBuilder builder) =>
+                    builder.AddAttribute(1, "aria-label", "Dismiss");
+        """);
+
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(source, new HardcodedStringAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "DX1003");
+    }
+
+    [Fact]
+    public async Task DX1003_fires_for_hardcoded_visible_content_and_interpolated_prose()
+    {
+        string source = LocalizedComponent("""
+                public void Render(RenderTreeBuilder builder, int count)
+                {
+                    builder.AddContent(1, "Select all rows");
+                    builder.AddContent(2, $"Chart of {count} points");
+                }
+        """);
+
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(source, new HardcodedStringAnalyzer());
+
+        Assert.Equal(2, diagnostics.Count(d => d.Id == "DX1003"));
+    }
+
+    [Fact]
+    public async Task DX1003_fires_for_a_defaulted_Parameter_string()
+    {
+        string source = LocalizedComponent("""
+                [Parameter] public string SubmitText { get; set; } = "Submit";
+        """);
+
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(source, new HardcodedStringAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "DX1003");
+    }
+
+    [Fact]
+    public async Task DX1003_stays_silent_for_text_routed_through_the_localizer()
+    {
+        string source = LocalizedComponent("""
+                public void Render(RenderTreeBuilder builder)
+                {
+                    builder.AddAttribute(1, "aria-label", S["Dismiss", "Dismiss"]);
+                    builder.AddContent(2, $"{S["Copy", "Copy"]} ▾");
+                }
+        """);
+
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(source, new HardcodedStringAnalyzer());
+
+        Assert.Empty(diagnostics.Where(d => d.Id == "DX1003"));
+    }
+
+    [Fact]
+    public async Task DX1003_ignores_machine_facing_attributes_glyphs_and_formats()
+    {
+        // class/style/role/type are machine-facing; glyphs and format strings carry no language.
+        string source = LocalizedComponent("""
+                public void Render(RenderTreeBuilder builder, double value)
+                {
+                    builder.AddAttribute(1, "class", "dx-alert dx-alert-info");
+                    builder.AddAttribute(2, "role", "status");
+                    builder.AddAttribute(3, "type", "button");
+                    builder.AddContent(4, "✕");
+                    builder.AddContent(5, " *");
+                    builder.AddContent(6, value.ToString("0.#"));
+                }
+        """);
+
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(source, new HardcodedStringAnalyzer());
+
+        Assert.Empty(diagnostics.Where(d => d.Id == "DX1003"));
+    }
+
+    [Fact]
+    public async Task DX1003_stays_silent_for_a_component_that_does_not_localize_yet()
+    {
+        // The ratchet: the not-yet-localized backlog must not break the build. Localizing a
+        // component is what switches the rule on for it.
+        string source = $$"""
+            {{LocalizationPreamble}}
+
+            namespace Test
+            {
+                using Microsoft.AspNetCore.Components.Rendering;
+
+                public sealed class DxNotYetLocalized
+                {
+                    public void Render(RenderTreeBuilder builder) =>
+                        builder.AddAttribute(1, "aria-label", "Dismiss");
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(source, new HardcodedStringAnalyzer());
+
+        Assert.Empty(diagnostics.Where(d => d.Id == "DX1003"));
+    }
 }

--- a/tests/BlazorDX.Components.Tests/DxAlertTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxAlertTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using AngleSharp.Dom;
 using Bunit;
 using Microsoft.AspNetCore.Components;
@@ -8,21 +9,18 @@ using Xunit;
 namespace BlazorDX.Components.Tests;
 
 /// <summary>
-/// <see cref="DxAlert"/>'s <c>Dismiss</c> aria-label is injected via
-/// <see cref="IStringLocalizer{DxAlert}"/> (ADR 0016's localization spike) -- every test that
-/// renders the component needs one registered (Blazor resolves <c>[Inject]</c> properties
-/// unconditionally at activation, whether or not the component logic ends up reading them),
-/// so each test explicitly registers either the real localizer (<see cref="Services"/>'s
-/// <c>AddLocalization()</c>, resolving <c>DxAlert.resx</c>'s real values) or
-/// <see cref="FakeStringLocalizer{T}"/> (a sentinel, for the one test that needs to prove the
-/// string is actually wired through the localizer rather than still hardcoded).
+/// <see cref="DxAlert"/>'s <c>Dismiss</c> aria-label goes through <c>DxStrings</c>, which
+/// resolves <see cref="IStringLocalizer{T}"/> <i>optionally</i> (ADR 0021): with none registered
+/// the English text at the call site renders, so a test only registers a localizer when it is
+/// asserting something about localization. The three that do cover the three states that can
+/// differ -- no localizer at all, a registered localizer (sentinel, proving the string is really
+/// routed through it), and the real resource pipeline.
 /// </summary>
 public sealed class DxAlertTests : TestContext
 {
     [Fact]
     public void Renders_severity_class_role_and_title()
     {
-        Services.AddLocalization();
         IRenderedComponent<DxAlert> alert = RenderComponent<DxAlert>(p => p
             .Add(a => a.Severity, "error")
             .Add(a => a.Title, "Build failed"));
@@ -46,10 +44,10 @@ public sealed class DxAlertTests : TestContext
     [Fact]
     public void Dismiss_aria_label_is_wired_through_the_localizer_not_hardcoded()
     {
-        // The real English resource value is also "Dismiss" -- asserting that string would
-        // pass whether or not the component actually calls the localizer. The sentinel is
-        // the only assertion that distinguishes "wired to IStringLocalizer<DxAlert>" from
-        // "still a hardcoded literal that happens to match."
+        // The English fallback is also "Dismiss" -- asserting that string would pass whether or
+        // not the component actually calls the localizer. The sentinel is the only assertion that
+        // distinguishes "routed through the localizer" from "still a hardcoded literal that
+        // happens to match" -- the exact confusion ADR 0016 hit during Phase 0.
         Services.AddSingleton<IStringLocalizer<DxAlert>>(new FakeStringLocalizer<DxAlert>());
 
         IRenderedComponent<DxAlert> alert = RenderComponent<DxAlert>(p => p
@@ -76,6 +74,45 @@ public sealed class DxAlertTests : TestContext
 
         IElement button = alert.Find("button.dx-alert-close");
         Assert.Equal("Dismiss", button.GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void Dismiss_renders_English_when_no_localizer_is_registered_at_all()
+    {
+        // The reason DxStrings exists. A consumer who never calls AddLocalization() must get
+        // English, not an activation exception -- rendering this component with an empty service
+        // collection is the whole assertion. Before ADR 0021 this threw.
+        IRenderedComponent<DxAlert> alert = RenderComponent<DxAlert>(p => p
+            .Add(a => a.Severity, "error")
+            .Add(a => a.Dismissible, true)
+            .Add(a => a.OnDismiss, EventCallback.Factory.Create(this, () => { })));
+
+        Assert.Equal("Dismiss", alert.Find("button.dx-alert-close").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void Dismiss_resolves_the_French_resource_under_a_French_UI_culture()
+    {
+        // Nothing else in the suite sets a culture, so DxAlert.fr.resx was only ever validated by
+        // the AOT publish job noticing a satellite assembly. This is the assertion that the
+        // fr -> invariant fallback chain actually resolves a translated value.
+        CultureInfo original = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("fr");
+            Services.AddLocalization();
+
+            IRenderedComponent<DxAlert> alert = RenderComponent<DxAlert>(p => p
+                .Add(a => a.Severity, "error")
+                .Add(a => a.Dismissible, true)
+                .Add(a => a.OnDismiss, EventCallback.Factory.Create(this, () => { })));
+
+            Assert.Equal("Ignorer", alert.Find("button.dx-alert-close").GetAttribute("aria-label"));
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = original;
+        }
     }
 
     [Fact]

--- a/tests/BlazorDX.Components.Tests/DxDataGridChooserTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridChooserTests.cs
@@ -14,7 +14,6 @@ public sealed class DxDataGridChooserTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
-        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridDetailTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridDetailTests.cs
@@ -15,7 +15,6 @@ public sealed class DxDataGridDetailTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
-        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridExportTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridExportTests.cs
@@ -91,7 +91,6 @@ public sealed class DxDataGridExportTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop>(_ => dom);
-        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridFilterMenuTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridFilterMenuTests.cs
@@ -14,7 +14,6 @@ public sealed class DxDataGridFilterMenuTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
-        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridKeyboardTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridKeyboardTests.cs
@@ -18,7 +18,6 @@ public sealed class DxDataGridKeyboardTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
-        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridMultiSortTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridMultiSortTests.cs
@@ -15,7 +15,6 @@ public sealed class DxDataGridMultiSortTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
-        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/DxDataGridTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridTests.cs
@@ -69,11 +69,11 @@ public sealed class DxDataGridTests : TestContext
     [Fact]
     public void Select_all_aria_label_is_wired_through_the_localizer_not_hardcoded()
     {
-        // Same reasoning as DxAlertTests's sentinel test: the real English resource value is
-        // also "Select all rows", so only a sentinel distinguishes "wired to
-        // IStringLocalizer<DxDataGridResources>" from "still a hardcoded literal." Registered
-        // against the non-generic marker type, not IStringLocalizer<DxDataGrid<WidgetRow>> --
-        // see the doc comment on DxDataGrid<TRow>'s own L field for why.
+        // Same reasoning as DxAlertTests's sentinel test: the English fallback is also
+        // "Select all rows", so only a sentinel distinguishes "routed through the localizer"
+        // from "still a hardcoded literal." Registered against the non-generic marker type,
+        // not IStringLocalizer<DxDataGrid<WidgetRow>> -- see the comment on DxDataGrid<TRow>'s
+        // own DxStrings<DxDataGridResources> field for why the closed generic would miss.
         Services.AddSingleton<IStringLocalizer<DxDataGridResources>>(new FakeStringLocalizer<DxDataGridResources>());
 
         IRenderedComponent<DxDataGrid<WidgetRow>> grid = RenderComponent<DxDataGrid<WidgetRow>>(parameters => parameters

--- a/tests/BlazorDX.Components.Tests/DxFeedbackTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxFeedbackTests.cs
@@ -11,7 +11,6 @@ public sealed class DxFeedbackTests : TestContext
 {
     public DxFeedbackTests()
     {
-        Services.AddLocalization();
     }
 
     [Fact]

--- a/tests/BlazorDX.Components.Tests/GridStateTests.cs
+++ b/tests/BlazorDX.Components.Tests/GridStateTests.cs
@@ -20,7 +20,6 @@ public sealed class GridStateTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
-        Services.AddLocalization();
     }
 
     private static List<WidgetRow> Rows() =>

--- a/tests/BlazorDX.Components.Tests/LocalizedStringConsistencyTests.cs
+++ b/tests/BlazorDX.Components.Tests/LocalizedStringConsistencyTests.cs
@@ -1,0 +1,137 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// Guards the one real cost of ADR 0021's optional-localization design: English lives in two
+/// places — the fallback at each <c>DxStrings</c> call site, and the invariant <c>.resx</c> —
+/// and nothing in the compiler or the runtime makes them agree.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The failure this catches is specifically invisible. If a call site says "Clear filter" and the
+/// resource says "Clear filters", both render fine; a consumer who called <c>AddLocalization()</c>
+/// simply sees different English than one who did not, and every existing test passes either way
+/// because each asserts against only one of the two. The same is true of a key that exists at a
+/// call site but not in the resource file: <c>DxStrings</c> falls back to English, so it looks
+/// correct in English and silently loses every translation.
+/// </para>
+/// <para>
+/// This is why ADR 0021 could accept the duplication. Unchecked it is a slow drift; checked it is
+/// bookkeeping the build does for you.
+/// </para>
+/// <para>
+/// No opt-in marker here, unlike DX1003 and <c>RtlLogicalPropertyTests</c> — those ratchet because
+/// they would otherwise report the whole unconverted backlog at once. This one keys off
+/// <c>DxStrings</c> usage, so it already covers exactly the localized components and picks up each
+/// new one in the rollout for free.
+/// </para>
+/// </remarks>
+public sealed class LocalizedStringConsistencyTests
+{
+    // The DxStrings<T> a component holds names its resource file: DxStrings<DxAlert> -> DxAlert.resx.
+    // Anchored on `private`, which matters: both pilots reference `DxStrings<T>` in a doc comment
+    // above the real field, so matching the bare type name resolves the resource type as "T".
+    private static readonly Regex ResourceType = new(@"private\s+DxStrings<(\w+)>", RegexOptions.Compiled);
+
+    // S["Key", "English"...] — literal key and literal English only. A computed key would not match
+    // and would go unchecked, which is a gap worth knowing about; there are none today.
+    private static readonly Regex CallSite = new(@"S\[\s*""([^""]*)""\s*,\s*""([^""]*)""", RegexOptions.Compiled);
+
+    [Fact]
+    public void Call_site_English_matches_the_invariant_resource_value()
+    {
+        List<string> problems = [];
+        int checkedSites = 0;
+
+        foreach (string component in LocalizedComponents())
+        {
+            string source = File.ReadAllText(component);
+            string resourceName = ResourceType.Match(source).Groups[1].Value;
+            string resx = Path.Combine(ComponentsDirectory(), $"{resourceName}.resx");
+
+            if (!File.Exists(resx))
+            {
+                problems.Add($"{Path.GetFileName(component)} uses DxStrings<{resourceName}> but "
+                    + $"{resourceName}.resx does not exist. It must sit at the project root — see "
+                    + "docs/localization.md on why ResourcesPath breaks the lookup.");
+                continue;
+            }
+
+            Dictionary<string, string> resources = ReadResources(resx);
+            HashSet<string> used = [];
+
+            foreach (Match site in CallSite.Matches(source))
+            {
+                string key = site.Groups[1].Value;
+                string english = site.Groups[2].Value;
+                used.Add(key);
+                checkedSites++;
+
+                if (!resources.TryGetValue(key, out string? value))
+                {
+                    problems.Add($"{resourceName}.resx has no entry for \"{key}\" "
+                        + $"(used in {Path.GetFileName(component)}). The call site renders English "
+                        + "and silently loses every translation.");
+                }
+                else if (value != english)
+                {
+                    problems.Add($"{resourceName}.resx[\"{key}\"] is \"{value}\" but the call site "
+                        + $"in {Path.GetFileName(component)} falls back to \"{english}\".");
+                }
+            }
+
+            foreach (string orphan in resources.Keys.Where(k => !used.Contains(k)).OrderBy(k => k))
+            {
+                problems.Add($"{resourceName}.resx[\"{orphan}\"] is not used by any call site — "
+                    + "the string moved or was removed, and translators are still maintaining it.");
+            }
+        }
+
+        // If this trips, the regexes stopped matching the codebase rather than the codebase
+        // becoming consistent — a guard that checks nothing must fail loudly.
+        Assert.True(checkedSites > 0, "No DxStrings call sites found. Has the pattern changed?");
+
+        Assert.True(problems.Count == 0,
+            "Call-site English and .resx values have drifted:" + Environment.NewLine
+            + string.Join(Environment.NewLine, problems.Select(p => "  " + p)));
+    }
+
+    private static Dictionary<string, string> ReadResources(string path) =>
+        XDocument.Load(path).Root!
+            .Elements("data")
+            .Where(data => data.Attribute("name") is not null)
+            .ToDictionary(
+                data => data.Attribute("name")!.Value,
+                data => data.Element("value")?.Value ?? string.Empty,
+                StringComparer.Ordinal);
+
+    // AllDirectories, not TopDirectoryOnly: components may live in subfolders as the rollout
+    // proceeds, and a silently-skipped component is exactly the drift this test exists to catch.
+    // The .resx files themselves stay at the project root regardless — that placement is the
+    // configuration that works (docs/localization.md).
+    private static IEnumerable<string> LocalizedComponents() =>
+        Directory.EnumerateFiles(ComponentsDirectory(), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => Path.GetFileName(path) != "DxStrings.cs")
+            .Where(path => ResourceType.IsMatch(File.ReadAllText(path)));
+
+    private static string ComponentsDirectory() =>
+        Path.Combine(RepositoryRoot(), "src", "BlazorDX.Components");
+
+    private static string RepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "BlazorDX.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.True(directory is not null, $"No BlazorDX.slnx above {AppContext.BaseDirectory}.");
+        return directory!.FullName;
+    }
+}

--- a/tests/BlazorDX.Components.Tests/ObservabilityTests.cs
+++ b/tests/BlazorDX.Components.Tests/ObservabilityTests.cs
@@ -47,7 +47,6 @@ public sealed class ObservabilityTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
-        Services.AddLocalization();
     }
 
     // ---- Diagnostics sink ----

--- a/tests/BlazorDX.Components.Tests/RemoteGridTests.cs
+++ b/tests/BlazorDX.Components.Tests/RemoteGridTests.cs
@@ -19,7 +19,6 @@ public sealed class RemoteGridTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
-        Services.AddLocalization();
     }
 
     // Records the last request and serves an in-memory dataset as if it were a server.

--- a/tests/BlazorDX.Components.Tests/RemoteGroupGridTests.cs
+++ b/tests/BlazorDX.Components.Tests/RemoteGroupGridTests.cs
@@ -20,7 +20,6 @@ public sealed class RemoteGroupGridTests : TestContext
     {
         Services.AddScoped<IGridCompute, ManagedGridCompute>();
         Services.AddScoped<IGridDomInterop, NullGridDomInterop>();
-        Services.AddLocalization();
     }
 
     // An in-memory dataset answering both group-summary and per-group row queries like a server.

--- a/tests/BlazorDX.Components.Tests/RtlLogicalPropertyTests.cs
+++ b/tests/BlazorDX.Components.Tests/RtlLogicalPropertyTests.cs
@@ -1,0 +1,179 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// Guards the RTL half of ADR 0016: a stylesheet that declares itself converted must not use
+/// physical directional properties (<c>margin-left</c>, <c>text-align: right</c>, a bare
+/// <c>left:</c>, ...) without a justification.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists because RTL was otherwise verified by exactly one axe-only E2E check on
+/// <c>/dialog?dir=rtl</c>, which asserts no accessibility violations and nothing about layout — a
+/// stylesheet could be entirely unconverted and still pass it. A static check is the cheap half
+/// that actually catches an unconverted (or re-physicalized) declaration, and it catches it at
+/// the source rather than in a browser.
+/// </para>
+/// <para>
+/// <b>Opt-in by marker, deliberately.</b> Only files containing <c>rtl-clean</c> are enforced.
+/// The conversion backlog is 24 stylesheets and ~104 declarations; enforcing everything now would
+/// just fail. Each conversion batch adds the marker to the files it converts, and the end state
+/// is every stylesheet carrying it — the same ratchet DX1003 uses for hardcoded strings.
+/// </para>
+/// <para>
+/// <b>Escape hatch.</b> A line carrying <c>rtl-exempt: &lt;reason&gt;</c> is allowed. Some
+/// physical usages are correct: <c>DxSheet</c>'s <c>Side="left"/"right"</c> names a physical
+/// screen edge (converting it would make <c>Side="right"</c> dock left under RTL, contradicting
+/// the parameter), and a box pinned to both edges is symmetric. This formalizes the prose
+/// carve-out the pilot already wrote into dx-overlay.css.
+/// </para>
+/// </remarks>
+public sealed class RtlLogicalPropertyTests
+{
+    private const string ConvertedMarker = "rtl-clean";
+    private const string ExemptMarker = "rtl-exempt";
+
+    private static readonly (string Name, Regex Pattern)[] PhysicalProperties =
+    [
+        ("margin-left/right", new Regex(@"margin-(left|right)\s*:", RegexOptions.Compiled)),
+        ("padding-left/right", new Regex(@"padding-(left|right)\s*:", RegexOptions.Compiled)),
+        ("border-left/right", new Regex(@"border-(left|right)(-\w+)?\s*:", RegexOptions.Compiled)),
+        ("border-*-left/right-radius", new Regex(@"border-(top|bottom)-(left|right)-radius\s*:", RegexOptions.Compiled)),
+        ("text-align: left/right", new Regex(@"text-align\s*:\s*(left|right)\b", RegexOptions.Compiled)),
+        ("float: left/right", new Regex(@"float\s*:\s*(left|right)\b", RegexOptions.Compiled)),
+
+        // A bare `left:`/`right:` positioning property. The lookbehind keeps this from matching
+        // the hyphenated properties above (border-left:, margin-right:, ...), which have their
+        // own rules and their own messages.
+        ("bare left:/right:", new Regex(@"(?<![-\w])(left|right)\s*:", RegexOptions.Compiled)),
+    ];
+
+    [Fact]
+    public void Stylesheets_marked_rtl_clean_use_logical_properties()
+    {
+        string[] converted = ShippedStylesheets()
+            .Where(path => File.ReadAllText(path).Contains(ConvertedMarker, StringComparison.Ordinal))
+            .ToArray();
+
+        // If this trips, the marker was dropped from dx-overlay.css (ADR 0016's pilot) and the
+        // guard would silently be checking nothing.
+        Assert.NotEmpty(converted);
+
+        List<string> violations = [];
+        foreach (string path in converted)
+        {
+            string[] lines = File.ReadAllLines(path);
+            string[] code = StripComments(lines);
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                // Detect on the code, exempt on the original line: a declaration mentioned inside
+                // a comment (including this guard's own documentation) is not a declaration, and
+                // the `rtl-exempt` justification necessarily lives in a comment.
+                if (lines[i].Contains(ExemptMarker, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                foreach ((string name, Regex pattern) in PhysicalProperties)
+                {
+                    if (pattern.IsMatch(code[i]))
+                    {
+                        violations.Add($"{Path.GetFileName(path)}:{i + 1}: {name} — {lines[i].Trim()}");
+                        break;
+                    }
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            $"Physical directional properties in rtl-clean stylesheets. Convert them to logical "
+            + $"properties (margin-inline-start, text-align: start, inset-inline-start, ...), or add "
+            + $"`/* {ExemptMarker}: <reason> */` on the line if the usage is deliberately physical:"
+            + Environment.NewLine + string.Join(Environment.NewLine, violations));
+    }
+
+    [Fact]
+    public void The_converted_pilot_still_documents_its_deliberate_physical_usages()
+    {
+        // dx-overlay.css is the worked example the rollout copies: converted, marked, and with
+        // every intentionally-physical line carrying a reason. If the exemptions disappear, the
+        // convention has been lost even though the guard above would still pass.
+        string overlay = File.ReadAllText(
+            Path.Combine(ComponentsWwwroot(), "dx-overlay.css"));
+
+        Assert.Contains(ConvertedMarker, overlay, StringComparison.Ordinal);
+        Assert.Contains($"{ExemptMarker}:", overlay, StringComparison.Ordinal);
+        Assert.Contains("text-align: start", overlay, StringComparison.Ordinal);
+        Assert.Contains("margin-inline-start", overlay, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Blanks out <c>/* ... */</c> spans (which CSS allows to run across lines) while keeping the
+    /// line count and column positions intact, so a match's line number still points at the real
+    /// source line.
+    /// </summary>
+    private static string[] StripComments(string[] lines)
+    {
+        string[] code = new string[lines.Length];
+        bool inComment = false;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            // Read from the original line, write to a separate buffer: blanking in place would
+            // erase the '*' that the very next character needs to see to close the comment.
+            string line = lines[i];
+            char[] stripped = new char[line.Length];
+
+            for (int c = 0; c < line.Length; c++)
+            {
+                if (!inComment && c + 1 < line.Length && line[c] == '/' && line[c + 1] == '*')
+                {
+                    inComment = true;
+                }
+
+                bool closing = inComment && c > 0 && line[c - 1] == '*' && line[c] == '/';
+                stripped[c] = inComment ? ' ' : line[c];
+
+                if (closing)
+                {
+                    inComment = false;
+                }
+            }
+
+            code[i] = new string(stripped);
+        }
+
+        return code;
+    }
+
+    private static IEnumerable<string> ShippedStylesheets() =>
+        Directory.EnumerateFiles(Path.Combine(RepositoryRoot(), "src"), "*.css", SearchOption.AllDirectories)
+            .Where(path => path.Contains($"{Path.DirectorySeparatorChar}wwwroot{Path.DirectorySeparatorChar}",
+                StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+                StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                StringComparison.Ordinal));
+
+    private static string ComponentsWwwroot() =>
+        Path.Combine(RepositoryRoot(), "src", "BlazorDX.Components", "wwwroot");
+
+    // Walks up from the test binaries to the directory holding the solution. Failing loudly beats
+    // skipping: a guard that silently finds no files to check is worse than no guard.
+    private static string RepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "BlazorDX.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.True(directory is not null, $"No BlazorDX.slnx above {AppContext.BaseDirectory}.");
+        return directory!.FullName;
+    }
+}

--- a/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
+++ b/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
@@ -118,10 +118,11 @@ public sealed class AccessibilityE2ETests(PlaywrightFixture fx)
     {
         IPage page = await fx.NewPageAsync();
         await page.GotoAsync($"{fx.BaseUrl}{route}", new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 60_000 });
-        await page.WaitForSelectorAsync(".dx-select-trigger", new PageWaitForSelectorOptions { Timeout = 30_000 });
 
-        // Centres, not edges: the two boxes have different widths, so comparing left edges would
-        // report an ordering difference that is really a width difference.
+        // Wait for the two elements actually being measured, in a *visible* state — not merely for
+        // their parent. Waiting on .dx-select-trigger alone raced Blazor's prerender-then-hydrate
+        // swap: the trigger was in the DOM while its children were momentarily unlaid-out, so
+        // BoundingBoxAsync returned null. That failed on Firefox only, and only intermittently.
         double value = await CentreXAsync(page, ".dx-select-trigger .dx-select-value");
         double caret = await CentreXAsync(page, ".dx-select-trigger .dx-select-caret");
         string direction = await page.EvaluateAsync<string>("() => getComputedStyle(document.documentElement).direction");
@@ -131,7 +132,12 @@ public sealed class AccessibilityE2ETests(PlaywrightFixture fx)
 
     private static async Task<double> CentreXAsync(IPage page, string selector)
     {
-        LocatorBoundingBoxResult? box = await page.Locator(selector).First.BoundingBoxAsync();
+        ILocator locator = page.Locator(selector).First;
+        await locator.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+
+        // Centres, not edges: the two boxes have different widths, so comparing left edges would
+        // report an ordering difference that is really a width difference.
+        LocatorBoundingBoxResult? box = await locator.BoundingBoxAsync();
         Assert.True(box is not null, $"No bounding box for {selector} — the control did not render.");
         return box!.X + (box.Width / 2);
     }

--- a/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
+++ b/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
@@ -40,6 +40,13 @@ public sealed class AccessibilityE2ETests(PlaywrightFixture fx)
     [InlineData("/charts")]              // all 25 chart types, incl. interactive selection (Bar/Treemap/Network graph)
     [InlineData("/dialog")]              // Overlays family (dx-overlay.css): Dialog, backed by DxDialog/DialogPrimitive
     [InlineData("/dialog?dir=rtl")]      // same route under dir="rtl" — ADR 0016's RTL pilot (logical-property CSS)
+    // The RTL sweep, widened beyond the pilot. axe reports direction-independent failures
+    // (contrast, names, roles), so these catch mirroring that breaks semantics — an overlapped or
+    // clipped control loses its accessible name — not mirroring that merely looks wrong. The three
+    // routes are the densest directional layouts in the showcase.
+    [InlineData("/scheduler?dir=rtl")]   // grid of day columns — the most direction-sensitive layout
+    [InlineData("/app/records?dir=rtl")] // DxDataGrid: sort/filter affordances, sticky header, toolbar
+    [InlineData("/charts?dir=rtl")]      // chart geometry is C#-computed, so RTL is unreviewed here by construction
     public async Task Page_has_no_serious_axe_violations(string route)
     {
         Skip.IfNot(fx.Ready, fx.SkipReason);
@@ -71,5 +78,61 @@ public sealed class AccessibilityE2ETests(PlaywrightFixture fx)
         }));
 
         Assert.True(serious.Length == 0, $"axe-core found {serious.Length} serious/critical violation(s) on {route}:\n{report}");
+    }
+
+    /// <summary>
+    /// The one RTL assertion about <i>layout</i> rather than semantics: a control's directional
+    /// order actually mirrors.
+    /// </summary>
+    /// <remarks>
+    /// Every other RTL check in the suite is axe-based, and axe is direction-agnostic — a
+    /// stylesheet could be entirely unconverted and pass all of them. <c>RtlLogicalPropertyTests</c>
+    /// closes most of that gap statically, but it can only read CSS text; it cannot tell whether a
+    /// browser actually flipped anything. This is the end-to-end half.
+    /// <para>
+    /// <c>DxSelect</c>'s trigger is the subject because it is the simplest control in the pilot
+    /// stylesheet with an unambiguous leading/trailing pair: <c>.dx-select-value</c> then
+    /// <c>.dx-select-caret</c>, laid out by <c>justify-content: space-between</c>. If anyone
+    /// re-physicalizes that rule — a <c>float</c>, an absolute <c>left:</c>, a fixed
+    /// <c>flex-direction: row</c> — the caret stops mirroring and this fails.
+    /// </para>
+    /// </remarks>
+    [SkippableFact]
+    public async Task Select_trigger_mirrors_its_caret_under_rtl()
+    {
+        Skip.IfNot(fx.Ready, fx.SkipReason);
+
+        (double value, double caret, string direction) ltr = await MeasureSelectTriggerAsync("/select");
+        (double value, double caret, string direction) rtl = await MeasureSelectTriggerAsync("/select?dir=rtl");
+
+        // Guard against the whole test passing vacuously by comparing two LTR pages: if ?dir=rtl
+        // ever stops reaching App.razor's <html dir> the mirroring assertion below is meaningless.
+        Assert.Equal("ltr", ltr.direction);
+        Assert.Equal("rtl", rtl.direction);
+
+        Assert.True(ltr.caret > ltr.value, $"LTR: caret ({ltr.caret}) should sit after the value ({ltr.value}).");
+        Assert.True(rtl.caret < rtl.value, $"RTL: caret ({rtl.caret}) should sit before the value ({rtl.value}).");
+    }
+
+    private async Task<(double Value, double Caret, string Direction)> MeasureSelectTriggerAsync(string route)
+    {
+        IPage page = await fx.NewPageAsync();
+        await page.GotoAsync($"{fx.BaseUrl}{route}", new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 60_000 });
+        await page.WaitForSelectorAsync(".dx-select-trigger", new PageWaitForSelectorOptions { Timeout = 30_000 });
+
+        // Centres, not edges: the two boxes have different widths, so comparing left edges would
+        // report an ordering difference that is really a width difference.
+        double value = await CentreXAsync(page, ".dx-select-trigger .dx-select-value");
+        double caret = await CentreXAsync(page, ".dx-select-trigger .dx-select-caret");
+        string direction = await page.EvaluateAsync<string>("() => getComputedStyle(document.documentElement).direction");
+
+        return (value, caret, direction);
+    }
+
+    private static async Task<double> CentreXAsync(IPage page, string selector)
+    {
+        LocatorBoundingBoxResult? box = await page.Locator(selector).First.BoundingBoxAsync();
+        Assert.True(box is not null, $"No bounding box for {selector} — the control did not render.");
+        return box!.X + (box.Width / 2);
     }
 }

--- a/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
+++ b/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
@@ -119,26 +119,39 @@ public sealed class AccessibilityE2ETests(PlaywrightFixture fx)
         IPage page = await fx.NewPageAsync();
         await page.GotoAsync($"{fx.BaseUrl}{route}", new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 60_000 });
 
-        // Wait for the two elements actually being measured, in a *visible* state — not merely for
-        // their parent. Waiting on .dx-select-trigger alone raced Blazor's prerender-then-hydrate
-        // swap: the trigger was in the DOM while its children were momentarily unlaid-out, so
-        // BoundingBoxAsync returned null. That failed on Firefox only, and only intermittently.
-        double value = await CentreXAsync(page, ".dx-select-trigger .dx-select-value");
-        double caret = await CentreXAsync(page, ".dx-select-trigger .dx-select-caret");
-        string direction = await page.EvaluateAsync<string>("() => getComputedStyle(document.documentElement).direction");
+        // /select is @rendermode InteractiveWebAssembly: the server-prerendered markup is thrown
+        // away and re-created when the WASM runtime finishes booting. Waiting for an element and
+        // then measuring it in a second call straddles that swap — the node found by the wait can
+        // be detached by the time it is measured, and BoundingBoxAsync returns null for a detached
+        // node instead of re-resolving. That is what made this Firefox-only and intermittent:
+        // Firefox is the slowest of the three to start WASM.
+        await page.WaitForFunctionAsync("() => !!window.DotNet", null,
+            new PageWaitForFunctionOptions { Timeout = 60_000 });
 
-        return (value, caret, direction);
-    }
-
-    private static async Task<double> CentreXAsync(IPage page, string selector)
-    {
-        ILocator locator = page.Locator(selector).First;
-        await locator.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
-
+        // So take one atomic in-page measurement, polled until both boxes are laid out. Returning
+        // null keeps WaitForFunctionAsync polling, so there is no window between "found" and
+        // "measured" for a re-render to slip into.
+        //
         // Centres, not edges: the two boxes have different widths, so comparing left edges would
         // report an ordering difference that is really a width difference.
-        LocatorBoundingBoxResult? box = await locator.BoundingBoxAsync();
-        Assert.True(box is not null, $"No bounding box for {selector} — the control did not render.");
-        return box!.X + (box.Width / 2);
+        IJSHandle measurement = await page.WaitForFunctionAsync(
+            """
+            () => {
+                const value = document.querySelector('.dx-select-trigger .dx-select-value');
+                const caret = document.querySelector('.dx-select-trigger .dx-select-caret');
+                if (!value || !caret) return null;
+                const v = value.getBoundingClientRect();
+                const c = caret.getBoundingClientRect();
+                if (v.width === 0 || c.width === 0) return null;
+                return [v.x + (v.width / 2), c.x + (c.width / 2)];
+            }
+            """,
+            null,
+            new PageWaitForFunctionOptions { Timeout = 30_000 });
+
+        double[] centres = await measurement.JsonValueAsync<double[]>();
+        string direction = await page.EvaluateAsync<string>("() => getComputedStyle(document.documentElement).direction");
+
+        return (centres[0], centres[1], direction);
     }
 }


### PR DESCRIPTION
Foundation pass for the localization/RTL roadmap item — the decisions that had to be settled *before* 83 components bake in a pattern. Follows [ADR 0016](docs/adr/0016-localization-rtl-strategy.md), which proved the mechanism on two pilots and explicitly sequenced the analyzer "after Phase 0, before the multi-component rollout."

## The load-bearing change: localization is now opt-in

The pilots injected the localizer directly:

```csharp
[Inject] private IStringLocalizer<DxAlert> L { get; set; } = default!;
```

Blazor resolves `[Inject]` **unconditionally at component activation**, before any component logic runs. A consumer who hasn't called `AddLocalization()` therefore gets an `InvalidOperationException` when the component is *created* — not English, and not a message naming localization as the cause. At two components that's an obscure edge. Across 83 it silently becomes a **mandatory registration for the entire library**.

That tax was already visible in our own test suite: five test classes had added `Services.AddLocalization()` while asserting nothing about localization.

Components now hold a `DxStrings<T>` (new, `src/BlazorDX.Components/DxStrings.cs`) which resolves the localizer lazily via `GetService` — Blazor has no optional-inject attribute — and falls back to English supplied at the call site:

```csharp
builder.AddAttribute(16, "aria-label", S["Dismiss", "Dismiss"]);
builder.AddContent(147, S["ColumnsToggle", "Columns ({0}/{1})", VisibleColumnCount, Columns.Count]);
```

The same fallback fires on `LocalizedString.ResourceNotFound`, which fixes a hazard ADR 0016 recorded but couldn't fix from inside the pilot: a bare `IStringLocalizer` returns *the key* on a failed lookup, so a typo ships `ColumnsToggle` into the UI, invisible to any test asserting against the same key.

**The proof the breaking change is gone:** eleven test classes that called `AddLocalization()` purely to keep components activating no longer do.

Trade-off, recorded in the ADR: English now lives at the call site *and* in the invariant `.resx`. That duplication is inherent to having a code-level fallback at all. Reading the invariant `.resx` via `ResourceManager` was considered and rejected — new AOT-sensitive runtime machinery to remove a duplication whose practical cost is low, against inline English that a reviewer can actually read.

## Two ratchets

`TreatWarningsAsErrors` is repo-wide, so a guard that fired everywhere would break the build on 83 components at once. Both new guards are scoped by an opt-in marker and report **zero** on the current tree.

**DX1003** (`HardcodedStringAnalyzer`) flags user-facing literals — `AddContent`, the user-facing attributes (`aria-label`, `aria-description`, `aria-roledescription`, `aria-valuetext`, `alt`, `placeholder`, `title`), and defaulted `[Parameter] string` properties — **only inside types that already hold a `DxStrings<…>`**. Localizing a component is what switches its own guard on. Ignores letter-free glyphs (`"✓"`, `"▾"`), format strings, and machine-facing attributes. Known hole, stated in the ADR rather than discovered later: a never-localized component is unguarded, and closing that is the rollout's completion criterion.

This isn't hypothetical — the scatter/bubble zoom work in #46 added ~5 new hardcoded strings while this was being planned.

**`RtlLogicalPropertyTests`** flags physical directional CSS (`margin-left`, `text-align: right`, a bare `left:`, …), **only** in stylesheets marked `/* rtl-clean */`, with a per-line `/* rtl-exempt: <reason> */` escape hatch. The escape hatch exists because some physical usage is *correct*: `DxSheet`'s `Side="left"/"right"` names a physical screen edge, and converting it would make `Side="right"` dock left under RTL. `dx-overlay.css` is retro-annotated as the worked example, formalizing the carve-out ADR 0016 had written as prose.

## RTL actually gets verified now

It previously had exactly one check: `/dialog?dir=rtl` running axe, which is direction-agnostic — it asserts no accessibility violations and **nothing about layout**. A stylesheet could be 100% unconverted and pass it. Landing a 104-declaration sweep against that would be unverified by construction.

- `?dir=rtl` axe variants for `/scheduler`, `/app/records`, `/charts` — the densest directional layouts.
- One end-to-end mirroring assertion: `DxSelect`'s caret sits after its value in LTR and before it in RTL, with computed `direction` asserted on both pages so the comparison can't pass vacuously.
- The first test anywhere to set `CultureInfo.CurrentUICulture` — the `.fr.resx` files were previously validated only by the AOT job noticing a satellite assembly existed. This is what proves the `fr-FR` → `fr` → invariant chain resolves.

## Docs

New [ADR 0021](docs/adr/0021-optional-localization-and-rollout-guardrails.md) and a rollout runbook at [docs/localization.md](docs/localization.md) (pattern, resx placement and *why* `ResourcesPath` breaks it, the marker-type rule for generics, the two-test convention, batch order).

Roadmap corrected: the backlog is **83 components / ~250–270 strings**, not "~130 components" — 57 of the 142 files have no user-facing text at all. RTL is 24 stylesheets, 104 mechanical + 27 judgment declarations.

## Verification

`BlazorDX.Components` can't be built locally (SDK Roslyn 5.3.0.0 vs the repo's pinned 5.9.0 → CS9057), so CI is the gate. Locally: `BlazorDX.Analyzers` builds clean (0 warnings, 0 errors), and the RTL guard's logic was simulated against the tree — 25 stylesheets found, 1 marked `rtl-clean`, 0 violations — plus a negative control proving it isn't vacuous (it would flag 15 in `dx-datagrid.css`, 23 in `dx-scheduler.css`, matching the research inventory).

Watch specifically: the **AOT publish job** (Phase 0's whole proof was that satellite assemblies survive it — the `DxStrings` indirection must not change that), and that DX1003 produces zero diagnostics, or the ratchet is mis-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
