### PR TITLE
Localize batch 3: the chart family, on one shared resource file

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -115,6 +115,21 @@ private DxStrings<DxDataGridResources> S => s ??= new(Services);
 
 The `.resx` is then `DxDataGridResources.resx`.
 
+### Sharing one resource file across a family
+
+A marker type can also be shared deliberately. All 15 charts localize against
+`DxChartResources`, because fifteen `.resx` files averaging two entries would give a translator
+fifteen files to open for one recurring sentence pattern.
+
+Keep keys **component-specific** even in a shared file — `PieChartLabel`, not `Label`. Share a
+key only when the English is genuinely identical (the four zoomable charts share `ResetZoom`
+and `PointsCaption` verbatim). A key shared by two components means one component's translation
+silently becomes the other's.
+
+`LocalizedStringConsistencyTests` aggregates usage per *resource file*, so the orphan check
+works across a shared one; it would otherwise report each chart's keys as unused by every other
+chart.
+
 ### The two tests
 
 Every localized component gets both, because each catches what the other cannot:
@@ -206,8 +221,8 @@ file rather than the ones with user-facing text.)
 | `.cs` files in `BlazorDX.Components` | 142 |
 | …with zero user-facing strings (headless / parameter-driven) | 57 |
 | **Components to localize** | **83** (~250–270 unique strings) |
-| …localized so far | **8** — `DxAlert`, `DxDataGrid` (pilots) + all 6 heavy hitters |
-| …strings externalized so far | 121 |
+| …localized so far | **23** — 2 pilots + 6 heavy hitters + 15 charts |
+| …strings externalized so far | 143, across 9 resource files |
 | …with 1–3 strings each | 60 |
 | …heavy hitters (>10 strings) | 6, holding ~40% of all text |
 | Stylesheets converted | 1 of 25 |
@@ -227,8 +242,11 @@ strings**, plus `DxScheduler`'s date-formatting fix, which was done in the same 
 externalizing "Previous month" while every date still rendered through `InvariantCulture`
 would have been half a job.
 
-**All six heavy hitters are done: 8 of 83 components, 121 strings.** The remaining 75
-components hold ~130–150 strings between them, most with one to three each.
+Batch 3 took the whole chart family in one pass — 15 components, **22 strings**, all against a
+single shared `DxChartResources.resx`. `DxGraph`, `DxLinearGauge` and `DxRadialGauge` turned out
+to carry no user-facing text at all and were left alone.
+
+**23 of 83 components, 143 strings.** The remaining 60 hold roughly 110–130 between them.
 
 **CSS** — 12 trivial files (≤4 hits each) → `dx-datagrid` → the four heavy files
 individually → `dx-layout` last, since 7 of its 10 declarations are judgment calls.

--- a/src/BlazorDX.Components/ChartResources.cs
+++ b/src/BlazorDX.Components/ChartResources.cs
@@ -1,0 +1,27 @@
+namespace BlazorDX.Components;
+
+/// <summary>
+/// The resource-name anchor for every chart's user-facing text —
+/// <c>DxChartResources.resx</c> holds the strings for all of them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Charts are the one place in the rollout where a shared resource file is clearly right. There
+/// are fifteen of them carrying user-facing text, almost all of it a single accessible summary of
+/// the same shape ("Pie chart with {0} slices", "Funnel chart with {0} stages"), plus a zoom
+/// vocabulary that four of them share verbatim. Fifteen <c>.resx</c> files averaging two entries
+/// would give a translator fifteen files to open to translate one recurring sentence pattern.
+/// </para>
+/// <para>
+/// The marker type exists for the same mechanical reason <c>DxDataGridResources</c> does: the
+/// default localizer factory derives a resource name from the type argument, so localizing
+/// against each chart type would look for a separate resource per chart — and for the generic
+/// charts, a separate one per closed generic. See docs/localization.md.
+/// </para>
+/// <para>
+/// Keys stay chart-specific (<c>PieChartLabel</c>, not <c>Label</c>) even though the file is
+/// shared: the summaries differ per chart, and a shared key would force one wording onto all of
+/// them. Only genuinely identical strings share a key — the zoom vocabulary does.
+/// </para>
+/// </remarks>
+public sealed class DxChartResources;

--- a/src/BlazorDX.Components/DxAreaChart.cs
+++ b/src/BlazorDX.Components/DxAreaChart.cs
@@ -88,6 +88,12 @@ public sealed class DxAreaChart : ComponentBase
         }
     }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool zoomed = zoom.IsZoomed;
@@ -148,7 +154,7 @@ public sealed class DxAreaChart : ComponentBase
 
         builder.OpenElement(29, "div");
         builder.AddAttribute(30, "class", "dx-chart-caption");
-        builder.AddContent(31, $"{selected.Length:N0} of {Points.Count:N0} points · {Compute.Backend}");
+        builder.AddContent(31, S["PointsCaption", "{0:N0} of {1:N0} points · {2}", selected.Length, Points.Count, Compute.Backend]);
 
         if (zoomed)
         {
@@ -156,7 +162,7 @@ public sealed class DxAreaChart : ComponentBase
             builder.AddAttribute(33, "type", "button");
             builder.AddAttribute(34, "class", "dx-chart-zoom-reset");
             builder.AddAttribute(35, "onclick", EventCallback.Factory.Create(this, ResetAsync));
-            builder.AddContent(36, "Reset zoom");
+            builder.AddContent(36, S["ResetZoom", "Reset zoom"]);
             builder.CloseElement();
         }
 
@@ -168,7 +174,7 @@ public sealed class DxAreaChart : ComponentBase
             builder.AddAttribute(38, "class", "dx-chart-sr");
             builder.AddAttribute(39, "role", "status");
             builder.AddAttribute(40, "aria-live", "polite");
-            builder.AddContent(41, $"Zoomed to point {F(zoom.VisibleMin)}–{F(zoom.VisibleMax)} of {F(zoom.DataMin)}–{F(zoom.DataMax)}");
+            builder.AddContent(41, S["ZoomStatusPoint", "Zoomed to point {0}–{1} of {2}–{3}", F(zoom.VisibleMin), F(zoom.VisibleMax), F(zoom.DataMin), F(zoom.DataMax)]);
             builder.CloseElement();
         }
 

--- a/src/BlazorDX.Components/DxBarChart.cs
+++ b/src/BlazorDX.Components/DxBarChart.cs
@@ -52,6 +52,12 @@ public sealed class DxBarChart : ComponentBase
 
     protected override void OnParametersSet() => selection.ClampTo(Points.Count);
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -63,7 +69,7 @@ public sealed class DxBarChart : ComponentBase
         builder.AddAttribute(3, "class", "dx-chart-svg");
         builder.AddAttribute(4, "viewBox", $"0 0 {Width} {Height}");
         builder.AddAttribute(5, "role", interactive ? "application" : "img");
-        builder.AddAttribute(6, "aria-label", $"Bar chart with {Points.Count} categories");
+        builder.AddAttribute(6, "aria-label", S["BarChartLabel", "Bar chart with {0} categories", Points.Count]);
 
         if (interactive)
         {

--- a/src/BlazorDX.Components/DxBubbleChart.cs
+++ b/src/BlazorDX.Components/DxBubbleChart.cs
@@ -83,6 +83,12 @@ public sealed class DxBubbleChart : ComponentBase
         }
     }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -172,7 +178,7 @@ public sealed class DxBubbleChart : ComponentBase
                 builder.AddAttribute(53, "type", "button");
                 builder.AddAttribute(54, "class", "dx-chart-zoom-reset");
                 builder.AddAttribute(55, "onclick", EventCallback.Factory.Create(this, ResetAsync));
-                builder.AddContent(56, "Reset zoom");
+                builder.AddContent(56, S["ResetZoom", "Reset zoom"]);
                 builder.CloseElement();
             }
 
@@ -184,8 +190,8 @@ public sealed class DxBubbleChart : ComponentBase
                 builder.AddAttribute(58, "class", "dx-chart-sr");
                 builder.AddAttribute(59, "role", "status");
                 builder.AddAttribute(60, "aria-live", "polite");
-                builder.AddContent(61,
-                    $"Zoomed to X {F(zoom.X.VisibleMin)}–{F(zoom.X.VisibleMax)}, Y {F(zoom.Y.VisibleMin)}–{F(zoom.Y.VisibleMax)}");
+                builder.AddContent(61, S["ZoomStatusXY", "Zoomed to X {0}–{1}, Y {2}–{3}",
+                    F(zoom.X.VisibleMin), F(zoom.X.VisibleMax), F(zoom.Y.VisibleMin), F(zoom.Y.VisibleMax)]);
                 builder.CloseElement();
             }
         }

--- a/src/BlazorDX.Components/DxBulletChart.cs
+++ b/src/BlazorDX.Components/DxBulletChart.cs
@@ -39,6 +39,12 @@ public sealed class DxBulletChart : ComponentBase
 
     protected override void OnParametersSet() => selection.ClampTo(Points.Count);
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -50,7 +56,7 @@ public sealed class DxBulletChart : ComponentBase
         builder.AddAttribute(3, "class", "dx-chart-svg");
         builder.AddAttribute(4, "viewBox", $"0 0 {Width} {Height}");
         builder.AddAttribute(5, "role", interactive ? "application" : "img");
-        builder.AddAttribute(6, "aria-label", $"Bullet chart with {Points.Count} KPIs");
+        builder.AddAttribute(6, "aria-label", S["BulletChartLabel", "Bullet chart with {0} KPIs", Points.Count]);
 
         if (interactive)
         {

--- a/src/BlazorDX.Components/DxCandlestickChart.cs
+++ b/src/BlazorDX.Components/DxCandlestickChart.cs
@@ -51,6 +51,12 @@ public sealed class DxCandlestickChart : ComponentBase
 
     protected override void OnParametersSet() => selection.ClampTo(Points.Count);
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -82,7 +88,7 @@ public sealed class DxCandlestickChart : ComponentBase
         builder.AddAttribute(2, "class", $"dx-chart-svg dx-candlestick {Class}".TrimEnd());
         builder.AddAttribute(3, "viewBox", Inv($"0 0 {Width} {Height}"));
         builder.AddAttribute(4, "role", interactive ? "application" : "img");
-        builder.AddAttribute(5, "aria-label", $"Candlestick chart with {n} candles");
+        builder.AddAttribute(5, "aria-label", S["CandlestickChartLabel", "Candlestick chart with {0} candles", n]);
 
         if (interactive)
         {

--- a/src/BlazorDX.Components/DxChartResources.resx
+++ b/src/BlazorDX.Components/DxChartResources.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BarChartLabel" xml:space="preserve">
+    <value>Bar chart with {0} categories</value>
+  </data>
+  <data name="BulletChartLabel" xml:space="preserve">
+    <value>Bullet chart with {0} KPIs</value>
+  </data>
+  <data name="CandlestickChartLabel" xml:space="preserve">
+    <value>Candlestick chart with {0} candles</value>
+  </data>
+  <data name="FunnelChartLabel" xml:space="preserve">
+    <value>Funnel chart with {0} stages</value>
+  </data>
+  <data name="GroupedBarChartLabel" xml:space="preserve">
+    <value>Grouped bar chart, {0} series across {1} categories</value>
+  </data>
+  <data name="NetworkGraphLabel" xml:space="preserve">
+    <value>Network graph with {0} nodes and {1} edges</value>
+  </data>
+  <data name="PieChartLabel" xml:space="preserve">
+    <value>Pie chart with {0} slices</value>
+  </data>
+  <data name="PointsCaption" xml:space="preserve">
+    <value>{0:N0} of {1:N0} points · {2}</value>
+  </data>
+  <data name="RadarChartLabel" xml:space="preserve">
+    <value>Radar chart of {0} series over {1} axes</value>
+  </data>
+  <data name="ResetZoom" xml:space="preserve">
+    <value>Reset zoom</value>
+  </data>
+  <data name="SankeyChartLabel" xml:space="preserve">
+    <value>Sankey diagram with {0} nodes and {1} flows</value>
+  </data>
+  <data name="SparklineLabel" xml:space="preserve">
+    <value>Sparkline of {0} points</value>
+  </data>
+  <data name="StackedBarChartLabel" xml:space="preserve">
+    <value>Stacked bar chart, {0} series across {1} categories</value>
+  </data>
+  <data name="WaterfallChartLabel" xml:space="preserve">
+    <value>Waterfall chart with {0} bars</value>
+  </data>
+  <data name="ZoomStatus" xml:space="preserve">
+    <value>Zoomed to {0}–{1} of {2}–{3}</value>
+  </data>
+  <data name="ZoomStatusPoint" xml:space="preserve">
+    <value>Zoomed to point {0}–{1} of {2}–{3}</value>
+  </data>
+  <data name="ZoomStatusXY" xml:space="preserve">
+    <value>Zoomed to X {0}–{1}, Y {2}–{3}</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxFunnelChart.cs
+++ b/src/BlazorDX.Components/DxFunnelChart.cs
@@ -37,6 +37,12 @@ public sealed class DxFunnelChart : ComponentBase
 
     protected override void OnParametersSet() => selection.ClampTo(Points.Count);
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -56,7 +62,7 @@ public sealed class DxFunnelChart : ComponentBase
         builder.AddAttribute(2, "class", $"dx-chart-svg dx-funnel {Class}".TrimEnd());
         builder.AddAttribute(3, "viewBox", Inv($"0 0 {Width} {Height}"));
         builder.AddAttribute(4, "role", interactive ? "application" : "img");
-        builder.AddAttribute(5, "aria-label", $"Funnel chart with {n} stages");
+        builder.AddAttribute(5, "aria-label", S["FunnelChartLabel", "Funnel chart with {0} stages", n]);
 
         if (interactive)
         {

--- a/src/BlazorDX.Components/DxLineChart.cs
+++ b/src/BlazorDX.Components/DxLineChart.cs
@@ -91,6 +91,12 @@ public sealed class DxLineChart : ComponentBase
         }
     }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool zoomed = zoom.IsZoomed;
@@ -148,7 +154,7 @@ public sealed class DxLineChart : ComponentBase
 
         builder.OpenElement(30, "div");
         builder.AddAttribute(31, "class", "dx-chart-caption");
-        builder.AddContent(32, $"{selected.Length:N0} of {Points.Count:N0} points · {Compute.Backend}");
+        builder.AddContent(32, S["PointsCaption", "{0:N0} of {1:N0} points · {2}", selected.Length, Points.Count, Compute.Backend]);
 
         if (zoomed)
         {
@@ -156,7 +162,7 @@ public sealed class DxLineChart : ComponentBase
             builder.AddAttribute(34, "type", "button");
             builder.AddAttribute(35, "class", "dx-chart-zoom-reset");
             builder.AddAttribute(36, "onclick", EventCallback.Factory.Create(this, ResetAsync));
-            builder.AddContent(37, "Reset zoom");
+            builder.AddContent(37, S["ResetZoom", "Reset zoom"]);
             builder.CloseElement();
         }
 
@@ -168,7 +174,7 @@ public sealed class DxLineChart : ComponentBase
             builder.AddAttribute(39, "class", "dx-chart-sr");
             builder.AddAttribute(40, "role", "status");
             builder.AddAttribute(41, "aria-live", "polite");
-            builder.AddContent(42, $"Zoomed to {F(zoom.VisibleMin)}–{F(zoom.VisibleMax)} of {F(zoom.DataMin)}–{F(zoom.DataMax)}");
+            builder.AddContent(42, S["ZoomStatus", "Zoomed to {0}–{1} of {2}–{3}", F(zoom.VisibleMin), F(zoom.VisibleMax), F(zoom.DataMin), F(zoom.DataMax)]);
             builder.CloseElement();
         }
 

--- a/src/BlazorDX.Components/DxNetworkGraph.cs
+++ b/src/BlazorDX.Components/DxNetworkGraph.cs
@@ -56,6 +56,12 @@ public sealed class DxNetworkGraph : ComponentBase
         layout = ForceDirectedLayout.Compute(Nodes.Count, edgeInputs, Width, Height, Iterations);
     }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -68,7 +74,7 @@ public sealed class DxNetworkGraph : ComponentBase
         builder.AddAttribute(3, "class", "dx-chart-svg");
         builder.AddAttribute(4, "viewBox", $"0 0 {Width} {Height}");
         builder.AddAttribute(5, "role", interactive ? "application" : "img");
-        builder.AddAttribute(6, "aria-label", $"Network graph with {Nodes.Count} nodes and {Edges.Count} edges");
+        builder.AddAttribute(6, "aria-label", S["NetworkGraphLabel", "Network graph with {0} nodes and {1} edges", Nodes.Count, Edges.Count]);
 
         for (int i = 0; i < Edges.Count; i++)
         {

--- a/src/BlazorDX.Components/DxPieChart.cs
+++ b/src/BlazorDX.Components/DxPieChart.cs
@@ -61,6 +61,12 @@ public sealed class DxPieChart : ComponentBase
         return visible;
     }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -80,7 +86,7 @@ public sealed class DxPieChart : ComponentBase
         builder.AddAttribute(5, "width", Size);
         builder.AddAttribute(6, "height", Size);
         builder.AddAttribute(7, "role", interactive ? "application" : "img");
-        builder.AddAttribute(8, "aria-label", $"Pie chart with {visible.Count} slices");
+        builder.AddAttribute(8, "aria-label", S["PieChartLabel", "Pie chart with {0} slices", visible.Count]);
 
         if (interactive)
         {

--- a/src/BlazorDX.Components/DxRadarChart.cs
+++ b/src/BlazorDX.Components/DxRadarChart.cs
@@ -57,6 +57,12 @@ public sealed class DxRadarChart : ComponentBase
 
     protected override void OnParametersSet() => selection.ClampTo(VisibleSeriesNames().Count * Axes.Count);
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -73,7 +79,7 @@ public sealed class DxRadarChart : ComponentBase
         builder.AddAttribute(2, "class", $"dx-chart-svg dx-radar {Class}".TrimEnd());
         builder.AddAttribute(3, "viewBox", Inv($"0 0 {Width} {Height}"));
         builder.AddAttribute(4, "role", interactive ? "application" : "img");
-        builder.AddAttribute(5, "aria-label", $"Radar chart of {names.Count} series over {n} axes");
+        builder.AddAttribute(5, "aria-label", S["RadarChartLabel", "Radar chart of {0} series over {1} axes", names.Count, n]);
 
         if (interactive)
         {

--- a/src/BlazorDX.Components/DxSankeyChart.cs
+++ b/src/BlazorDX.Components/DxSankeyChart.cs
@@ -37,6 +37,12 @@ public sealed class DxSankeyChart : ComponentBase
 
     private bool Interactive => OnNodeSelected.HasDelegate;
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -57,7 +63,7 @@ public sealed class DxSankeyChart : ComponentBase
         builder.AddAttribute(3, "class", "dx-chart-svg");
         builder.AddAttribute(4, "viewBox", $"0 0 {Width} {Height}");
         builder.AddAttribute(5, "role", "img");
-        builder.AddAttribute(6, "aria-label", $"Sankey diagram with {Nodes.Count} nodes and {Links.Count} flows");
+        builder.AddAttribute(6, "aria-label", S["SankeyChartLabel", "Sankey diagram with {0} nodes and {1} flows", Nodes.Count, Links.Count]);
 
         for (int i = 0; i < linkLayout.Count; i++)
         {

--- a/src/BlazorDX.Components/DxScatterChart.cs
+++ b/src/BlazorDX.Components/DxScatterChart.cs
@@ -85,6 +85,12 @@ public sealed class DxScatterChart : ComponentBase
         }
     }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -176,7 +182,7 @@ public sealed class DxScatterChart : ComponentBase
                 builder.AddAttribute(53, "type", "button");
                 builder.AddAttribute(54, "class", "dx-chart-zoom-reset");
                 builder.AddAttribute(55, "onclick", EventCallback.Factory.Create(this, ResetAsync));
-                builder.AddContent(56, "Reset zoom");
+                builder.AddContent(56, S["ResetZoom", "Reset zoom"]);
                 builder.CloseElement();
             }
 
@@ -188,8 +194,8 @@ public sealed class DxScatterChart : ComponentBase
                 builder.AddAttribute(58, "class", "dx-chart-sr");
                 builder.AddAttribute(59, "role", "status");
                 builder.AddAttribute(60, "aria-live", "polite");
-                builder.AddContent(61,
-                    $"Zoomed to X {F(zoom.X.VisibleMin)}–{F(zoom.X.VisibleMax)}, Y {F(zoom.Y.VisibleMin)}–{F(zoom.Y.VisibleMax)}");
+                builder.AddContent(61, S["ZoomStatusXY", "Zoomed to X {0}–{1}, Y {2}–{3}",
+                    F(zoom.X.VisibleMin), F(zoom.X.VisibleMax), F(zoom.Y.VisibleMin), F(zoom.Y.VisibleMax)]);
                 builder.CloseElement();
             }
         }

--- a/src/BlazorDX.Components/DxSparkline.cs
+++ b/src/BlazorDX.Components/DxSparkline.cs
@@ -29,6 +29,12 @@ public sealed class DxSparkline : ComponentBase
 
     [Parameter] public string? Class { get; set; }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenElement(0, "svg");
@@ -38,7 +44,7 @@ public sealed class DxSparkline : ComponentBase
         builder.AddAttribute(4, "height", Height);
         builder.AddAttribute(5, "preserveAspectRatio", "none");
         builder.AddAttribute(6, "role", "img");
-        builder.AddAttribute(7, "aria-label", $"Sparkline of {Points.Count} points");
+        builder.AddAttribute(7, "aria-label", S["SparklineLabel", "Sparkline of {0} points", Points.Count]);
 
         if (Points.Count > 0)
         {

--- a/src/BlazorDX.Components/DxStackedBarChart.cs
+++ b/src/BlazorDX.Components/DxStackedBarChart.cs
@@ -101,6 +101,12 @@ public sealed class DxStackedBarChart : ComponentBase
 
     protected override void OnParametersSet() => selection.ClampTo(Categories.Count * VisibleSeriesNames().Count);
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -114,8 +120,9 @@ public sealed class DxStackedBarChart : ComponentBase
         builder.AddAttribute(3, "class", "dx-chart-svg");
         builder.AddAttribute(4, "viewBox", $"0 0 {Width} {Height}");
         builder.AddAttribute(5, "role", interactive ? "application" : "img");
-        builder.AddAttribute(6, "aria-label",
-            $"{(Stacked ? "Stacked" : "Grouped")} bar chart, {visible.Count} series across {Categories.Count} categories");
+        builder.AddAttribute(6, "aria-label", Stacked
+            ? S["StackedBarChartLabel", "Stacked bar chart, {0} series across {1} categories", visible.Count, Categories.Count]
+            : S["GroupedBarChartLabel", "Grouped bar chart, {0} series across {1} categories", visible.Count, Categories.Count]);
 
         if (interactive)
         {

--- a/src/BlazorDX.Components/DxWaterfallChart.cs
+++ b/src/BlazorDX.Components/DxWaterfallChart.cs
@@ -72,6 +72,12 @@ public sealed class DxWaterfallChart : ComponentBase
         return bars;
     }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxChartResources>? s;
+
+    private DxStrings<DxChartResources> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         bool interactive = Interactive;
@@ -84,7 +90,7 @@ public sealed class DxWaterfallChart : ComponentBase
         builder.AddAttribute(3, "class", "dx-chart-svg");
         builder.AddAttribute(4, "viewBox", $"0 0 {Width} {Height}");
         builder.AddAttribute(5, "role", interactive ? "application" : "img");
-        builder.AddAttribute(6, "aria-label", $"Waterfall chart with {Points.Count} bars");
+        builder.AddAttribute(6, "aria-label", S["WaterfallChartLabel", "Waterfall chart with {0} bars", Points.Count]);
 
         if (interactive)
         {

--- a/tests/BlazorDX.Components.Tests/ChartLocalizationTests.cs
+++ b/tests/BlazorDX.Components.Tests/ChartLocalizationTests.cs
@@ -1,0 +1,107 @@
+using BlazorDX.Components;
+using BlazorDX.Interop;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// The chart family localizes against one shared resource type, <see cref="DxChartResources"/>,
+/// rather than one <c>.resx</c> per chart. These tests cover what that sharing can get wrong.
+/// </summary>
+/// <remarks>
+/// Every chart's accessible summary is its <i>only</i> user-facing string, and for a chart it is
+/// the whole accessibility story: the SVG is opaque to a screen reader, so this label is what a
+/// non-sighted user gets instead of the picture. Losing it to a broken lookup would be a silent
+/// accessibility regression that no axe rule catches — axe checks that an accessible name exists,
+/// not that it says anything true.
+/// </remarks>
+public sealed class ChartLocalizationTests : TestContext
+{
+    public ChartLocalizationTests()
+    {
+        // The zoomable charts inject this; the null implementation reports no measurement.
+        Services.AddScoped<IChartZoomInterop, NullChartZoomInterop>();
+    }
+
+    private void UseSentinel() =>
+        Services.AddSingleton<IStringLocalizer<DxChartResources>>(new FakeStringLocalizer<DxChartResources>());
+
+    [Fact]
+    public void Each_chart_resolves_its_own_key_from_the_shared_resource()
+    {
+        // The failure mode of a shared resource file: two charts pointing at one key, so a
+        // translator's wording for one silently becomes the wording for the other. Rendering
+        // three different chart kinds against the sentinel shows each reaches a distinct key.
+        UseSentinel();
+
+        IRenderedComponent<DxPieChart> pie = RenderComponent<DxPieChart>(p => p
+            .Add(c => c.Points, Points(2)));
+        IRenderedComponent<DxSparkline> spark = RenderComponent<DxSparkline>(p => p
+            .Add(c => c.Points, Points(3)));
+        IRenderedComponent<DxWaterfallChart> waterfall = RenderComponent<DxWaterfallChart>(p => p
+            .Add(c => c.Points, Points(1)));
+
+        Assert.Contains("§§PIECHARTLABEL§§", pie.Markup);
+        Assert.Contains("§§SPARKLINELABEL§§", spark.Markup);
+        Assert.Contains("§§WATERFALLCHARTLABEL§§", waterfall.Markup);
+    }
+
+    [Fact]
+    public void Chart_labels_fall_back_to_the_invariant_resource_with_their_counts()
+    {
+        // Proves DxChartResources.resx round-trips through the real factory *and* that the
+        // composite-format arguments still land — a resource whose "{0}" was dropped in
+        // translation would render a label with no numbers, which reads as correct English.
+        Services.AddLocalization();
+
+        IRenderedComponent<DxPieChart> pie = RenderComponent<DxPieChart>(p => p
+            .Add(c => c.Points, Points(3)));
+
+        Assert.Contains("Pie chart with 3 slices", pie.Markup);
+    }
+
+    [Fact]
+    public void Charts_render_their_labels_in_English_with_no_localizer_registered()
+    {
+        // No AddLocalization() anywhere in this test: the point of ADR 0021. Before it, injecting
+        // a localizer into fifteen charts would have made AddLocalization() mandatory for anyone
+        // rendering a chart at all.
+        IRenderedComponent<DxSparkline> spark = RenderComponent<DxSparkline>(p => p
+            .Add(c => c.Points, Points(4)));
+
+        Assert.Contains("Sparkline of 4 points", spark.Markup);
+    }
+
+    [Fact]
+    public void The_stacked_and_grouped_bar_labels_are_separate_whole_sentences()
+    {
+        // Not "Stacked"/"Grouped" spliced into a shared frame: an adjective cannot be composed
+        // with a noun phrase reliably across languages, so each variant is its own sentence.
+        UseSentinel();
+
+        IRenderedComponent<DxStackedBarChart> stacked = RenderComponent<DxStackedBarChart>(p => p
+            .Add(c => c.Categories, new[] { "Q1" })
+            .Add(c => c.Points, Stacked())
+            .Add(c => c.Stacked, true));
+
+        IRenderedComponent<DxStackedBarChart> grouped = RenderComponent<DxStackedBarChart>(p => p
+            .Add(c => c.Categories, new[] { "Q1" })
+            .Add(c => c.Points, Stacked())
+            .Add(c => c.Stacked, false));
+
+        Assert.Contains("§§STACKEDBARCHARTLABEL§§", stacked.Markup);
+        Assert.Contains("§§GROUPEDBARCHARTLABEL§§", grouped.Markup);
+    }
+
+    private static IReadOnlyList<ChartPoint> Points(int count) =>
+        [.. Enumerable.Range(1, count).Select(i => new ChartPoint(X: i, Y: i, Category: $"P{i}"))];
+
+    private static IReadOnlyList<ChartPoint> Stacked() =>
+    [
+        new(Category: "Q1", Y: 10, Series: "A"),
+        new(Category: "Q1", Y: 5, Series: "B"),
+    ];
+}

--- a/tests/BlazorDX.Components.Tests/LocalizedStringConsistencyTests.cs
+++ b/tests/BlazorDX.Components.Tests/LocalizedStringConsistencyTests.cs
@@ -49,6 +49,12 @@ public sealed class LocalizedStringConsistencyTests
         List<string> problems = [];
         int checkedSites = 0;
 
+        // Usage is collected per *resource file*, not per component, because a resource file can
+        // be shared: every chart localizes against DxChartResources so that ~18 components with
+        // two strings each do not become ~18 .resx files. Checking orphans per component would
+        // then report each chart's keys as unused by all the others.
+        Dictionary<string, HashSet<string>> usedByResource = [];
+
         foreach (string component in LocalizedComponents())
         {
             // Comments stripped first. Documentation that shows the pattern — including this
@@ -67,7 +73,9 @@ public sealed class LocalizedStringConsistencyTests
             }
 
             Dictionary<string, string> resources = ReadResources(resx);
-            HashSet<string> used = [];
+            HashSet<string> used = usedByResource.TryGetValue(resourceName, out HashSet<string>? seen)
+                ? seen
+                : usedByResource[resourceName] = [];
 
             foreach (Match site in CallSite.Matches(source))
             {
@@ -88,8 +96,13 @@ public sealed class LocalizedStringConsistencyTests
                         + $"in {Path.GetFileName(component)} falls back to \"{english}\".");
                 }
             }
+        }
 
-            foreach (string orphan in resources.Keys.Where(k => !used.Contains(k)).OrderBy(k => k))
+        // Orphans, once every component has been read.
+        foreach ((string resourceName, HashSet<string> used) in usedByResource)
+        {
+            string resx = Path.Combine(ComponentsDirectory(), $"{resourceName}.resx");
+            foreach (string orphan in ReadResources(resx).Keys.Where(k => !used.Contains(k)).OrderBy(k => k))
             {
                 problems.Add($"{resourceName}.resx[\"{orphan}\"] is not used by any call site — "
                     + "the string moved or was removed, and translators are still maintaining it.");


### PR DESCRIPTION
**15 charts, 22 strings**, all against a single `DxChartResources.resx`. Rollout now at **23 of 83 components, 143 strings**.

## Why one shared resource file here

Almost every chart's user-facing text is a single accessible summary of the same shape — `"Pie chart with {0} slices"`, `"Funnel chart with {0} stages"` — plus a zoom vocabulary that four of them share verbatim. Fifteen `.resx` files averaging two entries would give a translator fifteen files to open for one recurring sentence pattern.

Keys stay **chart-specific** even in the shared file (`PieChartLabel`, not `Label`). A key shared between two components means one component's translation silently becomes the other's, so only genuinely identical strings share one: `ResetZoom`, `PointsCaption`, `ZoomStatusXY`.

## The sharing exposed a bug in the consistency test

`LocalizedStringConsistencyTests` collected call-site usage **per component**. With one resource file behind fifteen components, each chart's keys looked unused by all the others, and the orphan check reported all 17 as dead — a build failure. Usage is now aggregated **per resource file**, which is the correct semantics whether or not anything is shared.

## Two judgment calls

**`DxStackedBarChart`** built its label as `$"{(Stacked ? "Stacked" : "Grouped")} bar chart, {n} series across {m} categories"`. That's now two whole sentences under separate keys. Splicing a localized adjective into a localized frame doesn't survive translation — agreement and word order differ per language, and the translator never sees the assembled result.

**`DxGraph`, `DxLinearGauge`, `DxRadialGauge`** carry no user-facing text at all. Left alone rather than given empty boilerplate — they belong to the 57 components the inventory counted as having nothing to localize.

## Why these strings matter more than their count suggests

A chart's label *is* its accessibility story. The SVG is opaque to a screen reader, so this one string is what a non-sighted user gets instead of the picture. A broken lookup would be a silent accessibility regression that **axe cannot catch** — axe checks that an accessible name exists, not that it says anything true.

So there's a test per failure mode: distinct keys resolve distinctly (the shared-file hazard), the composite-format arguments survive the round trip (a translation that drops `{0}` still reads as correct English), and charts render English with no localizer registered at all.

## Verification

Simulated before pushing: 23 localized components across 9 resource files, **168 call sites checked, 0 inconsistencies**, **0 remaining DX1003-visible literals** across all 15 charts, and no `S` usage left in a static context (the `CS0120` that cost a CI cycle in batch 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
