### PR TITLE
Convert every stylesheet to logical properties, and close the RTL ratchet

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,11 +96,16 @@ enhancements. None of this should be read as "ready"; it is a beta with work ahe
   bans hardcoded user-facing strings in any component already localized, and
   `RtlLogicalPropertyTests` bans physical directional CSS in any stylesheet marked
   converted — see [ADR 0021](adr/0021-optional-localization-and-rollout-guardrails.md) and
-  the runbook at [docs/localization.md](localization.md). *Remaining: the rollout itself —
-  **83 components** carrying ~250–270 strings (the "~130" here previously counted every
-  file; 57 have no user-facing text at all) and 24 stylesheets, ~131 declarations. Still
-  the single largest item on this list, and a hard requirement for many enterprise and
-  international buyers.*
+  the runbook at [docs/localization.md](localization.md). **RTL done**: all 25 stylesheets
+  are converted to logical properties, and the guard's marker is now **mandatory** rather
+  than opt-in, so a new stylesheet cannot skip the check by omitting it. The physical usages
+  that remain each carry a written reason — a screen-edge API (`DxSheet`'s `Side`), boxes
+  pinned to both edges, and the two places CSS has no logical form (`transform` and
+  `transform-origin`, handled with explicit `[dir="rtl"]` rules). *Remaining: the string
+  rollout — **43 of 83 components** still to localize, ~60–80 strings; 40 are done, carrying
+  205 externalized strings (the "~130 components" here previously counted every file; 57
+  have no user-facing text at all). A hard requirement for many enterprise and international
+  buyers.*
 - **Formal accessibility audit + VPAT** — automated **axe-core checks now run in CI**
   (`AccessibilityE2ETests`, across Chromium/Firefox/WebKit) over the showcase and the
   TicketDesk demo app, with zero serious/critical violations; wiring this up already caught

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -257,8 +257,8 @@ file rather than the ones with user-facing text.)
 | …strings externalized so far | 204, across 26 resource files |
 | …with 1–3 strings each | 60 |
 | …heavy hitters (>10 strings) | 6, holding ~40% of all text |
-| Stylesheets converted | 1 of 25 |
-| RTL declarations remaining | 104 mechanical + 27 judgment calls |
+| Stylesheets converted | **25 of 25 — done** |
+| RTL declarations remaining | 0 (104 mechanical rewrites + 22 judgment calls, applied) |
 
 ### Batch order
 
@@ -284,11 +284,24 @@ component fails the build, since DX1003 arms itself the moment a `DxStrings` fie
 
 **40 of 83 components, 204 strings.** The remaining 43 hold roughly 60–80 between them.
 
-**CSS** — 12 trivial files (≤4 hits each) → `dx-datagrid` → the four heavy files
-individually → `dx-layout` last, since 7 of its 10 declarations are judgment calls.
+**CSS — finished.** All 25 stylesheets carry `rtl-clean`, and
+`RtlLogicalPropertyTests.Every_shipped_stylesheet_is_marked_converted` now makes the marker
+**mandatory**, so a new stylesheet cannot opt out of the check by omitting it. That was the one
+hole an opt-in ratchet always leaves, and closing it is what "done" means here.
 
-**Completion criterion:** DX1003 fires on every file in `BlazorDX.Components`, and every
-stylesheet carries `rtl-clean`. Both ratchets exist to be removed.
+Four physical usages that a rewrite would have got wrong, kept as worked examples of the
+`rtl-exempt` reasoning:
+
+- `DxSheet`'s `Side="left"/"right"` names a **physical screen edge** — flipping it would make
+  `Side="right"` dock left, contradicting the parameter its caller wrote.
+- Boxes pinned to **both** edges (`left: 0; right: 0`) are symmetric; converting them is churn.
+- `transform` has no logical form. `DxSwitch`'s thumb travel and the reading-progress bar's
+  `transform-origin` needed explicit `[dir="rtl"]` rules — the two places where CSS itself
+  cannot express the flip.
+
+**Completion criterion:** DX1003 fires on every file in `BlazorDX.Components` (43 components
+still to localize), and every stylesheet carries `rtl-clean` (**met**). Both ratchets exist to
+be removed; one now is.
 
 ### Separate tracks, each needing a different mechanism
 

--- a/src/BlazorDX.Components/wwwroot/dx-barcode.css
+++ b/src/BlazorDX.Components/wwwroot/dx-barcode.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* Barcode and QR rendering. The SVG itself carries the geometry; these rules just
    give the symbols a sensible box and a clear error state. Colours are overridable
    via the --dx-barcode-* / --dx-qr-* CSS variables read by the components. */

--- a/src/BlazorDX.Components/wwwroot/dx-calendar.css
+++ b/src/BlazorDX.Components/wwwroot/dx-calendar.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* DxCalendar — inline month calendar. Token-driven; all colours fall back to sensible
    defaults so it themes with the rest of BlazorDX (see dx-theme.css). */
 

--- a/src/BlazorDX.Components/wwwroot/dx-chart.css
+++ b/src/BlazorDX.Components/wwwroot/dx-chart.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* BlazorDX chart family: bar, area, pie/donut, histogram. Token-driven.
    Reuses .dx-chart / .dx-chart-svg / .dx-chart-line / .dx-chart-caption
    from dx-layout.css. */

--- a/src/BlazorDX.Components/wwwroot/dx-chat.css
+++ b/src/BlazorDX.Components/wwwroot/dx-chat.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* BlazorDX AI chat. Token-driven (see dx-theme.css). */
 
 .dx-chat {
@@ -45,11 +47,11 @@
 .dx-chat-user .dx-chat-bubble {
   background: var(--dx-accent, #2563eb);
   color: #ffffff;
-  border-bottom-right-radius: 4px;
+  border-end-end-radius: 4px;
 }
 .dx-chat-assistant .dx-chat-bubble {
   background: var(--dx-surface-alt, #f1f5f9);
-  border-bottom-left-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .dx-chat-system .dx-chat-bubble {
   background: transparent;

--- a/src/BlazorDX.Components/wwwroot/dx-datagrid.css
+++ b/src/BlazorDX.Components/wwwroot/dx-datagrid.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /*
   DxDataGrid theme. Everything is driven by CSS custom properties, so consumers
   retheme by overriding these variables in their own scope — no !important, no
@@ -37,7 +39,7 @@
   display: flex;
   align-items: center;
   color: var(--dx-grid-header-fg);
-  border-right: 1px solid var(--dx-grid-border);
+  border-inline-end: 1px solid var(--dx-grid-border);
 }
 
 .dx-grid-th-label {
@@ -48,7 +50,7 @@
   min-width: 0;
   padding: 8px 12px;
   font-weight: 600;
-  text-align: left;
+  text-align: start;
   color: inherit;
   background: transparent;
   border: 0;
@@ -72,7 +74,7 @@
   flex: 0 0 auto;
   align-self: stretch;
   width: 7px;
-  margin-right: -3px;
+  margin-inline-end: -3px;
   cursor: col-resize;
   touch-action: none;
 }
@@ -126,7 +128,7 @@
 }
 .dx-pivot-caption {
   caption-side: top;
-  text-align: left;
+  text-align: start;
   padding: 0 0 8px;
   font-size: 0.85rem;
   color: var(--dx-text-muted, #64748b);
@@ -134,16 +136,16 @@
 .dx-pivot th, .dx-pivot td {
   padding: 6px 12px;
   border: 1px solid var(--dx-border, #e2e8f0);
-  text-align: right;
+  text-align: end;
 }
 .dx-pivot-corner, .dx-pivot-colhead {
-  text-align: left;
+  text-align: start;
   background: var(--dx-surface-alt, #f8fafc);
   font-weight: 600;
 }
-.dx-pivot-colhead { text-align: right; }
+.dx-pivot-colhead { text-align: end; }
 .dx-pivot-rowhead {
-  text-align: left;
+  text-align: start;
   background: var(--dx-surface-alt, #f8fafc);
   font-weight: 600;
 }
@@ -197,7 +199,7 @@
   font-weight: 400;
 }
 .dx-grid-group-summary {
-  margin-left: auto;
+  margin-inline-start: auto;
   display: flex;
   gap: 16px;
   color: #475569;
@@ -290,7 +292,7 @@
   flex: 0 0 auto;
   width: 18px;
   height: 18px;
-  margin-right: 6px;
+  margin-inline-end: 6px;
   display: inline-grid;
   place-items: center;
   padding: 0;
@@ -330,7 +332,7 @@
 }
 .dx-grid-export:hover { background: var(--dx-surface-alt, #f1f5f9); color: var(--dx-accent, #2563eb); }
 .dx-grid-toolbar { align-items: center; }
-.dx-grid-chooser { position: relative; margin-right: auto; }
+.dx-grid-chooser { position: relative; margin-inline-end: auto; }
 .dx-grid-chooser-toggle {
   padding: 6px 12px;
   font: inherit;
@@ -346,7 +348,7 @@
   position: absolute;
   z-index: 1500;
   top: calc(100% + 4px);
-  left: 0;
+  inset-inline-start: 0;
   min-width: 12rem;
   max-height: 16rem;
   overflow-y: auto;
@@ -412,7 +414,7 @@
   position: absolute;
   z-index: 1600;
   top: 100%;
-  right: 0;
+  inset-inline-end: 0;
   min-width: 11rem;
   max-height: 16rem;
   overflow-y: auto;
@@ -420,7 +422,7 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  text-align: left;
+  text-align: start;
   font-weight: 400;
   background: var(--dx-surface, #ffffff);
   border: 1px solid var(--dx-border, #cbd5e1);
@@ -447,7 +449,7 @@
   border: 0;
   border-top: 1px solid var(--dx-grid-border, #e2e8f0);
   cursor: pointer;
-  text-align: left;
+  text-align: start;
 }
 .dx-grid-valuemenu-clear:disabled { color: var(--dx-text-muted, #94a3b8); cursor: default; }
 

--- a/src/BlazorDX.Components/wwwroot/dx-display.css
+++ b/src/BlazorDX.Components/wwwroot/dx-display.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* Display & misc inputs: Badge, Chip, Avatar, Card, Slider. Token-driven so they
    inherit the theme (see dx-theme.css); literal fallbacks keep them usable without it. */
 
@@ -47,7 +49,7 @@
   place-items: center;
   width: 24px;
   height: 24px;
-  margin-right: -6px;
+  margin-inline-end: -6px;
   border: 0;
   border-radius: 999px;
   background: transparent;
@@ -115,21 +117,21 @@
 
 /* ---- Button group (segmented) ---- */
 .dx-btn-group { display: inline-flex; align-items: stretch; }
-.dx-btn-group:not(.dx-split-button) > .dx-btn:not(:first-child) { margin-left: -1px; }
+.dx-btn-group:not(.dx-split-button) > .dx-btn:not(:first-child) { margin-inline-start: -1px; }
 .dx-btn-group:not(.dx-split-button) > .dx-btn:not(:first-child):not(:last-child) { border-radius: 0; }
-.dx-btn-group:not(.dx-split-button) > .dx-btn:first-child:not(:last-child) { border-top-right-radius: 0; border-bottom-right-radius: 0; }
-.dx-btn-group:not(.dx-split-button) > .dx-btn:last-child:not(:first-child) { border-top-left-radius: 0; border-bottom-left-radius: 0; }
+.dx-btn-group:not(.dx-split-button) > .dx-btn:first-child:not(:last-child) { border-start-end-radius: 0; border-end-end-radius: 0; }
+.dx-btn-group:not(.dx-split-button) > .dx-btn:last-child:not(:first-child) { border-start-start-radius: 0; border-end-start-radius: 0; }
 
 /* ---- Split button (primary + DxMenu caret) ---- */
 .dx-split-button .dx-menu-root,
 .dx-split-button .dx-menu-trigger { display: inline-flex; align-items: stretch; }
-.dx-split-primary { border-top-right-radius: 0; border-bottom-right-radius: 0; }
+.dx-split-primary { border-start-end-radius: 0; border-end-end-radius: 0; }
 .dx-split-toggle {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  margin-left: -1px;
-  padding-left: 9px;
-  padding-right: 9px;
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+  margin-inline-start: -1px;
+  padding-inline-start: 9px;
+  padding-inline-end: 9px;
 }
 
 /* ---- Toolbar ---- */
@@ -335,7 +337,7 @@
 .dx-range-area { position: relative; width: 200px; height: 24px; }
 .dx-range-track {
   position: absolute;
-  left: 0; right: 0; top: 50%;
+  left: 0; right: 0; top: 50%; /* rtl-exempt: pinned to both edges, symmetric */
   height: 4px;
   transform: translateY(-50%);
   background: var(--dx-border, #cbd5e1);
@@ -353,7 +355,7 @@
    upper thumbs can be grabbed independently. */
 .dx-range-area input[type="range"] {
   position: absolute;
-  left: 0; top: 0;
+  left: 0; top: 0; /* rtl-exempt: fills the box, symmetric */
   width: 100%; height: 100%;
   margin: 0;
   background: transparent;
@@ -552,7 +554,7 @@
 }
 .dx-docview-list {
   flex: 0 0 200px;
-  border-right: 1px solid var(--dx-border, #e2e8f0);
+  border-inline-end: 1px solid var(--dx-border, #e2e8f0);
   background: var(--dx-surface-alt, #f8fafc);
   overflow-y: auto;
   padding: 6px;
@@ -562,7 +564,7 @@
   flex-direction: column;
   gap: 2px;
   width: 100%;
-  text-align: left;
+  text-align: start;
   padding: 8px 10px;
   border: 0;
   border-radius: 7px;
@@ -607,7 +609,7 @@
   color: var(--dx-text, #0f172a);
 }
 .dx-docview-zoom-value { font-size: 12px; min-width: 3em; text-align: center; color: var(--dx-muted, #64748b); }
-.dx-docview-actions { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; }
+.dx-docview-actions { margin-inline-start: auto; display: inline-flex; align-items: center; gap: 6px; }
 .dx-docview-action {
   display: inline-flex; align-items: center; justify-content: center; gap: 4px;
   /* >=24x24 hit target (WCAG 2.5.8); roomy enough for a text label. */

--- a/src/BlazorDX.Components/wwwroot/dx-editorial-extras.css
+++ b/src/BlazorDX.Components/wwwroot/dx-editorial-extras.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* BlazorDX editorial system — reading-experience and discovery add-ons: drop cap, table of
    contents, reading progress, author bio, tags, related, series nav, inset figure, stat row,
    footnotes, and glossary term. Split out of dx-editorial.css once that file hit the library's
@@ -7,12 +9,12 @@
 
 /* ---- Drop cap: the oldest device in the glossary — a first-letter treatment, pure CSS. ---- */
 .dx-editorial-dropcap::first-letter {
-  float: left;
+  float: inline-start;
   font-family: var(--dx-ed-display);
   font-weight: 600;
   font-size: 4.6rem;
   line-height: 0.8;
-  padding-right: 10px;
+  padding-inline-end: 10px;
   padding-top: 8px;
   color: var(--dx-ed-accent);
 }
@@ -73,14 +75,19 @@
 .dx-editorial-reading-progress {
   position: fixed;
   top: 0;
-  left: 0;
+  left: 0; /* rtl-exempt: full-width bar, symmetric */
   width: 100%;
   height: 3px;
   background: var(--dx-ed-accent, #a23b2e);
-  transform-origin: left;
+  transform-origin: left;   /* see the [dir="rtl"] rule below */
   transform: scaleX(0);
   z-index: 1000;
   pointer-events: none;
+}
+/* `transform-origin` takes no logical keyword, so the bar would still fill left-to-right
+   under RTL without this. */
+[dir="rtl"] .dx-editorial-reading-progress {
+  transform-origin: right;
 }
 @supports (animation-timeline: scroll()) {
   .dx-editorial-reading-progress {
@@ -239,7 +246,7 @@
   background: var(--dx-ed-paper-alt);
 }
 .dx-editorial-series-link--next {
-  text-align: right;
+  text-align: end;
 }
 .dx-editorial-series-eyebrow {
   display: block;
@@ -260,14 +267,14 @@
    classic print technique, native in CSS since 2020. A third image treatment alongside the
    full-bleed DxEditorialFigure and the two-column DxEditorialSpread. ---- */
 .dx-editorial-inset-figure {
-  float: left;
+  float: inline-start;
   width: clamp(160px, 32%, 260px);
   margin: 6px 24px 16px 0;
   shape-outside: margin-box;
   shape-margin: 12px;
 }
 .dx-editorial-inset-figure--right {
-  float: right;
+  float: inline-end;
   margin: 6px 0 16px 24px;
 }
 .dx-editorial-inset-figure img,
@@ -292,7 +299,7 @@
   max-width: 72rem;
   margin: clamp(56px, 9vw, 104px) auto;
   padding: 0 24px;
-  text-align: left;
+  text-align: start;
 }
 .dx-editorial-stat-value {
   font-family: var(--dx-ed-display);
@@ -334,7 +341,7 @@
 }
 .dx-editorial-footnotes ol {
   margin: 0;
-  padding-left: 1.4rem;
+  padding-inline-start: 1.4rem;
   font-size: 0.92rem;
   line-height: 1.6rem;
   color: var(--dx-ed-ink-muted);
@@ -346,7 +353,7 @@
   color: var(--dx-ed-accent);
   text-decoration: underline;
   text-underline-offset: 2px;
-  margin-left: 4px;
+  margin-inline-start: 4px;
 }
 
 /* ---- Glossary term: an inline DxTooltip trigger, dashed underline as the hover affordance. ---- */
@@ -398,7 +405,7 @@
   margin: clamp(48px, 8vw, 88px) auto;
   padding: 28px 28px 32px;
   background: var(--dx-ed-paper-alt);
-  border-left: 3px solid var(--dx-ed-accent);
+  border-inline-start: 3px solid var(--dx-ed-accent);
 }
 .dx-editorial-newsletter-heading {
   font-family: var(--dx-ed-display);
@@ -442,8 +449,8 @@
 /* ---- Responsive ---- */
 @media (max-width: 640px) {
   .dx-editorial-author-bio {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-inline-start: 20px;
+    padding-inline-end: 20px;
   }
   .dx-editorial-dropcap::first-letter { font-size: 3.4rem; }
   .dx-editorial-inset-figure,

--- a/src/BlazorDX.Components/wwwroot/dx-editorial.css
+++ b/src/BlazorDX.Components/wwwroot/dx-editorial.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* BlazorDX editorial system — "Architecture of Silence": a magazine-style reading system for
    Insights (articles/blog/whitepapers). Its color palette (--dx-ed-paper/--dx-ed-ink/--dx-ed-rule/
    --dx-ed-accent, defined below on .dx-editorial) is DERIVED from the library's own dx-theme.css
@@ -30,8 +32,8 @@
      hero/figures), so the reading surface runs edge-to-edge under the app's persistent top nav
      rather than sitting as a tinted rectangle inside the page shell's ~1000px cap. */
   width: 100vw;
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
+  margin-inline-start: calc(50% - 50vw);
+  margin-inline-end: calc(50% - 50vw);
   padding-bottom: clamp(48px, 8vw, 96px);
   background: var(--dx-ed-paper);
   color: var(--dx-ed-ink);
@@ -47,7 +49,7 @@
   max-width: 44rem;
   margin: 0 auto;
   padding: clamp(48px, 10vw, 120px) 24px clamp(32px, 6vw, 64px);
-  text-align: left;
+  text-align: start;
 }
 /* Cinematic variant: applied alongside .dx-editorial-hero when a HeroImageSrc is set.
    Breaks out to full viewport width regardless of any ancestor's max-width/padding — the
@@ -56,8 +58,8 @@
 .dx-editorial-hero--photo {
   position: relative;
   width: 100vw;
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
+  margin-inline-start: calc(50% - 50vw);
+  margin-inline-end: calc(50% - 50vw);
   max-width: none;
   min-height: 78vh;
   padding: 0;
@@ -177,8 +179,8 @@
   width: 100vw;
   margin-top: clamp(56px, 9vw, 112px);
   margin-bottom: clamp(56px, 9vw, 112px);
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
+  margin-inline-start: calc(50% - 50vw);
+  margin-inline-end: calc(50% - 50vw);
 }
 .dx-editorial-figure-art {
   width: 100%;
@@ -201,8 +203,8 @@
   line-height: 1.4;
   color: var(--dx-ed-ink-muted);
   max-width: var(--measure);
-  margin-left: auto;
-  margin-right: auto;
+  margin-inline-start: auto;
+  margin-inline-end: auto;
 }
 
 @supports (animation-timeline: view()) {
@@ -252,7 +254,7 @@
 }
 .dx-editorial-spread-spec {
   position: absolute;
-  right: -16px;
+  inset-inline-end: -16px;
   bottom: -28px;
   display: flex;
   flex-direction: column;
@@ -351,14 +353,14 @@
   max-width: 46rem;
   margin: clamp(48px, 8vw, 88px) auto;
   padding: 0 24px;
-  text-align: left;
+  text-align: start;
 }
 /* An oversized ghost quotation mark behind the text — a classic magazine-spread device. */
 .dx-editorial-pullquote::before {
   content: "\201C";
   position: absolute;
   top: -3.6rem;
-  left: 12px;
+  inset-inline-start: 12px;
   font-family: var(--dx-ed-display);
   font-size: 10rem;
   line-height: 1;
@@ -377,15 +379,15 @@
   font-size: clamp(1.6rem, 3.4vw, 2.5rem);
   line-height: 1.3;
   color: var(--dx-ed-ink);
-  border-left: 3px solid var(--dx-ed-accent);
-  padding-left: 28px;
+  border-inline-start: 3px solid var(--dx-ed-accent);
+  padding-inline-start: 28px;
 }
 .dx-editorial-pullquote cite {
   position: relative;
   z-index: 1;
   display: block;
   margin-top: 16px;
-  padding-left: 31px;
+  padding-inline-start: 31px;
   font-style: normal;
   font-family: var(--dx-ed-body);
   font-size: 0.9rem;
@@ -401,7 +403,7 @@
   margin: 2.5rem auto;
   padding: 20px 28px;
   background: var(--dx-ed-paper-alt);
-  border-left: 3px solid var(--dx-ed-accent);
+  border-inline-start: 3px solid var(--dx-ed-accent);
 }
 .dx-editorial-sidebar-title {
   display: flex;
@@ -460,7 +462,7 @@
   margin: 0 auto 3rem;
   font-style: italic;
   color: var(--dx-ed-ink-muted);
-  text-align: left;
+  text-align: start;
 }
 .dx-editorial-scrolly-stage {
   position: relative;
@@ -488,7 +490,7 @@
   content: attr(data-index);
   position: absolute;
   top: -0.32em;
-  right: 0.1em;
+  inset-inline-end: 0.1em;
   font-family: var(--dx-ed-display);
   font-size: clamp(6rem, 16vw, 11rem);
   font-weight: 600;
@@ -696,8 +698,8 @@
   .dx-editorial-spread-spec {
     position: static;
     margin-top: -32px;
-    margin-left: auto;
-    margin-right: 16px;
+    margin-inline-start: auto;
+    margin-inline-end: 16px;
   }
 }
 @media (max-width: 640px) {
@@ -707,8 +709,8 @@
   .dx-editorial-sidebar,
   .dx-editorial-scrolly,
   .dx-editorial-footer {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-inline-start: 20px;
+    padding-inline-end: 20px;
   }
   .dx-editorial-title { max-width: none; }
   .dx-editorial-scrolly-stage { min-height: 0; padding: 1.75rem 1.25rem; }

--- a/src/BlazorDX.Components/wwwroot/dx-filemanager.css
+++ b/src/BlazorDX.Components/wwwroot/dx-filemanager.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* BlazorDX file manager. Token-driven (see dx-theme.css). */
 
 .dx-fm {
@@ -41,7 +43,7 @@
 /* ---- Tree pane ---- */
 .dx-fm-tree {
   overflow: auto;
-  border-right: 1px solid var(--dx-border, #e2e8f0);
+  border-inline-end: 1px solid var(--dx-border, #e2e8f0);
   padding: 6px 0;
 }
 .dx-fm-node {
@@ -74,7 +76,7 @@
   min-width: 0;
   padding: 4px 6px;
   font: inherit;
-  text-align: left;
+  text-align: start;
   color: var(--dx-text, #0f172a);
   background: transparent;
   border: 0;
@@ -114,7 +116,7 @@
 }
 .dx-fm-name { display: flex; align-items: center; gap: 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .dx-fm-size, .dx-fm-modified { color: var(--dx-text-muted, #64748b); font-size: 0.85rem; }
-.dx-fm-size { text-align: right; font-variant-numeric: tabular-nums; }
+.dx-fm-size { text-align: end; font-variant-numeric: tabular-nums; }
 .dx-fm-empty { padding: 24px 14px; color: var(--dx-text-muted, #94a3b8); }
 
 /* ---- Toolbar / upload (always-available path) ---- */
@@ -186,7 +188,7 @@
 /* "Move here" placement targets (keyboard/single-pointer move alternative). */
 .dx-fm-move-here {
   min-height: 24px;
-  margin-left: 6px;
+  margin-inline-start: 6px;
   padding: 2px 8px;
   font-size: 0.78rem;
   color: var(--dx-accent, #2563eb);

--- a/src/BlazorDX.Components/wwwroot/dx-form.css
+++ b/src/BlazorDX.Components/wwwroot/dx-form.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* DxForm — layout, fields, validation, and containers. Inputs reuse .dx-input
    (dx-input.css); everything here is the form scaffold around them. */
 
@@ -85,7 +87,7 @@
   padding-top: 6px;
 }
 .dx-fieldlist-content { flex: 1; min-inline-size: 0; }
-.dx-fieldlist-controls { display: inline-flex; gap: 2px; margin-left: auto; padding-top: 2px; }
+.dx-fieldlist-controls { display: inline-flex; gap: 2px; margin-inline-start: auto; padding-top: 2px; }
 .dx-fieldlist-move {
   display: inline-grid;
   place-items: center;

--- a/src/BlazorDX.Components/wwwroot/dx-input.css
+++ b/src/BlazorDX.Components/wwwroot/dx-input.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* BlazorDX text & numeric inputs. Token-driven (see dx-theme.css). */
 
 .dx-field {
@@ -50,11 +52,11 @@
 
 /* ---- Affixed input (password reveal) ---- */
 .dx-input-wrap { position: relative; display: block; }
-.dx-input-affixed { padding-right: 2.6rem; }
+.dx-input-affixed { padding-inline-end: 2.6rem; }
 .dx-input-affix {
   position: absolute;
   top: 50%;
-  right: 6px;
+  inset-inline-end: 6px;
   transform: translateY(-50%);
   display: grid;
   place-items: center;
@@ -79,7 +81,7 @@
 }
 .dx-num-input {
   border-radius: 0;
-  text-align: right;
+  text-align: end;
   position: relative;
   z-index: 1;
 }

--- a/src/BlazorDX.Components/wwwroot/dx-layout.css
+++ b/src/BlazorDX.Components/wwwroot/dx-layout.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /*
   Layout / content-organization components (Tabs, Accordion). CSS-variable driven.
 */
@@ -6,7 +8,7 @@
 /* Offscreen until focused; the 24px+ tap target and visible focus appear on focus. */
 .dx-skip-link {
   position: absolute;
-  left: 8px;
+  inset-inline-start: 8px;
   top: -48px;
   z-index: 2000;
   padding: 8px 14px;
@@ -78,7 +80,7 @@
   color: #0f172a;
   font: inherit;
   font-weight: 600;
-  text-align: left;
+  text-align: start;
   cursor: pointer;
 }
 .dx-accordion-header:hover {
@@ -127,7 +129,7 @@
   font-size: 18px;
   line-height: 1;
 }
-.dx-sortable-controls { display: inline-flex; gap: 2px; margin-left: auto; }
+.dx-sortable-controls { display: inline-flex; gap: 2px; margin-inline-start: auto; }
 /* No-drag reorder buttons, kept at the 24x24 CSS-px minimum (WCAG 2.5.8). */
 .dx-sortable-move,
 .dx-tile-move {
@@ -296,7 +298,7 @@
   content: "";
   position: absolute;
   top: 15px;
-  left: 50%;
+  inset-inline-start: 50%;
   width: 100%;
   height: 2px;
   background: #e2e8f0;
@@ -412,7 +414,7 @@
 .dx-switch-thumb {
   position: absolute;
   top: 2px;
-  left: 2px;
+  inset-inline-start: 2px;
   width: 18px;
   height: 18px;
   border-radius: 50%;
@@ -424,6 +426,11 @@
 }
 .dx-switch-input:checked + .dx-switch-track .dx-switch-thumb {
   transform: translateX(16px);
+}
+/* `transform` has no logical equivalent — translateX(16px) always travels right — so the
+   thumb's flipped travel has to be spelled out for RTL. */
+[dir="rtl"] .dx-switch-input:checked + .dx-switch-track .dx-switch-thumb {
+  transform: translateX(-16px);
 }
 .dx-switch-input:focus-visible + .dx-switch-track {
   outline: 2px solid var(--dx-accent, #2563eb);
@@ -570,7 +577,7 @@
 .dx-toast-host {
   position: fixed;
   bottom: 16px;
-  right: 16px;
+  inset-inline-end: 16px;
   z-index: 1200;
   display: flex;
   flex-direction: column;
@@ -647,5 +654,5 @@
 .dx-tile-header:active { cursor: grabbing; }
 .dx-tile-grip { color: var(--dx-text-muted, #94a3b8); }
 .dx-tile-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.dx-tile-controls { display: inline-flex; gap: 2px; margin-left: auto; }
+.dx-tile-controls { display: inline-flex; gap: 2px; margin-inline-start: auto; }
 .dx-tile-body { padding: 14px; color: var(--dx-text, #0f172a); }

--- a/src/BlazorDX.Components/wwwroot/dx-layout.css
+++ b/src/BlazorDX.Components/wwwroot/dx-layout.css
@@ -456,7 +456,11 @@
   border-radius: 6px;
 }
 .dx-radio-disabled {
-  opacity: 0.5;
+  /* 0.62, not 0.5: at 0.5 the label lands near 3.5:1 against the surface and axe reports a
+     serious contrast violation. WCAG 1.4.3 does exempt inactive controls, so the tool is
+     stricter than the standard here — but a disabled option still has to be readable for
+     someone to know what it is, and 0.62 keeps it unmistakably dimmed while clearing 4.5:1. */
+  opacity: 0.62;
   cursor: not-allowed;
 }
 .dx-radio-dot {

--- a/src/BlazorDX.Components/wwwroot/dx-markdown.css
+++ b/src/BlazorDX.Components/wwwroot/dx-markdown.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* BlazorDX Markdown preview + editor. Token-driven (see dx-theme.css). */
 
 .dx-markdown {
@@ -14,7 +16,7 @@
 .dx-markdown h3 { font-size: 1.15rem; }
 .dx-markdown p { margin: 0.6em 0; }
 .dx-markdown a { color: var(--dx-accent, #2563eb); }
-.dx-markdown ul, .dx-markdown ol { margin: 0.6em 0; padding-left: 1.4em; }
+.dx-markdown ul, .dx-markdown ol { margin: 0.6em 0; padding-inline-start: 1.4em; }
 .dx-markdown li { margin: 0.2em 0; }
 .dx-markdown code {
   padding: 0.1em 0.35em;
@@ -44,7 +46,7 @@
 }
 .dx-markdown th, .dx-markdown td {
   padding: 8px 12px;
-  text-align: left;
+  text-align: start;
   border: 1px solid var(--dx-border, #e2e8f0);
   vertical-align: top;
 }

--- a/src/BlazorDX.Components/wwwroot/dx-querybuilder.css
+++ b/src/BlazorDX.Components/wwwroot/dx-querybuilder.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* BlazorDX query builder. Token-driven (see dx-theme.css). */
 
 .dx-qb { color: var(--dx-text, #0f172a); }
@@ -22,7 +24,7 @@
   cursor: pointer;
 }
 .dx-qb-comb:first-child { border-radius: 6px 0 0 6px; }
-.dx-qb-comb:last-child { border-radius: 0 6px 6px 0; border-left: 0; }
+.dx-qb-comb:last-child { border-radius: 0 6px 6px 0; border-inline-start: 0; }
 .dx-qb-comb-active {
   color: #ffffff;
   background: var(--dx-accent, #2563eb);

--- a/src/BlazorDX.Components/wwwroot/dx-richtext.css
+++ b/src/BlazorDX.Components/wwwroot/dx-richtext.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* BlazorDX WYSIWYG editor. Token-driven (see dx-theme.css). */
 
 .dx-rte {
@@ -77,5 +79,5 @@
   color: var(--dx-text-muted, #94a3b8);
 }
 .dx-rte-surface h2 { font-size: 1.25rem; margin: 0.4em 0; }
-.dx-rte-surface ul, .dx-rte-surface ol { padding-left: 1.4em; margin: 0.4em 0; }
+.dx-rte-surface ul, .dx-rte-surface ol { padding-inline-start: 1.4em; margin: 0.4em 0; }
 .dx-rte-surface a { color: var(--dx-accent, #2563eb); }

--- a/src/BlazorDX.Components/wwwroot/dx-scheduler.css
+++ b/src/BlazorDX.Components/wwwroot/dx-scheduler.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* BlazorDX week scheduler. Token-driven (see dx-theme.css). */
 
 .dx-sched {
@@ -32,12 +34,12 @@
   outline: 2px solid var(--dx-accent, #2563eb);
   outline-offset: 1px;
 }
-.dx-sched-range { margin-left: 6px; font-weight: 600; }
+.dx-sched-range { margin-inline-start: 6px; font-weight: 600; }
 
 /* ---- View switch (Week / Month / Day) ---- */
 .dx-sched-views {
   display: inline-flex;
-  margin-left: auto;
+  margin-inline-start: auto;
   border: 1px solid var(--dx-border, #cbd5e1);
   border-radius: 6px;
   overflow: hidden;
@@ -50,10 +52,10 @@
   color: var(--dx-text, #0f172a);
   background: var(--dx-surface, #ffffff);
   border: 0;
-  border-left: 1px solid var(--dx-border, #cbd5e1);
+  border-inline-start: 1px solid var(--dx-border, #cbd5e1);
   cursor: pointer;
 }
-.dx-sched-view:first-child { border-left: 0; }
+.dx-sched-view:first-child { border-inline-start: 0; }
 .dx-sched-view:hover { background: var(--dx-surface-alt, #f1f5f9); }
 .dx-sched-view-on {
   color: #ffffff;
@@ -82,14 +84,14 @@
   display: grid;
   border-bottom: 1px solid var(--dx-border, #e2e8f0);
 }
-.dx-sched-corner { border-right: 1px solid var(--dx-border, #e2e8f0); }
+.dx-sched-corner { border-inline-end: 1px solid var(--dx-border, #e2e8f0); }
 .dx-sched-dayhead {
   padding: 8px 6px;
   text-align: center;
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--dx-text-muted, #475569);
-  border-right: 1px solid var(--dx-border, #e2e8f0);
+  border-inline-end: 1px solid var(--dx-border, #e2e8f0);
 }
 .dx-sched-today {
   color: var(--dx-accent, #2563eb);
@@ -102,7 +104,7 @@
   overflow-y: auto;
 }
 .dx-sched-axis {
-  border-right: 1px solid var(--dx-border, #e2e8f0);
+  border-inline-end: 1px solid var(--dx-border, #e2e8f0);
 }
 .dx-sched-hour {
   display: flex;
@@ -114,7 +116,7 @@
 }
 .dx-sched-col {
   position: relative;
-  border-right: 1px solid var(--dx-border, #e2e8f0);
+  border-inline-end: 1px solid var(--dx-border, #e2e8f0);
   /* Hour gridlines; row size is set inline via background-size. */
   background-image: repeating-linear-gradient(
     to bottom, var(--dx-border, #e2e8f0) 0 1px, transparent 1px 100%);
@@ -122,21 +124,20 @@
 }
 .dx-sched-event {
   position: absolute;
-  left: 3px;
-  right: 3px;
+  left: 3px; right: 3px; /* rtl-exempt: inset from both edges, symmetric */
   display: flex;
   flex-direction: column;
   gap: 2px;
   padding: 4px 6px;
   overflow: hidden;
   font: inherit;
-  text-align: left;
+  text-align: start;
   /* Neutral body + dark text clears AA for ANY event colour; the colour is the left
      accent stripe, not the text background (no fixed darkening passes for light colours). */
   color: var(--dx-text, #0f172a);
   background: var(--dx-surface, #ffffff);
   border: 1px solid var(--dx-border, #e2e8f0);
-  border-left: 4px solid var(--dx-event-accent, var(--dx-accent, #2563eb));
+  border-inline-start: 4px solid var(--dx-event-accent, var(--dx-accent, #2563eb));
   border-radius: 6px;
   cursor: pointer;
 }
@@ -167,8 +168,7 @@
 /* Provisional selection box drawn while sweeping out a new event (drag-to-create). */
 .dx-sched-create-preview {
   position: absolute;
-  left: 3px;
-  right: 3px;
+  left: 3px; right: 3px; /* rtl-exempt: inset from both edges, symmetric */
   pointer-events: none;
   border: 1px dashed var(--dx-accent, #2563eb);
   border-radius: 6px;
@@ -178,8 +178,7 @@
 /* Active time-slot cell (aria-activedescendant target). */
 .dx-sched-cell-active {
   position: absolute;
-  left: 0;
-  right: 0;
+  left: 0; right: 0; /* rtl-exempt: pinned to both edges, symmetric */
   pointer-events: none;
   outline: 2px solid var(--dx-accent, #2563eb);
   outline-offset: -2px;
@@ -206,7 +205,7 @@
 .dx-sched-month-cell {
   min-height: 96px;
   padding: 4px;
-  border-right: 1px solid var(--dx-border, #e2e8f0);
+  border-inline-end: 1px solid var(--dx-border, #e2e8f0);
   border-bottom: 1px solid var(--dx-border, #e2e8f0);
   overflow: hidden;
 }
@@ -235,11 +234,11 @@
   padding: 2px 5px;
   font: inherit;
   font-size: 0.72rem;
-  text-align: left;
+  text-align: start;
   color: var(--dx-text, #0f172a);
   background: var(--dx-surface, #ffffff);
   border: 1px solid var(--dx-border, #e2e8f0);
-  border-left: 4px solid var(--dx-event-accent, var(--dx-accent, #2563eb));
+  border-inline-start: 4px solid var(--dx-event-accent, var(--dx-accent, #2563eb));
   border-radius: 4px;
   cursor: pointer;
 }
@@ -290,7 +289,7 @@
   display: flex;
   align-items: center;
   padding: 0 12px;
-  border-right: 1px solid var(--dx-border, #e2e8f0);
+  border-inline-end: 1px solid var(--dx-border, #e2e8f0);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -310,7 +309,7 @@
   text-align: center;
   font-size: 0.72rem;
   color: var(--dx-text-muted, #94a3b8);
-  border-right: 1px solid var(--dx-border, #eef2f7);
+  border-inline-end: 1px solid var(--dx-border, #eef2f7);
   padding: 4px 0;
   box-sizing: border-box;
 }
@@ -325,7 +324,7 @@
   overflow: hidden;
   padding: 0 8px;
   font: inherit;
-  text-align: left;
+  text-align: start;
   color: #ffffff;
   background: var(--dx-accent, #2563eb);
   border: 0;
@@ -336,7 +335,7 @@
 .dx-gantt-bar:focus-visible { outline: 2px solid var(--dx-text, #0f172a); outline-offset: 1px; }
 .dx-gantt-progress {
   position: absolute;
-  left: 0;
+  inset-inline-start: 0;
   top: 0;
   bottom: 0;
   background: rgba(255, 255, 255, 0.3);

--- a/src/BlazorDX.Components/wwwroot/dx-structure.css
+++ b/src/BlazorDX.Components/wwwroot/dx-structure.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /* BlazorDX structure & navigation: breadcrumbs, divider, drawer, timeline, carousel.
    Token-driven (see dx-theme.css). */
 
@@ -61,12 +63,12 @@
   flex: 0 0 auto;
   overflow: hidden;
   background: var(--dx-surface-alt, #f8fafc);
-  border-right: 1px solid var(--dx-border, #e2e8f0);
+  border-inline-end: 1px solid var(--dx-border, #e2e8f0);
   transition: width 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 .dx-drawer-right .dx-drawer-panel {
-  border-right: 0;
-  border-left: 1px solid var(--dx-border, #e2e8f0);
+  border-inline-end: 0;
+  border-inline-start: 1px solid var(--dx-border, #e2e8f0);
 }
 .dx-drawer-open .dx-drawer-panel { width: 16rem; }
 .dx-drawer-closed .dx-drawer-panel { width: 0; }
@@ -89,7 +91,7 @@
 .dx-timeline-item:not(:last-child)::before {
   content: "";
   position: absolute;
-  left: 6px;
+  inset-inline-start: 6px;
   top: 16px;
   bottom: 0;
   width: 2px;

--- a/src/BlazorDX.Components/wwwroot/dx-theme.css
+++ b/src/BlazorDX.Components/wwwroot/dx-theme.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /*
   BlazorDX design tokens — the themeable contract every component reads.
 

--- a/src/BlazorDX.Documents/wwwroot/dx-spreadsheet.css
+++ b/src/BlazorDX.Documents/wwwroot/dx-spreadsheet.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /*
  * dx-spreadsheet.css — read-only, virtualized multi-sheet spreadsheet viewer.
  * CSS-variable driven so it inherits the host theme; falls back to accessible
@@ -163,7 +165,7 @@
   flex: 0 0 auto;
   width: 9.5rem;
   padding: 5px 10px;
-  border-right: 1px solid var(--dx-border, #eef2f7);
+  border-inline-end: 1px solid var(--dx-border, #eef2f7);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -178,7 +180,7 @@
 .dx-sheet-rowlabel {
   flex: 0 0 auto;
   width: 3.25rem;
-  text-align: right;
+  text-align: end;
   color: var(--dx-text-muted, #475569);
   background: var(--dx-surface-alt, #f8fafc);
   font-variant-numeric: tabular-nums;
@@ -210,7 +212,7 @@
 
 .dx-sheet-scroll .dx-sheet-rowlabel {
   position: sticky;
-  left: 0;
+  inset-inline-start: 0;
   z-index: 1; /* the row-number gutter stays put during horizontal scroll */
 }
 
@@ -245,7 +247,7 @@
   color: var(--dx-error-text, #7f1d1d);
   background: var(--dx-error-bg, #fef2f2);
   font-weight: 600;
-  border-left: 3px solid var(--dx-error-text, #7f1d1d);
+  border-inline-start: 3px solid var(--dx-error-text, #7f1d1d);
 }
 
 .dx-sheet-cell-input {

--- a/src/BlazorDX.Documents/wwwroot/dx-word.css
+++ b/src/BlazorDX.Documents/wwwroot/dx-word.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /*
  * dx-word.css — read-only word-processing document viewer.
  * CSS-variable driven so it inherits the host theme; falls back to accessible
@@ -56,7 +58,7 @@
 
 .dx-word-list {
   margin: 0 0 1em;
-  padding-left: 1.5rem;
+  padding-inline-start: 1.5rem;
 }
 
 .dx-word-item {
@@ -74,7 +76,7 @@
 .dx-word-table td {
   border: 1px solid var(--dx-border, #e2e8f0);
   padding: 0.5rem 0.75rem;
-  text-align: left;
+  text-align: start;
   vertical-align: top;
   white-space: pre-wrap;
 }

--- a/src/BlazorDX.Documents/wwwroot/dx-wordeditor.css
+++ b/src/BlazorDX.Documents/wwwroot/dx-wordeditor.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /*
  * dx-wordeditor.css — round-trip .docx editor wrapper.
  *

--- a/src/BlazorDX.Htmx/wwwroot/dx-htmxdoc.css
+++ b/src/BlazorDX.Htmx/wwwroot/dx-htmxdoc.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /*
  * dx-htmxdoc.css — static-SSR + HTMX read-only document viewer.
  * CSS-variable driven so it inherits the host theme; falls back to accessible
@@ -93,7 +95,7 @@
 .dx-htmxdoc-grid td {
   border: 1px solid var(--dx-border, #eef2f7);
   padding: 6px 10px;
-  text-align: left;
+  text-align: start;
   white-space: nowrap;
 }
 
@@ -106,7 +108,7 @@
 }
 
 .dx-htmxdoc-rowlabel {
-  text-align: right;
+  text-align: end;
   color: var(--dx-text-muted, #475569);
   background: var(--dx-surface-alt, #f8fafc);
   font-weight: 400;
@@ -153,7 +155,7 @@
 
 .dx-htmxdoc-list {
   margin: 0 0 1em;
-  padding-left: 1.5rem;
+  padding-inline-start: 1.5rem;
 }
 
 .dx-htmxdoc-list li {
@@ -170,7 +172,7 @@
 .dx-htmxdoc-wordtable td {
   border: 1px solid var(--dx-border, #e2e8f0);
   padding: 0.5rem 0.75rem;
-  text-align: left;
+  text-align: start;
   vertical-align: top;
   white-space: pre-wrap;
 }

--- a/src/BlazorDX.Integrations.PowerBI/wwwroot/dx-powerbi.css
+++ b/src/BlazorDX.Integrations.PowerBI/wwwroot/dx-powerbi.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /*
  * dx-powerbi.css — the interactive Power BI embed (DxPowerBiReport). BlazorDX owns
  * only the wrapper: the labeled container, the loading indicator, and the error

--- a/src/BlazorDX.Integrations.Reporting/wwwroot/dx-report.css
+++ b/src/BlazorDX.Integrations.Reporting/wwwroot/dx-report.css
@@ -1,3 +1,5 @@
+/* rtl-clean — converted to logical properties; physical usages that remain carry
+   an rtl-exempt reason. See docs/localization.md. */
 /*
  * dx-report.css — static-SSR + HTMX SSRS report viewer (DxReportViewer).
  * CSS-variable driven so it inherits the host theme; falls back to accessible
@@ -119,7 +121,7 @@
 .dx-report-html :is(th, td) {
   border: 1px solid var(--dx-border, #e2e8f0);
   padding: 6px 10px;
-  text-align: left;
+  text-align: start;
 }
 
 .dx-report-pdf {

--- a/tests/BlazorDX.Components.Tests/RtlLogicalPropertyTests.cs
+++ b/tests/BlazorDX.Components.Tests/RtlLogicalPropertyTests.cs
@@ -18,10 +18,11 @@ namespace BlazorDX.Components.Tests;
 /// the source rather than in a browser.
 /// </para>
 /// <para>
-/// <b>Opt-in by marker, deliberately.</b> Only files containing <c>rtl-clean</c> are enforced.
-/// The conversion backlog is 24 stylesheets and ~104 declarations; enforcing everything now would
-/// just fail. Each conversion batch adds the marker to the files it converts, and the end state
-/// is every stylesheet carrying it — the same ratchet DX1003 uses for hardcoded strings.
+/// <b>The ratchet is closed.</b> It began as an opt-in marker because enforcing 24 unconverted
+/// stylesheets at once would only have failed. All 25 are now converted, so
+/// <see cref="Every_shipped_stylesheet_is_marked_converted"/> makes the marker mandatory: a new
+/// stylesheet cannot quietly opt out of the check by omitting it, which is the one hole an
+/// opt-in ratchet always leaves.
 /// </para>
 /// <para>
 /// <b>Escape hatch.</b> A line carrying <c>rtl-exempt: &lt;reason&gt;</c> is allowed. Some
@@ -95,6 +96,26 @@ public sealed class RtlLogicalPropertyTests
             + $"properties (margin-inline-start, text-align: start, inset-inline-start, ...), or add "
             + $"`/* {ExemptMarker}: <reason> */` on the line if the usage is deliberately physical:"
             + Environment.NewLine + string.Join(Environment.NewLine, violations));
+    }
+
+    [Fact]
+    public void Every_shipped_stylesheet_is_marked_converted()
+    {
+        // What closing the ratchet means. While the marker was opt-in, the check could be
+        // sidestepped by simply not adding it — so a brand-new stylesheet full of margin-left
+        // would have passed. Now the marker is the requirement, and the test above is what the
+        // marker promises.
+        string[] unmarked = ShippedStylesheets()
+            .Where(path => !File.ReadAllText(path).Contains(ConvertedMarker, StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray()!;
+
+        Assert.True(unmarked.Length == 0,
+            $"Stylesheets with no `{ConvertedMarker}` marker. Convert them to logical properties "
+            + $"and add the marker (docs/localization.md), or add `{ExemptMarker}: <reason>` to the "
+            + "individual lines that must stay physical:"
+            + Environment.NewLine + string.Join(Environment.NewLine, unmarked.Select(n => "  " + n)));
     }
 
     [Fact]

--- a/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
+++ b/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
@@ -50,7 +50,7 @@ public sealed class AccessibilityE2ETests(PlaywrightFixture fx)
     // Added once every stylesheet was converted. These exercise the sheets whose bare
     // left/right positioning was flipped rather than merely mapped — the judgment calls, which
     // is where a conversion mistake would actually show.
-    [InlineData("/forms?dir=rtl")]       // dx-input: the affixed-input reveal button
+    [InlineData("/controls?dir=rtl")]    // dx-input: DxPassword's affixed reveal button
     [InlineData("/files?dir=rtl")]       // dx-filemanager, plus dx-layout's toast host
     [InlineData("/excel?dir=rtl")]       // dx-spreadsheet: the sticky row-number gutter
     public async Task Page_has_no_serious_axe_violations(string route)

--- a/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
+++ b/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
@@ -47,6 +47,12 @@ public sealed class AccessibilityE2ETests(PlaywrightFixture fx)
     [InlineData("/scheduler?dir=rtl")]   // grid of day columns — the most direction-sensitive layout
     [InlineData("/app/records?dir=rtl")] // DxDataGrid: sort/filter affordances, sticky header, toolbar
     [InlineData("/charts?dir=rtl")]      // chart geometry is C#-computed, so RTL is unreviewed here by construction
+    // Added once every stylesheet was converted. These exercise the sheets whose bare
+    // left/right positioning was flipped rather than merely mapped — the judgment calls, which
+    // is where a conversion mistake would actually show.
+    [InlineData("/forms?dir=rtl")]       // dx-input: the affixed-input reveal button
+    [InlineData("/files?dir=rtl")]       // dx-filemanager, plus dx-layout's toast host
+    [InlineData("/excel?dir=rtl")]       // dx-spreadsheet: the sticky row-number gutter
     public async Task Page_has_no_serious_axe_violations(string route)
     {
         Skip.IfNot(fx.Ready, fx.SkipReason);


### PR DESCRIPTION
**All 25 shipped stylesheets are now `rtl-clean`** — 104 mechanical rewrites and 22 judgment calls. This is the other half of the localization/RTL roadmap item, untouched since the foundation PR converted the single pilot sheet.

## The judgment calls found real bugs, not just unconverted syntax

A bare `left:` either follows the reading direction or pins a physical edge, and only reading the rule tells you which. Doing that turned up genuine RTL defects:

- **`dx-input`'s affixed input** already used `padding-inline-end` for the text but pinned the reveal button with `right`. Under RTL the padding moved and the button didn't — **the button sat on top of the text**.
- **`dx-spreadsheet`'s row-number gutter** was stuck to the physical left; a right-to-left sheet wants it on the right.
- **`dx-layout`'s skip link** — the first thing a keyboard user reaches — was anchored left regardless of direction.
- The Gantt progress fill, the pull-quote's ghost quotation mark, the scrolly-stage index, and the DataGrid's two dropdown panels all anchored to a physical side.

## Two places CSS can't express the flip

`transform` has no logical form. `DxSwitch`'s thumb travels with `translateX(16px)` and the reading-progress bar scales from `transform-origin: left`. Both needed explicit `[dir="rtl"]` rules.

These are the nastiest category: everything *around* them flips correctly, so the element moves the wrong way and it reads as a rendering glitch rather than a missing conversion. A property-mapping sweep would have silently left both.

## Eight declarations stay physical, each with a reason

- Boxes pinned to **both** edges (a scheduler event inset 3px each side, the range-slider track) are symmetric — converting them is churn.
- **`DxSheet`'s `Side="left"/"right"` names a screen edge.** Flipping it would make `Side="right"` dock left, contradicting the parameter its caller wrote.

## The ratchet is now closed

The `rtl-clean` marker started opt-in because enforcing 24 unconverted sheets at once would only have failed. With all 25 converted, `Every_shipped_stylesheet_is_marked_converted` makes the marker **mandatory** — a new stylesheet can no longer skip the check by omitting it, which is the one hole an opt-in ratchet always leaves.

Three more `?dir=rtl` axe routes (`/forms`, `/files`, `/excel`) cover the sheets whose positioning was *flipped* rather than merely mapped, since that's where a mistake would show.

## Verification

The static guard reports **25 of 25 marked, 0 violations**. Comments were excluded from the rewrite, so documentation mentioning a physical property wasn't mangled.

Worth being plain about the limits: the static guard proves no physical property survives, and axe proves RTL doesn't break semantics, but **neither proves the result looks right**. The one real layout assertion remains `DxSelect`'s caret mirroring. A visual pass over `?dir=rtl` is still a manual job, and the `transform` rules above are exactly the kind of thing it would catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

