### PR TITLE
Localize batch 1: DxKbd, DxImageEditor, DxDocumentViewer, DxFileManager

### DIFF
--- a/docs/adr/0021-optional-localization-and-rollout-guardrails.md
+++ b/docs/adr/0021-optional-localization-and-rollout-guardrails.md
@@ -123,6 +123,40 @@ construction.
 has never been localized is unguarded. The rollout's completion criterion is flipping
 DX1003 to fire on every component file in `BlazorDX.Components`, which closes it.
 
+### Amendment (first rollout batch): DX1003 sees less than the paragraph above claims
+
+The first rollout batch contradicted that completion criterion, and the correction belongs
+here rather than in a commit message. DX1003 inspects **literals at render call sites**, and
+that turns out to be where a minority of BlazorDX's user-facing text actually lives. The
+rest reaches the DOM through a variable:
+
+- **Lookup tables** — `DxRichTextEditor` holds all 17 toolbar labels in a
+  `static readonly (Command, Value, Glyph, Label)[]` and renders them in a loop.
+- **Switch expressions** — `DxKbd`'s entire vocabulary (18 strings) is switch arms in
+  `Display`/`Spoken`; the component has *no* user-facing literal at a call site at all, so
+  DX1003 would have reported it fully compliant while every string was hardcoded.
+- **Local helper arguments** — `Slider(builder, 20, "Brightness", …)`,
+  `ZoomButton(builder, 122, "−", "Zoom out", …)`, `Header(builder, 74, "Name")`. This is the
+  most common shape across the styled tier.
+
+Flipping DX1003 to every component would not change this: the literal is not at a call site,
+so there is nothing for the rule to see. Widening it to "any string literal in a localized
+type" is not the fix either — it would flag CSS class names, element names, command
+identifiers and format strings, which are the *majority* of literals in these files.
+
+The answer is a **convention the analyzer cannot enforce but the consistency test can**:
+indirect text still resolves through a literal `S["Key", "English"]` pair, just at the
+lookup instead of at the render site (`DxKbd.Display` is the worked example). Because the
+pair stays literal, `LocalizedStringConsistencyTests` — which does not care *where* in the
+file the pair appears — validates it against the `.resx` exactly as it validates a direct
+call site.
+
+So the honest guarantee is three-part: **the analyzer catches regressions at render call
+sites; the consistency test catches drift anywhere the convention is followed; nothing
+mechanically catches a brand-new hardcoded literal introduced inside a helper method.** That
+last gap is closed by review, and mitigated by every component's strings now being
+enumerated in one `.resx` where an omission is visible.
+
 ## Decision 3 — RTL is verified statically, by the same ratchet
 
 Before this ADR, RTL was verified by exactly one check: `/dialog?dir=rtl` in

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -41,6 +41,51 @@ The English text at the call site is the fallback used when no localizer is regi
 `IStringLocalizer` returns the key itself on a failed lookup, so a typo ships `ColumnsToggle`
 into the UI. `DxStrings` returns the English instead.
 
+### Text that isn't at a render call site
+
+Most BlazorDX text is **not** a literal sitting in `AddContent`/`AddAttribute`. It reaches
+the DOM through a variable, in three shapes:
+
+| Shape | Example |
+|---|---|
+| Lookup table | `static readonly (Command, Value, Glyph, Label)[] Tools` in `DxRichTextEditor` |
+| Switch expression | `DxKbd.Display` / `DxKbd.Spoken` |
+| Local helper argument | `Slider(builder, 20, "Brightness", …)`, `Header(builder, 74, "Name")` |
+
+**The rule: keep the `S["Key", "English"]` pair literal, and put it where the text is
+*chosen* rather than where it is rendered.**
+
+```csharp
+// Switch arms resolve through the localizer; the method becomes an instance method.
+private string Display(string token) => token.ToLowerInvariant() switch
+{
+    "ctrl" or "control" => S["KeyCapControl", "Ctrl"],
+    "cmd" or "command"  => "⌘",   // no letters, no language — deliberately not localized
+    // ...
+};
+
+// Helper arguments are wrapped at the call site, not inside the helper.
+Slider(builder, 20, S["Brightness", "Brightness"], brightness, v => brightness = v);
+Header(builder, 74, S["ColumnName", "Name"]);
+```
+
+This matters for more than tidiness. **DX1003 cannot see any of these** — the literal is not
+at a call site — so the convention is what keeps them covered: because the pair stays
+literal, `LocalizedStringConsistencyTests` validates it against the `.resx` wherever in the
+file it appears. Hide the text behind a computed key (`S[keyVariable, label]`) and it drops
+out of every check at once, and its resource entry then looks orphaned. See
+[ADR 0021](adr/0021-optional-localization-and-rollout-guardrails.md), the amendment under
+Decision 2.
+
+Two consequences worth planning for:
+
+- A `static` helper that returns user-facing text has to become an **instance** method,
+  since `S` is an instance member.
+- Give the display form and the spoken form **separate keys** even when the English
+  collides. `DxKbd` renders "Ctrl" on the key cap and says "Control" to a screen reader; a
+  language that abbreviates differently needs both, and sharing one key would make the
+  screen reader announce the abbreviation.
+
 ### The `.resx` files
 
 Put them at the **project root**, next to the `.cs` file, named for the type:
@@ -161,6 +206,7 @@ file rather than the ones with user-facing text.)
 | `.cs` files in `BlazorDX.Components` | 142 |
 | …with zero user-facing strings (headless / parameter-driven) | 57 |
 | **Components to localize** | **83** (~250–270 unique strings) |
+| …localized so far | 6 — `DxAlert`, `DxDataGrid` (pilots) + batch 1's 4 |
 | …with 1–3 strings each | 60 |
 | …heavy hitters (>10 strings) | 6, holding ~40% of all text |
 | Stylesheets converted | 1 of 25 |
@@ -168,10 +214,15 @@ file rather than the ones with user-facing text.)
 
 ### Batch order
 
-**Strings** — the 6 heavy hitters individually (`DxRichTextEditor` ~30, `DxScheduler` ~25,
-then `DxDocumentViewer` / `DxFileManager` / `DxKbd` / `DxImageEditor` ~18 each) → the 4
-near-identical zoomable charts as one batch → the ~20 remaining charts sharing one
-`DxChartResources.resx` → 11 editorial components → ~28 stragglers alphabetically.
+**Strings** — the 6 heavy hitters individually → the 4 near-identical zoomable charts as one
+batch → the ~20 remaining charts sharing one `DxChartResources.resx` → 11 editorial
+components → ~28 stragglers alphabetically.
+
+Batch 1 landed 4 of the 6 heavy hitters — `DxKbd` (18), `DxImageEditor` (18),
+`DxDocumentViewer` (18), `DxFileManager` (14): **68 strings**. `DxRichTextEditor` (~28, all
+in a lookup table) and `DxScheduler` (~25) are deferred to batch 2; `DxScheduler` is
+entangled with the date-formatting track below (hardcoded weekday abbreviations), so it
+should be done together with that rather than twice.
 
 **CSS** — 12 trivial files (≤4 hits each) → `dx-datagrid` → the four heavy files
 individually → `dx-layout` last, since 7 of its 10 declarations are judgment calls.

--- a/src/BlazorDX.Components/DxDocumentViewer.cs
+++ b/src/BlazorDX.Components/DxDocumentViewer.cs
@@ -454,7 +454,10 @@ public sealed class DxDocumentViewer : ComponentBase
 
     // Safe placeholder shown when a source is missing or fails the scheme allowlist:
     // nothing clickable, no embed/img with an unsafe URL.
-    private static void BuildUnavailable(RenderTreeBuilder builder)
+    //
+    // Instance, not static: it renders user-facing text, and S is an instance member. Any
+    // helper that produces text has to give up `static` when its component is localized.
+    private void BuildUnavailable(RenderTreeBuilder builder)
     {
         builder.OpenElement(260, "div");
         builder.AddAttribute(261, "class", "dx-docview-unavailable");

--- a/src/BlazorDX.Components/DxDocumentViewer.cs
+++ b/src/BlazorDX.Components/DxDocumentViewer.cs
@@ -81,6 +81,12 @@ public sealed class DxDocumentViewer : ComponentBase
     /// <summary>Shows the Open-in-new-tab control in the toolbar (PDF/image). On by default.</summary>
     [Parameter] public bool ShowOpenInNewTab { get; set; } = true;
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxDocumentViewer>? s;
+
+    private DxStrings<DxDocumentViewer> S => s ??= new(Services);
+
     [Inject] private IDocumentViewerInterop Interop { get; set; } = default!;
 
     private int current;
@@ -123,7 +129,7 @@ public sealed class DxDocumentViewer : ComponentBase
         {
             builder.OpenElement(102, "div");
             builder.AddAttribute(103, "class", "dx-docview-empty");
-            builder.AddContent(104, "No document");
+            builder.AddContent(104, S["NoDocument", "No document"]);
             builder.CloseElement();
         }
         else
@@ -144,7 +150,7 @@ public sealed class DxDocumentViewer : ComponentBase
     {
         builder.OpenElement(10, "nav");
         builder.AddAttribute(11, "class", "dx-docview-list");
-        builder.AddAttribute(12, "aria-label", "Documents");
+        builder.AddAttribute(12, "aria-label", S["DocumentList", "Documents"]);
 
         for (int i = 0; i < Documents.Count; i++)
         {
@@ -192,13 +198,13 @@ public sealed class DxDocumentViewer : ComponentBase
         {
             builder.OpenElement(120, "div");
             builder.AddAttribute(121, "class", "dx-docview-zoom");
-            ZoomButton(builder, 122, "−", "Zoom out", () => zoom = Math.Max(25, zoom - 25));
+            ZoomButton(builder, 122, "−", S["ZoomOut", "Zoom out"], () => zoom = Math.Max(25, zoom - 25));
             builder.OpenElement(128, "span");
             builder.AddAttribute(129, "class", "dx-docview-zoom-value");
             builder.AddContent(130, $"{zoom}%");
             builder.CloseElement();
-            ZoomButton(builder, 131, "+", "Zoom in", () => zoom = Math.Min(400, zoom + 25));
-            ZoomButton(builder, 137, "Reset", "Reset zoom", () => zoom = 100);
+            ZoomButton(builder, 131, "+", S["ZoomIn", "Zoom in"], () => zoom = Math.Min(400, zoom + 25));
+            ZoomButton(builder, 137, S["ZoomResetGlyph", "Reset"], S["ZoomReset", "Reset zoom"], () => zoom = 100);
             builder.CloseElement();
         }
 
@@ -211,7 +217,7 @@ public sealed class DxDocumentViewer : ComponentBase
             builder.OpenElement(140, "div");
             builder.AddAttribute(141, "class", "dx-docview-actions");
             builder.AddAttribute(142, "role", "group");
-            builder.AddAttribute(143, "aria-label", "Document actions");
+            builder.AddAttribute(143, "aria-label", S["DocumentActions", "Document actions"]);
 
             // Source-bound links (download, open) are only emitted for a safe source;
             // a rejected/empty source never becomes a clickable href.
@@ -222,8 +228,11 @@ public sealed class DxDocumentViewer : ComponentBase
                 builder.AddAttribute(147, "href", doc.Source);
                 builder.AddAttribute(148, "download", doc.Name);
                 builder.AddAttribute(149, "rel", "noopener noreferrer");
-                builder.AddAttribute(150, "aria-label", $"Download {doc.Name}");
-                builder.AddContent(151, "⭳ Download");
+                builder.AddAttribute(150, "aria-label", S["DownloadNamed", "Download {0}", doc.Name]);
+                // The glyph is inside the localized value rather than prefixed around it: a
+                // translator may need to move it, since an RTL layout wants the affordance on the
+                // other side of the word. Same for the Print and Open buttons below.
+                builder.AddContent(151, S["DownloadButton", "⭳ Download"]);
                 builder.CloseElement();
             }
 
@@ -233,10 +242,10 @@ public sealed class DxDocumentViewer : ComponentBase
                 builder.OpenElement(155, "button");
                 builder.AddAttribute(156, "type", "button");
                 builder.AddAttribute(157, "class", "dx-docview-action");
-                builder.AddAttribute(158, "aria-label", $"Print {doc.Name}");
+                builder.AddAttribute(158, "aria-label", S["PrintNamed", "Print {0}", doc.Name]);
                 builder.AddAttribute(159, "onclick",
                     EventCallback.Factory.Create(this, () => PrintAsync(doc.Kind)));
-                builder.AddContent(160, "⎙ Print");
+                builder.AddContent(160, S["PrintButton", "⎙ Print"]);
                 builder.CloseElement();
             }
 
@@ -248,8 +257,8 @@ public sealed class DxDocumentViewer : ComponentBase
                 builder.AddAttribute(167, "href", doc.Source);
                 builder.AddAttribute(168, "target", "_blank");
                 builder.AddAttribute(169, "rel", "noopener noreferrer");
-                builder.AddAttribute(170, "aria-label", $"Open {doc.Name} in a new tab");
-                builder.AddContent(171, "↗ Open");
+                builder.AddAttribute(170, "aria-label", S["OpenNamed", "Open {0} in a new tab", doc.Name]);
+                builder.AddContent(171, S["OpenButton", "↗ Open"]);
                 builder.CloseElement();
             }
 
@@ -394,11 +403,11 @@ public sealed class DxDocumentViewer : ComponentBase
                     // browsers without an inline PDF plugin can still get the file.
                     builder.OpenElement(226, "p");
                     builder.AddAttribute(227, "class", "dx-docview-pdf-fallback");
-                    builder.AddContent(228, "Can't see the PDF above? ");
+                    builder.AddContent(228, S["PdfFallbackPrompt", "Can't see the PDF above? "]);
                     builder.OpenElement(229, "a");
                     builder.AddAttribute(230, "href", doc.Source);
                     builder.AddAttribute(231, "download", doc.Name);
-                    builder.AddContent(232, "Download the PDF");
+                    builder.AddContent(232, S["DownloadThePdf", "Download the PDF"]);
                     builder.CloseElement();
                     builder.AddContent(233, ".");
                     builder.CloseElement();
@@ -427,13 +436,13 @@ public sealed class DxDocumentViewer : ComponentBase
             default:
                 builder.OpenElement(250, "div");
                 builder.AddAttribute(251, "class", "dx-docview-unsupported");
-                builder.AddContent(252, "Preview not available for this file type. ");
+                builder.AddContent(252, S["NoPreview", "Preview not available for this file type. "]);
                 if (IsSafeSource(doc.Source))
                 {
                     builder.OpenElement(253, "a");
                     builder.AddAttribute(254, "href", doc.Source);
                     builder.AddAttribute(255, "download", doc.Name);
-                    builder.AddContent(256, "Download");
+                    builder.AddContent(256, S["Download", "Download"]);
                     builder.CloseElement();
                 }
                 builder.CloseElement();
@@ -449,7 +458,7 @@ public sealed class DxDocumentViewer : ComponentBase
     {
         builder.OpenElement(260, "div");
         builder.AddAttribute(261, "class", "dx-docview-unavailable");
-        builder.AddContent(262, "Document source unavailable");
+        builder.AddContent(262, S["SourceUnavailable", "Document source unavailable"]);
         builder.CloseElement();
     }
 }

--- a/src/BlazorDX.Components/DxDocumentViewer.resx
+++ b/src/BlazorDX.Components/DxDocumentViewer.resx
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DocumentActions" xml:space="preserve">
+    <value>Document actions</value>
+  </data>
+  <data name="DocumentList" xml:space="preserve">
+    <value>Documents</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="DownloadButton" xml:space="preserve">
+    <value>⭳ Download</value>
+  </data>
+  <data name="DownloadNamed" xml:space="preserve">
+    <value>Download {0}</value>
+  </data>
+  <data name="DownloadThePdf" xml:space="preserve">
+    <value>Download the PDF</value>
+  </data>
+  <data name="NoDocument" xml:space="preserve">
+    <value>No document</value>
+  </data>
+  <data name="NoPreview" xml:space="preserve">
+    <value>Preview not available for this file type. </value>
+  </data>
+  <data name="OpenButton" xml:space="preserve">
+    <value>↗ Open</value>
+  </data>
+  <data name="OpenNamed" xml:space="preserve">
+    <value>Open {0} in a new tab</value>
+  </data>
+  <data name="PdfFallbackPrompt" xml:space="preserve">
+    <value>Can't see the PDF above? </value>
+  </data>
+  <data name="PrintButton" xml:space="preserve">
+    <value>⎙ Print</value>
+  </data>
+  <data name="PrintNamed" xml:space="preserve">
+    <value>Print {0}</value>
+  </data>
+  <data name="SourceUnavailable" xml:space="preserve">
+    <value>Document source unavailable</value>
+  </data>
+  <data name="ZoomIn" xml:space="preserve">
+    <value>Zoom in</value>
+  </data>
+  <data name="ZoomOut" xml:space="preserve">
+    <value>Zoom out</value>
+  </data>
+  <data name="ZoomReset" xml:space="preserve">
+    <value>Reset zoom</value>
+  </data>
+  <data name="ZoomResetGlyph" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxFileManager.cs
+++ b/src/BlazorDX.Components/DxFileManager.cs
@@ -26,6 +26,12 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
 {
     private const int IndentPerLevel = 16;
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxFileManager>? s;
+
+    private DxStrings<DxFileManager> S => s ??= new(Services);
+
     [Inject] private IFileDndInterop Dnd { get; set; } = default!;
 
     [Inject] private IFileHashInterop Hash { get; set; } = default!;
@@ -118,11 +124,11 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
     {
         builder.OpenElement(4, "nav");
         builder.AddAttribute(5, "class", "dx-fm-breadcrumb");
-        builder.AddAttribute(6, "aria-label", "Path");
+        builder.AddAttribute(6, "aria-label", S["Breadcrumb", "Path"]);
 
         builder.OpenElement(7, "span");
         builder.AddAttribute(8, "class", "dx-fm-crumb-home");
-        builder.AddContent(9, "Files");
+        builder.AddContent(9, S["RootName", "Files"]);
         builder.CloseElement();
 
         // "Move here" affordance on the root while an item is marked for moving.
@@ -131,9 +137,9 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
             builder.OpenElement(10, "button");
             builder.AddAttribute(11, "type", "button");
             builder.AddAttribute(12, "class", "dx-fm-move-here");
-            builder.AddAttribute(13, "aria-label", $"Move {MoveCandidate.Name} to Files");
+            builder.AddAttribute(13, "aria-label", S["MoveToRoot", "Move {0} to Files", MoveCandidate.Name]);
             builder.AddAttribute(14, "onclick", EventCallback.Factory.Create(this, () => PlaceMoveCandidateAsync(null)));
-            builder.AddContent(15, "Move here");
+            builder.AddContent(15, S["MoveHere", "Move here"]);
             builder.CloseElement();
         }
 
@@ -180,7 +186,7 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
 
         builder.OpenElement(33, "span");
         builder.AddAttribute(34, "class", "dx-fm-upload-prompt");
-        builder.AddContent(35, "Upload files");
+        builder.AddContent(35, S["UploadFiles", "Upload files"]);
         builder.CloseElement();
 
         builder.CloseElement();   // label
@@ -222,7 +228,7 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
                 builder.OpenElement(47, "button");
                 builder.AddAttribute(48, "type", "button");
                 builder.AddAttribute(49, "class", "dx-fm-twisty");
-                builder.AddAttribute(50, "aria-label", row.Expanded ? "Collapse" : "Expand");
+                builder.AddAttribute(50, "aria-label", row.Expanded ? S["Collapse", "Collapse"] : S["Expand", "Expand"]);
                 builder.AddAttribute(51, "onclick", EventCallback.Factory.Create(this, () => ToggleFolderAsync(folder)));
                 builder.AddContent(52, row.Expanded ? "▾" : "▸");
                 builder.CloseElement();
@@ -249,9 +255,9 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
                 builder.OpenElement(61, "button");
                 builder.AddAttribute(62, "type", "button");
                 builder.AddAttribute(63, "class", "dx-fm-move-here");
-                builder.AddAttribute(64, "aria-label", $"Move {MoveCandidate.Name} into {folder.Name}");
+                builder.AddAttribute(64, "aria-label", S["MoveInto", "Move {0} into {1}", MoveCandidate.Name, folder.Name]);
                 builder.AddAttribute(65, "onclick", EventCallback.Factory.Create(this, () => PlaceMoveCandidateAsync(folder)));
-                builder.AddContent(66, "Move here");
+                builder.AddContent(66, S["MoveHere", "Move here"]);
                 builder.CloseElement();
             }
 
@@ -267,15 +273,15 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
         builder.AddAttribute(68, "id", DropZoneId);
         builder.AddAttribute(69, "class", "dx-fm-contents");
         builder.AddAttribute(70, "role", "table");
-        builder.AddAttribute(71, "aria-label", "Folder contents. Drop files here to upload.");
+        builder.AddAttribute(71, "aria-label", S["ContentsLabel", "Folder contents. Drop files here to upload."]);
 
         builder.OpenElement(72, "div");
         builder.AddAttribute(73, "class", "dx-fm-content-head");
         builder.AddAttribute(721, "role", "row");
-        Header(builder, 74, "Name");
-        Header(builder, 78, "Size");
-        Header(builder, 82, "Modified");
-        Header(builder, 86, "Actions");
+        Header(builder, 74, S["ColumnName", "Name"]);
+        Header(builder, 78, S["ColumnSize", "Size"]);
+        Header(builder, 82, S["ColumnModified", "Modified"]);
+        Header(builder, 86, S["ColumnActions", "Actions"]);
         builder.CloseElement();
 
         IReadOnlyList<FileSystemEntry> contents = Contents();
@@ -290,7 +296,7 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
             builder.AddAttribute(911, "role", "row");
             builder.OpenElement(912, "div");
             builder.AddAttribute(913, "role", "cell");
-            builder.AddContent(92, "This folder is empty. Drop files here or use Upload files.");
+            builder.AddContent(92, S["EmptyFolder", "This folder is empty. Drop files here or use Upload files."]);
             builder.CloseElement();
             builder.CloseElement();
         }

--- a/src/BlazorDX.Components/DxFileManager.resx
+++ b/src/BlazorDX.Components/DxFileManager.resx
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Breadcrumb" xml:space="preserve">
+    <value>Path</value>
+  </data>
+  <data name="Collapse" xml:space="preserve">
+    <value>Collapse</value>
+  </data>
+  <data name="ColumnActions" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+  <data name="ColumnModified" xml:space="preserve">
+    <value>Modified</value>
+  </data>
+  <data name="ColumnName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ColumnSize" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="ContentsLabel" xml:space="preserve">
+    <value>Folder contents. Drop files here to upload.</value>
+  </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>This folder is empty. Drop files here or use Upload files.</value>
+  </data>
+  <data name="Expand" xml:space="preserve">
+    <value>Expand</value>
+  </data>
+  <data name="MoveHere" xml:space="preserve">
+    <value>Move here</value>
+  </data>
+  <data name="MoveInto" xml:space="preserve">
+    <value>Move {0} into {1}</value>
+  </data>
+  <data name="MoveToRoot" xml:space="preserve">
+    <value>Move {0} to Files</value>
+  </data>
+  <data name="RootName" xml:space="preserve">
+    <value>Files</value>
+  </data>
+  <data name="UploadFiles" xml:space="preserve">
+    <value>Upload files</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxImageEditor.cs
+++ b/src/BlazorDX.Components/DxImageEditor.cs
@@ -38,6 +38,12 @@ public sealed class DxImageEditor : ComponentBase, IAsyncDisposable
     /// <summary>Extra CSS classes appended to the editor root.</summary>
     [Parameter] public string? Class { get; set; }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxImageEditor>? s;
+
+    private DxStrings<DxImageEditor> S => s ??= new(Services);
+
     [Inject] private IImageEditorInterop Interop { get; set; } = default!;
 
     private string EditsJson() =>
@@ -124,7 +130,7 @@ public sealed class DxImageEditor : ComponentBase, IAsyncDisposable
         {
             builder.OpenElement(302, "span");
             builder.AddAttribute(303, "class", "dx-imgedit-empty");
-            builder.AddContent(304, "Open an image to start editing");
+            builder.AddContent(304, S["EmptyState", "Open an image to start editing"]);
             builder.CloseElement();
         }
 
@@ -132,7 +138,7 @@ public sealed class DxImageEditor : ComponentBase, IAsyncDisposable
         builder.AddAttribute(306, "id", canvasId);
         builder.AddAttribute(307, "class", "dx-imgedit-canvas");
         builder.AddAttribute(308, "role", "img");
-        builder.AddAttribute(309, "aria-label", "Edited image preview");
+        builder.AddAttribute(309, "aria-label", S["CanvasLabel", "Edited image preview"]);
         if (!loaded)
         {
             builder.AddAttribute(310, "hidden", true);
@@ -157,24 +163,24 @@ public sealed class DxImageEditor : ComponentBase, IAsyncDisposable
         builder.AddComponentParameter(8, "accept", "image/*");
         builder.AddComponentParameter(9, "OnChange", EventCallback.Factory.Create<InputFileChangeEventArgs>(this, LoadAsync));
         builder.CloseComponent();
-        builder.AddContent(10, loaded ? "Replace image" : "Open image");
+        builder.AddContent(10, loaded ? S["ReplaceImage", "Replace image"] : S["OpenImage", "Open image"]);
         builder.CloseElement();
 
-        Slider(builder, 20, "Brightness", brightness, v => brightness = v);
-        Slider(builder, 40, "Contrast", contrast, v => contrast = v);
-        Slider(builder, 60, "Saturation", saturate, v => saturate = v);
+        Slider(builder, 20, S["Brightness", "Brightness"], brightness, v => brightness = v);
+        Slider(builder, 40, S["Contrast", "Contrast"], contrast, v => contrast = v);
+        Slider(builder, 60, S["Saturation", "Saturation"], saturate, v => saturate = v);
 
         builder.OpenElement(80, "div");
         builder.AddAttribute(81, "class", "dx-imgedit-actions");
-        Toggle(builder, 90, "Grayscale", grayscale, () => grayscale, v => grayscale = v);
-        Toggle(builder, 100, "Sepia", sepia, () => sepia, v => sepia = v);
-        Toggle(builder, 110, "Invert", invert, () => invert, v => invert = v);
-        Action(builder, 120, "⟲", "Rotate left", () => { rotate = (rotate + 270) % 360; return RenderAsync(); });
-        Action(builder, 130, "⟳", "Rotate right", () => { rotate = (rotate + 90) % 360; return RenderAsync(); });
-        Action(builder, 140, "⇋", "Flip horizontal", () => { flipH = !flipH; return RenderAsync(); });
-        Action(builder, 150, "⇅", "Flip vertical", () => { flipV = !flipV; return RenderAsync(); });
-        Action(builder, 160, "Reset", "Reset edits", ResetAsync);
-        Action(builder, 170, "⭳ Download", "Download image",
+        Toggle(builder, 90, S["Grayscale", "Grayscale"], grayscale, () => grayscale, v => grayscale = v);
+        Toggle(builder, 100, S["Sepia", "Sepia"], sepia, () => sepia, v => sepia = v);
+        Toggle(builder, 110, S["Invert", "Invert"], invert, () => invert, v => invert = v);
+        Action(builder, 120, "⟲", S["RotateLeft", "Rotate left"], () => { rotate = (rotate + 270) % 360; return RenderAsync(); });
+        Action(builder, 130, "⟳", S["RotateRight", "Rotate right"], () => { rotate = (rotate + 90) % 360; return RenderAsync(); });
+        Action(builder, 140, "⇋", S["FlipHorizontal", "Flip horizontal"], () => { flipH = !flipH; return RenderAsync(); });
+        Action(builder, 150, "⇅", S["FlipVertical", "Flip vertical"], () => { flipV = !flipV; return RenderAsync(); });
+        Action(builder, 160, S["ResetGlyph", "Reset"], S["ResetEdits", "Reset edits"], ResetAsync);
+        Action(builder, 170, S["DownloadGlyph", "⭳ Download"], S["DownloadImage", "Download image"],
             () => Interop.DownloadAsync(canvasId, DownloadName, "image/png").AsTask());
         builder.CloseElement();
 

--- a/src/BlazorDX.Components/DxImageEditor.resx
+++ b/src/BlazorDX.Components/DxImageEditor.resx
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Brightness" xml:space="preserve">
+    <value>Brightness</value>
+  </data>
+  <data name="CanvasLabel" xml:space="preserve">
+    <value>Edited image preview</value>
+  </data>
+  <data name="Contrast" xml:space="preserve">
+    <value>Contrast</value>
+  </data>
+  <data name="DownloadGlyph" xml:space="preserve">
+    <value>⭳ Download</value>
+  </data>
+  <data name="DownloadImage" xml:space="preserve">
+    <value>Download image</value>
+  </data>
+  <data name="EmptyState" xml:space="preserve">
+    <value>Open an image to start editing</value>
+  </data>
+  <data name="FlipHorizontal" xml:space="preserve">
+    <value>Flip horizontal</value>
+  </data>
+  <data name="FlipVertical" xml:space="preserve">
+    <value>Flip vertical</value>
+  </data>
+  <data name="Grayscale" xml:space="preserve">
+    <value>Grayscale</value>
+  </data>
+  <data name="Invert" xml:space="preserve">
+    <value>Invert</value>
+  </data>
+  <data name="OpenImage" xml:space="preserve">
+    <value>Open image</value>
+  </data>
+  <data name="ReplaceImage" xml:space="preserve">
+    <value>Replace image</value>
+  </data>
+  <data name="ResetEdits" xml:space="preserve">
+    <value>Reset edits</value>
+  </data>
+  <data name="ResetGlyph" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="RotateLeft" xml:space="preserve">
+    <value>Rotate left</value>
+  </data>
+  <data name="RotateRight" xml:space="preserve">
+    <value>Rotate right</value>
+  </data>
+  <data name="Saturation" xml:space="preserve">
+    <value>Saturation</value>
+  </data>
+  <data name="Sepia" xml:space="preserve">
+    <value>Sepia</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxKbd.cs
+++ b/src/BlazorDX.Components/DxKbd.cs
@@ -18,6 +18,12 @@ public sealed class DxKbd : ComponentBase
     /// <summary>Extra CSS classes appended to the combo wrapper.</summary>
     [Parameter] public string? Class { get; set; }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxKbd>? s;
+
+    private DxStrings<DxKbd> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         string[] tokens = Combo.Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -27,7 +33,9 @@ public sealed class DxKbd : ComponentBase
         if (tokens.Length > 0)
         {
             builder.AddAttribute(2, "role", "img");
-            builder.AddAttribute(3, "aria-label", string.Join(" plus ", tokens.Select(Spoken)));
+            // The joiner is spoken text, not punctuation: a screen reader reads it aloud between
+            // every pair of keys, so it has to translate along with the key names themselves.
+            builder.AddAttribute(3, "aria-label", string.Join(S["ComboJoiner", " plus "], tokens.Select(Spoken)));
         }
 
         int seq = 4;
@@ -52,18 +60,23 @@ public sealed class DxKbd : ComponentBase
         builder.CloseElement();
     }
 
-    // Short, glanceable label for the key cap.
-    private static string Display(string token) => token.ToLowerInvariant() switch
+    // Short, glanceable label for the key cap. Instance, not static, because the arms now read
+    // through the localizer -- and each arm is a literal S["Key", "English"] pair so the English
+    // stays visible here and LocalizedStringConsistencyTests can still check it against the .resx.
+    //
+    // The purely symbolic arms (⌘ ⌫ ↑ ↓ ← →) are deliberately NOT localized: they carry no
+    // language, and DX1003 ignores letter-free literals for exactly this reason.
+    private string Display(string token) => token.ToLowerInvariant() switch
     {
-        "ctrl" or "control" => "Ctrl",
+        "ctrl" or "control" => S["KeyCapControl", "Ctrl"],
         "cmd" or "command" or "meta" or "win" => "⌘",
-        "alt" or "option" or "opt" => "Alt",
-        "shift" => "Shift",
-        "enter" or "return" => "Enter",
-        "esc" or "escape" => "Esc",
-        "space" or "spacebar" => "Space",
-        "tab" => "Tab",
-        "del" or "delete" => "Del",
+        "alt" or "option" or "opt" => S["KeyCapAlt", "Alt"],
+        "shift" => S["KeyCapShift", "Shift"],
+        "enter" or "return" => S["KeyCapEnter", "Enter"],
+        "esc" or "escape" => S["KeyCapEscape", "Esc"],
+        "space" or "spacebar" => S["KeyCapSpace", "Space"],
+        "tab" => S["KeyCapTab", "Tab"],
+        "del" or "delete" => S["KeyCapDelete", "Del"],
         "backspace" => "⌫",
         "up" or "arrowup" => "↑",
         "down" or "arrowdown" => "↓",
@@ -72,18 +85,20 @@ public sealed class DxKbd : ComponentBase
         _ => token.Length == 1 ? token.ToUpperInvariant() : Capitalize(token),
     };
 
-    // Spoken form for the aria-label, so symbols are announced as words.
-    private static string Spoken(string token) => token.ToLowerInvariant() switch
+    // Spoken form for the aria-label, so symbols are announced as words. Separate keys from
+    // Display's: "Ctrl" and "Control" are the same key in English but need not be in every
+    // language, and a screen reader saying the abbreviation would be a regression.
+    private string Spoken(string token) => token.ToLowerInvariant() switch
     {
-        "ctrl" or "control" => "Control",
-        "cmd" or "command" or "meta" or "win" => "Command",
-        "alt" or "option" or "opt" => "Alt",
-        "shift" => "Shift",
-        "up" or "arrowup" => "Up arrow",
-        "down" or "arrowdown" => "Down arrow",
-        "left" or "arrowleft" => "Left arrow",
-        "right" or "arrowright" => "Right arrow",
-        "backspace" => "Backspace",
+        "ctrl" or "control" => S["SpokenControl", "Control"],
+        "cmd" or "command" or "meta" or "win" => S["SpokenCommand", "Command"],
+        "alt" or "option" or "opt" => S["SpokenAlt", "Alt"],
+        "shift" => S["SpokenShift", "Shift"],
+        "up" or "arrowup" => S["SpokenUpArrow", "Up arrow"],
+        "down" or "arrowdown" => S["SpokenDownArrow", "Down arrow"],
+        "left" or "arrowleft" => S["SpokenLeftArrow", "Left arrow"],
+        "right" or "arrowright" => S["SpokenRightArrow", "Right arrow"],
+        "backspace" => S["SpokenBackspace", "Backspace"],
         _ => token.Length == 1 ? token.ToUpperInvariant() : Capitalize(token),
     };
 

--- a/src/BlazorDX.Components/DxKbd.resx
+++ b/src/BlazorDX.Components/DxKbd.resx
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ComboJoiner" xml:space="preserve">
+    <value> plus </value>
+  </data>
+  <data name="KeyCapAlt" xml:space="preserve">
+    <value>Alt</value>
+  </data>
+  <data name="KeyCapControl" xml:space="preserve">
+    <value>Ctrl</value>
+  </data>
+  <data name="KeyCapDelete" xml:space="preserve">
+    <value>Del</value>
+  </data>
+  <data name="KeyCapEnter" xml:space="preserve">
+    <value>Enter</value>
+  </data>
+  <data name="KeyCapEscape" xml:space="preserve">
+    <value>Esc</value>
+  </data>
+  <data name="KeyCapShift" xml:space="preserve">
+    <value>Shift</value>
+  </data>
+  <data name="KeyCapSpace" xml:space="preserve">
+    <value>Space</value>
+  </data>
+  <data name="KeyCapTab" xml:space="preserve">
+    <value>Tab</value>
+  </data>
+  <data name="SpokenAlt" xml:space="preserve">
+    <value>Alt</value>
+  </data>
+  <data name="SpokenBackspace" xml:space="preserve">
+    <value>Backspace</value>
+  </data>
+  <data name="SpokenCommand" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="SpokenControl" xml:space="preserve">
+    <value>Control</value>
+  </data>
+  <data name="SpokenDownArrow" xml:space="preserve">
+    <value>Down arrow</value>
+  </data>
+  <data name="SpokenLeftArrow" xml:space="preserve">
+    <value>Left arrow</value>
+  </data>
+  <data name="SpokenRightArrow" xml:space="preserve">
+    <value>Right arrow</value>
+  </data>
+  <data name="SpokenShift" xml:space="preserve">
+    <value>Shift</value>
+  </data>
+  <data name="SpokenUpArrow" xml:space="preserve">
+    <value>Up arrow</value>
+  </data>
+</root>

--- a/tests/BlazorDX.Components.Tests/DxDocumentViewerTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDocumentViewerTests.cs
@@ -2,6 +2,7 @@ using BlazorDX.Components;
 using BlazorDX.Interop;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Xunit;
 
 namespace BlazorDX.Components.Tests;
@@ -350,5 +351,25 @@ public sealed class DxDocumentViewerTests : TestContext
         // The CSS targets .dx-docview-item:focus-visible; the buttons carry that class.
         Assert.All(v.FindAll(".dx-docview-item"),
             el => Assert.Contains("dx-docview-item", el.GetAttribute("class")));
+    }
+
+    [Fact]
+    public void Empty_state_and_actions_are_routed_through_the_localizer()
+    {
+        Services.AddSingleton<IStringLocalizer<DxDocumentViewer>>(new FakeStringLocalizer<DxDocumentViewer>());
+
+        IRenderedComponent<DxDocumentViewer> viewer = Render();
+
+        Assert.Contains("§§NODOCUMENT§§", viewer.Markup);
+    }
+
+    [Fact]
+    public void Empty_state_falls_back_to_the_invariant_resource()
+    {
+        Services.AddLocalization();
+
+        IRenderedComponent<DxDocumentViewer> viewer = Render();
+
+        Assert.Contains("No document", viewer.Markup);
     }
 }

--- a/tests/BlazorDX.Components.Tests/DxFileManagerTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxFileManagerTests.cs
@@ -5,6 +5,7 @@ using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Xunit;
 
 namespace BlazorDX.Components.Tests;
@@ -542,5 +543,27 @@ public sealed class DxFileManagerTests : TestContext
         fm.FindComponent<InputFile>().UploadFiles(InputFileContent.CreateFromText("x", "note.txt"));
 
         Assert.False(raised);   // VerifyIntegrity defaults off
+    }
+
+    [Fact]
+    public void Breadcrumb_and_column_headers_are_routed_through_the_localizer()
+    {
+        Services.AddSingleton<IStringLocalizer<DxFileManager>>(new FakeStringLocalizer<DxFileManager>());
+
+        IRenderedComponent<DxFileManager> fm = Render();
+
+        Assert.Contains("§§ROOTNAME§§", fm.Markup);
+        Assert.Contains("§§COLUMNMODIFIED§§", fm.Markup);
+    }
+
+    [Fact]
+    public void Breadcrumb_and_column_headers_fall_back_to_the_invariant_resource()
+    {
+        Services.AddLocalization();
+
+        IRenderedComponent<DxFileManager> fm = Render();
+
+        Assert.Contains("Files", fm.Markup);
+        Assert.Contains("Modified", fm.Markup);
     }
 }

--- a/tests/BlazorDX.Components.Tests/DxImageEditorTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxImageEditorTests.cs
@@ -3,6 +3,7 @@ using BlazorDX.Interop;
 using Bunit;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Xunit;
 
 namespace BlazorDX.Components.Tests;
@@ -130,5 +131,29 @@ public sealed class DxImageEditorTests : TestContext
         editor.Find("button[aria-label='Download image']").Click();
 
         Assert.Equal("out.png", fake.DownloadFile);
+    }
+
+    [Fact]
+    public void Toolbar_labels_are_routed_through_the_localizer()
+    {
+        // These reach the DOM as arguments to the local Slider/Toggle/Action helpers rather than
+        // as literals at a render call site, so only a sentinel shows they go through DxStrings.
+        Services.AddSingleton<IStringLocalizer<DxImageEditor>>(new FakeStringLocalizer<DxImageEditor>());
+
+        IRenderedComponent<DxImageEditor> editor = RenderEditor();
+
+        Assert.Contains("§§BRIGHTNESS§§", editor.Markup);
+        Assert.Contains("§§ROTATELEFT§§", editor.Markup);
+    }
+
+    [Fact]
+    public void Toolbar_labels_fall_back_to_the_invariant_resource()
+    {
+        Services.AddLocalization();
+
+        IRenderedComponent<DxImageEditor> editor = RenderEditor();
+
+        Assert.Contains("Brightness", editor.Markup);
+        Assert.Contains("Rotate left", editor.Markup);
     }
 }

--- a/tests/BlazorDX.Components.Tests/DxKbdTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxKbdTests.cs
@@ -1,5 +1,7 @@
 using BlazorDX.Components;
 using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Xunit;
 
 namespace BlazorDX.Components.Tests;
@@ -44,5 +46,33 @@ public sealed class DxKbdTests : TestContext
         IRenderedComponent<DxKbd> kbd = RenderComponent<DxKbd>(p => p.Add(c => c.Combo, ""));
 
         Assert.Empty(kbd.FindAll("kbd"));
+    }
+
+    [Fact]
+    public void Key_names_are_routed_through_the_localizer()
+    {
+        // Sentinel, not the English value: "Ctrl" is also the English fallback, so asserting it
+        // would pass whether or not the switch arm actually calls the localizer. DxKbd is the
+        // rollout's worked example for indirect text -- its user-facing strings live in switch
+        // arms rather than at AddContent/AddAttribute call sites.
+        Services.AddSingleton<IStringLocalizer<DxKbd>>(new FakeStringLocalizer<DxKbd>());
+
+        IRenderedComponent<DxKbd> kbd = RenderComponent<DxKbd>(p => p.Add(c => c.Combo, "Ctrl"));
+
+        Assert.Contains("§§KEYCAPCONTROL§§", kbd.Markup);
+        // The spoken form is a separate key: a screen reader must not be given the abbreviation.
+        Assert.Contains("§§SPOKENCONTROL§§", kbd.Markup);
+    }
+
+    [Fact]
+    public void Key_names_fall_back_to_the_invariant_resource()
+    {
+        // The real factory, so this proves DxKbd.resx's own values round-trip.
+        Services.AddLocalization();
+
+        IRenderedComponent<DxKbd> kbd = RenderComponent<DxKbd>(p => p.Add(c => c.Combo, "Ctrl+Shift"));
+
+        Assert.Equal("Ctrl", kbd.FindAll("kbd.dx-kbd")[0].TextContent);
+        Assert.Equal("Control plus Shift", kbd.Find(".dx-kbd-combo").GetAttribute("aria-label"));
     }
 }

--- a/tests/BlazorDX.Components.Tests/LocalizedStringConsistencyTests.cs
+++ b/tests/BlazorDX.Components.Tests/LocalizedStringConsistencyTests.cs
@@ -38,7 +38,9 @@ public sealed class LocalizedStringConsistencyTests
     private static readonly Regex ResourceType = new(@"private\s+DxStrings<(\w+)>", RegexOptions.Compiled);
 
     // S["Key", "English"...] — literal key and literal English only. A computed key would not match
-    // and would go unchecked, which is a gap worth knowing about; there are none today.
+    // and would go unchecked, which is a gap worth knowing about; the rollout's convention is that
+    // indirect text (switch arms, lookup helpers) still resolves through a literal pair like this,
+    // precisely so this check keeps working. See docs/localization.md.
     private static readonly Regex CallSite = new(@"S\[\s*""([^""]*)""\s*,\s*""([^""]*)""", RegexOptions.Compiled);
 
     [Fact]
@@ -49,7 +51,10 @@ public sealed class LocalizedStringConsistencyTests
 
         foreach (string component in LocalizedComponents())
         {
-            string source = File.ReadAllText(component);
+            // Comments stripped first. Documentation that shows the pattern — including this
+            // test's own guidance in docs and in component doc comments — otherwise reads as a
+            // real call site, and the orphan check then demands a resource entry named "Key".
+            string source = StripComments(File.ReadAllText(component));
             string resourceName = ResourceType.Match(source).Groups[1].Value;
             string resx = Path.Combine(ComponentsDirectory(), $"{resourceName}.resx");
 
@@ -98,6 +103,56 @@ public sealed class LocalizedStringConsistencyTests
         Assert.True(problems.Count == 0,
             "Call-site English and .resx values have drifted:" + Environment.NewLine
             + string.Join(Environment.NewLine, problems.Select(p => "  " + p)));
+    }
+
+    /// <summary>
+    /// Blanks out <c>//</c> and <c>/* … */</c> comments, leaving string literals intact — a
+    /// <c>//</c> inside a string starts no comment, and a quote inside a comment starts no string.
+    /// </summary>
+    /// <remarks>
+    /// Handles regular and verbatim (<c>@"…"</c>) literals. Raw string literals
+    /// (<c>"""…"""</c>) are treated as regular ones, which is safe here only because no component
+    /// puts a comment marker inside one; revisit if that changes.
+    /// </remarks>
+    private static string StripComments(string source)
+    {
+        char[] result = source.ToCharArray();
+        bool inLine = false, inBlock = false, inString = false, inChar = false, verbatim = false;
+
+        for (int i = 0; i < source.Length; i++)
+        {
+            char c = source[i];
+            char next = i + 1 < source.Length ? source[i + 1] : '\0';
+
+            if (inLine)
+            {
+                if (c is '\n') { inLine = false; } else { result[i] = ' '; }
+            }
+            else if (inBlock)
+            {
+                bool closing = c is '*' && next is '/';
+                if (c is not '\n') { result[i] = ' '; }
+                if (closing) { result[i + 1] = ' '; i++; inBlock = false; }
+            }
+            else if (inString)
+            {
+                // In a verbatim string "" is an escaped quote; otherwise a backslash escapes.
+                if (verbatim && c is '"' && next is '"') { i++; }
+                else if (!verbatim && c is '\\') { i++; }
+                else if (c is '"') { inString = false; verbatim = false; }
+            }
+            else if (inChar)
+            {
+                if (c is '\\') { i++; }
+                else if (c is '\'') { inChar = false; }
+            }
+            else if (c is '/' && next is '/') { inLine = true; result[i] = ' '; }
+            else if (c is '/' && next is '*') { inBlock = true; result[i] = ' '; }
+            else if (c is '"') { inString = true; verbatim = i > 0 && source[i - 1] is '@'; }
+            else if (c is '\'') { inChar = true; }
+        }
+
+        return new string(result);
     }
 
     private static Dictionary<string, string> ReadResources(string path) =>


### PR DESCRIPTION
First rollout batch after the [localization foundation](https://github.com/logixrcorp/BlazorDX/pull/47) — **68 strings** across four of the six heavy hitters, following [docs/localization.md](docs/localization.md).

It also corrected the plan it was executing, which is the more important half of this PR.

## DX1003 sees less than ADR 0021 claimed

The foundation specified DX1003 to guard any component holding a `DxStrings` field, and ADR 0021 said the only remaining hole was components not yet localized. Both are wrong. The analyzer inspects **literals at render call sites**, and that is where a *minority* of this library's user-facing text lives. The rest arrives through a variable:

| Shape | Example |
|---|---|
| Lookup table | `DxRichTextEditor`'s 17 toolbar labels in a `static readonly (Command, Value, Glyph, Label)[]` |
| Switch expression | `DxKbd.Display` / `DxKbd.Spoken` — 18 strings |
| Local helper argument | `Slider(builder, 20, "Brightness", …)`, `Header(builder, 74, "Name")` |

That third shape is the most common in the styled tier.

**`DxKbd` is the proof**: it had *no* user-facing literal at any call site, so DX1003 would have reported it fully compliant while every one of its strings was hardcoded. Flipping the analyzer to fire on every component — ADR 0021's stated completion criterion — would not have changed that.

Widening it to "any literal in a localized type" isn't the fix either: CSS class names, element names, command identifiers and format strings are the majority of literals in these files.

### What actually covers this text

A convention the analyzer can't enforce but the consistency test can — indirect text resolves through a literal `S["Key", "English"]` pair placed **where the text is chosen**, not where it's rendered:

```csharp
private string Display(string token) => token.ToLowerInvariant() switch
{
    "ctrl" or "control" => S["KeyCapControl", "Ctrl"],
    "cmd" or "command"  => "⌘",   // no letters, no language — deliberately not localized
};

Slider(builder, 20, S["Brightness", "Brightness"], brightness, v => brightness = v);
```

Because the pair stays literal, `LocalizedStringConsistencyTests` validates it against the `.resx` wherever in the file it appears. ADR 0021 now carries the amendment and states the guarantee honestly: **the analyzer catches regressions at call sites; the consistency test catches drift wherever the convention is followed; nothing mechanically catches a brand-new hardcoded literal inside a helper method.** That last gap is closed by review, and mitigated by each component's strings now being enumerated in one `.resx`.

## Two fixes from using the tooling for real

- **`LocalizedStringConsistencyTests` matched its own documentation.** A doc comment showing `S["Key", "English"]` read as a real call site, so the orphan check demanded a resource entry named `Key` — a build failure on the first component that documented the pattern. It now strips C# comments (string literals left intact) before matching.
- **Display and spoken forms get separate keys** even where the English collides. `DxKbd` shows "Ctrl" on the key cap and says "Control" to a screen reader; sharing one key would make the screen reader announce the abbreviation.

## Detail

Glyph-only values (`⌘ ⌫ ↑ ↓ ← →`) stay literal — they carry no language, and DX1003 ignores letter-free literals for the same reason. Glyph+word button labels (`"⭳ Download"`) are localized whole so a translator can move the glyph for RTL.

No `.fr.resx` in this batch: the rollout externalizes strings, it doesn't translate them, and inventing French would be fabricated content. The AOT satellite-assembly path is already proven by the two pilots.

Each component gets the two-test convention — a sentinel proving the string is routed through the localizer (the English fallback usually equals the English resource, so only a sentinel distinguishes "routed" from "still hardcoded"), and a real-resource test proving the `.resx` round-trips. Neither test class registers a localizer in its constructor, so every *other* test in those files is already the "renders with no localizer" proof.

**Deferred to batch 2:** `DxRichTextEditor` (~28, all in a lookup table) and `DxScheduler` (~25). `DxScheduler` is entangled with the date-formatting track — hardcoded weekday abbreviations — and should be done together with it rather than twice.

## Verification

`BlazorDX.Components` can't be built locally (SDK Roslyn 5.3.0.0 vs the repo's pinned 5.9.0 → CS9057), so CI is the gate. Before pushing, simulated against the tree: 6 localized components discovered, **91 call sites checked, 0 inconsistencies**, and **0 remaining DX1003-visible literals** in the four retrofitted files.

Watch specifically: DX1003 must report zero (it fired a false positive on the foundation PR's first run), and the AOT publish job, since four new `.resx` files join the satellite-assembly path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
