### PR TITLE
Localize every package, and make DxStrings shared source

### DIFF
--- a/analyzers/BlazorDX.Analyzers/HardcodedStringAnalyzer.cs
+++ b/analyzers/BlazorDX.Analyzers/HardcodedStringAnalyzer.cs
@@ -17,13 +17,9 @@ namespace BlazorDX.Analyzers;
 /// <c>DxStrings&lt;T&gt;</c> member, so localizing a component was what switched the rule on for
 /// it. That was scaffolding: with 83 components to convert and <c>TreatWarningsAsErrors</c>
 /// repo-wide, a rule that fired everywhere would have reported the whole backlog at once. The
-/// rollout is finished, so it now applies to every type in <c>BlazorDX.Components</c> —
+/// rollout is finished, so it now applies to every type in every package —
 /// including a brand-new component that localizes nothing, which the old scoping let opt out.
 /// See docs/adr/0021-optional-localization-and-rollout-guardrails.md.
-/// </para>
-/// <para>
-/// It is still scoped to one assembly, for a different and narrower reason — see
-/// <see cref="LocalizableAssembly"/>.
 /// </para>
 /// <para>
 /// What it still cannot see is text that reaches the DOM through a variable — a lookup table, a
@@ -72,24 +68,6 @@ public sealed class HardcodedStringAnalyzer : DiagnosticAnalyzer
         "Tooltip",
         "Prompt");
 
-    /// <summary>
-    /// The only assembly where <c>DxStrings</c> exists, and therefore the only one where this
-    /// rule's suggested fix can be written.
-    /// </summary>
-    /// <remarks>
-    /// Retiring the per-type ratchet surfaced 17 hardcoded strings in four other packages —
-    /// <c>BlazorDX.Primitives</c> (four placeholder defaults), <c>BlazorDX.Htmx</c>,
-    /// <c>BlazorDX.Integrations.PowerBI</c> and <c>BlazorDX.Integrations.Reporting</c>. They are
-    /// real findings, but none of those packages references <c>BlazorDX.Components</c>, so
-    /// <c>DxStrings</c> is unreachable from all of them and the diagnostic would demand a fix
-    /// that cannot be written — the same trap the defaulted-<c>[Parameter]</c> rule fell into.
-    /// <para>
-    /// Making the helper available there is a packaging decision (a new shared package, or new
-    /// dependencies on published packages), not a retrofit, so the rule is scoped to where its
-    /// advice holds. See docs/localization.md for the finding and what it would take to widen.
-    /// </para>
-    /// </remarks>
-    private const string LocalizableAssembly = "BlazorDX.Components";
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(DiagnosticDescriptors.HardcodedUserFacingString);
@@ -194,29 +172,23 @@ public sealed class HardcodedStringAnalyzer : DiagnosticAnalyzer
     private static bool ContainsLetter(string text) => text.Any(char.IsLetter);
 
     /// <summary>
-    /// Always true now — the ratchet is closed.
+    /// Always true. Both scopings this rule once had are gone.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This used to require the enclosing type to hold a <c>DxStrings&lt;…&gt;</c> member, so the
-    /// rule covered exactly the components already localized and grew with each rollout batch.
-    /// That was scaffolding for a migration: with 83 components to convert and
-    /// <c>TreatWarningsAsErrors</c> repo-wide, a rule that fired everywhere would have broken the
-    /// build on day one.
+    /// It first required the enclosing type to hold a <c>DxStrings&lt;…&gt;</c> member, so the rule
+    /// covered exactly the components already converted and grew with each rollout batch. That was
+    /// scaffolding for a migration under <c>TreatWarningsAsErrors</c>.
     /// </para>
     /// <para>
-    /// The rollout is finished — every component with user-facing text at a render call site now
-    /// routes it through a localizer — so the scoping is retired rather than left in place. It
-    /// was the rule's one hole: a brand-new component could opt out of the check simply by not
-    /// localizing anything, which is precisely the component most likely to need it.
-    /// </para>
-    /// <para>
-    /// Kept as a method rather than deleted at every call site: it names the decision, and this
-    /// remark is where the history belongs.
+    /// It was then scoped to <c>BlazorDX.Components</c>, because <c>DxStrings</c> lived there and
+    /// nowhere else — reporting in <c>BlazorDX.Primitives</c> or an integration package would have
+    /// demanded a fix that could not be written. That is fixed at the source: the helper is now
+    /// shared source compiled into every package that renders text, so the rule's advice holds
+    /// everywhere and the scoping has no reason to exist.
     /// </para>
     /// </remarks>
-    private static bool IsInLocalizedType(SyntaxNodeAnalysisContext context) =>
-        context.Compilation.AssemblyName == LocalizableAssembly;
+    private static bool IsInLocalizedType(SyntaxNodeAnalysisContext context) => true;
 
     private static bool IsRenderTreeBuilder(SyntaxNodeAnalysisContext context, ExpressionSyntax receiver) =>
         context.SemanticModel.GetTypeInfo(receiver, context.CancellationToken).Type?.Name

--- a/analyzers/BlazorDX.Analyzers/HardcodedStringAnalyzer.cs
+++ b/analyzers/BlazorDX.Analyzers/HardcodedStringAnalyzer.cs
@@ -172,23 +172,27 @@ public sealed class HardcodedStringAnalyzer : DiagnosticAnalyzer
     private static bool ContainsLetter(string text) => text.Any(char.IsLetter);
 
     /// <summary>
-    /// Always true. Both scopings this rule once had are gone.
+    /// Every assembly that ships UI — which is all of them except the test projects.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// It first required the enclosing type to hold a <c>DxStrings&lt;…&gt;</c> member, so the rule
-    /// covered exactly the components already converted and grew with each rollout batch. That was
-    /// scaffolding for a migration under <c>TreatWarningsAsErrors</c>.
+    /// Two earlier scopings are gone. The rule first required the enclosing type to hold a
+    /// <c>DxStrings&lt;…&gt;</c> member, so it covered exactly the components already converted and
+    /// grew with each rollout batch — scaffolding for a migration under
+    /// <c>TreatWarningsAsErrors</c>. It was then scoped to <c>BlazorDX.Components</c>, because
+    /// <c>DxStrings</c> lived there and nowhere else, so reporting elsewhere would have demanded a
+    /// fix that could not be written. The helper is now shared source compiled into every package
+    /// that renders text, and both scopings are retired.
     /// </para>
     /// <para>
-    /// It was then scoped to <c>BlazorDX.Components</c>, because <c>DxStrings</c> lived there and
-    /// nowhere else — reporting in <c>BlazorDX.Primitives</c> or an integration package would have
-    /// demanded a fix that could not be written. That is fixed at the source: the helper is now
-    /// shared source compiled into every package that renders text, so the rule's advice holds
-    /// everywhere and the scoping has no reason to exist.
+    /// Test projects stay excluded, and that is a statement about what the rule is for rather than
+    /// a convenience. DX1003 governs text a user reads in the product. A test that builds a render
+    /// tree out of <c>"Alpha body"</c> and <c>"Trigger text"</c> is writing fixture data; asking it
+    /// to route those through a localizer would be asking it to translate its own inputs.
     /// </para>
     /// </remarks>
-    private static bool IsInLocalizedType(SyntaxNodeAnalysisContext context) => true;
+    private static bool IsInLocalizedType(SyntaxNodeAnalysisContext context) =>
+        context.Compilation.AssemblyName?.EndsWith(".Tests", StringComparison.Ordinal) != true;
 
     private static bool IsRenderTreeBuilder(SyntaxNodeAnalysisContext context, ExpressionSyntax receiver) =>
         context.SemanticModel.GetTypeInfo(receiver, context.CancellationToken).Type?.Name

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -101,14 +101,13 @@ enhancements. None of this should be read as "ready"; it is a beta with work ahe
   than opt-in, so a new stylesheet cannot skip the check by omitting it. The physical usages
   that remain each carry a written reason — a screen-edge API (`DxSheet`'s `Side`), boxes
   pinned to both edges, and the two places CSS has no logical form (`transform` and
-  `transform-origin`, handled with explicit `[dir="rtl"]` rules). **Strings done for the styled tier**: all 83
-  components in `BlazorDX.Components` with user-facing text now route it through a localizer — 267 call sites across
-  52 resource files — and DX1003's ratchet is retired, so a hardcoded label is a build error
+  `transform-origin`, handled with explicit `[dir="rtl"]` rules). **Strings done**: every package now routes user-facing
+  text through a localizer — the styled tier plus `Primitives`, `Documents`, `Htmx` and both
+  `Integrations` packages — 309 call sites across
+  62 resource files — and DX1003's ratchet is retired, so a hardcoded label is a build error
   anywhere, not just in components that already localize. (The "~130 components" figure here
-  previously counted every file; 57 have no user-facing text at all.) *Remaining: 17 strings in four other
-  packages (`Primitives`, `Htmx`, and the two `Integrations`) are unconverted — `DxStrings`
-  is unreachable from them, so widening the rule is a packaging decision rather than a
-  retrofit. And this externalizes the strings, it does not translate them — the `.resx` files hold English, and
+  previously counted every file; 57 have no user-facing text at all.) *Remaining: this externalizes the strings, it
+  does not translate them — the `.resx` files hold English, and
   only two carry a French counterpart. Shipping translations, and a visual RTL pass that a
   static guard cannot do, are the parts left.*
 - **Formal accessibility audit + VPAT** — automated **axe-core checks now run in CI**

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -256,8 +256,8 @@ file rather than the ones with user-facing text.)
 | `.cs` files in `BlazorDX.Components` | 142 |
 | …with zero user-facing strings (headless / parameter-driven) | 57 |
 | **Components to localize** | **83 — done** (~250–270 unique strings) |
-| …localized | **all of them** — 75 components hold a localizer |
-| …strings externalized | 267 call sites, across 52 resource files |
+| …localized | **all of them**, plus 5 more packages — 88 types hold a localizer |
+| …strings externalized | 309 call sites, across 62 resource files |
 | …with 1–3 strings each | 60 |
 | …heavy hitters (>10 strings) | 6, holding ~40% of all text |
 | Stylesheets converted | **25 of 25 — done** |
@@ -309,43 +309,36 @@ Four physical usages that a rewrite would have got wrong, kept as worked example
   `transform-origin` needed explicit `[dir="rtl"]` rules — the two places where CSS itself
   cannot express the flip.
 
-**Completion criterion: met for `BlazorDX.Components`.** DX1003 fires on every file there, and
+**Completion criterion: met.** DX1003 fires on every file in every package, and
 every stylesheet carries `rtl-clean`. Both ratchets existed to be removed, and both are gone —
 the per-type scoping and the opt-in CSS marker.
 
-### The other packages
+### Every package, not just the styled tier
 
-Retiring the ratchet surfaced **17 hardcoded strings outside `BlazorDX.Components`**, which no
-scan in this rollout had ever looked at:
+The rollout originally covered `BlazorDX.Components` only, and ADR 0016 had scoped it that way
+on a false premise — "zero in `src/BlazorDX.Primitives` — primitives are unlabeled by design".
+Four Tier-1 placeholder defaults live there and reach the DOM through the styled tier, so a
+French app rendered "Select a date" regardless of culture.
 
-| Package | Strings |
-|---|---|
-| `BlazorDX.Integrations.Reporting` | 5 |
-| `BlazorDX.Htmx` | 6 |
-| `BlazorDX.Primitives` | 4 — `"Select a date"`, `"Type to search..."`, `"Type a command..."`, `"Select..."` |
-| `BlazorDX.Integrations.PowerBI` | 2 |
+Retiring DX1003's scoping surfaced the rest: **38 strings in five packages** that no earlier
+scan had looked at — `BlazorDX.Documents` (21), `BlazorDX.Htmx` (8), `.Integrations.Reporting`
+(5), `.Primitives` (4), `.Integrations.PowerBI` (2). All are localized now.
 
-The `BlazorDX.Primitives` four are the "Tier-1 primitive English defaults" this document already
-listed as a separate track. They are also a contradiction with
-[ADR 0001](adr/0001-two-tier-headless.md), which says primitives are unlabeled by design.
+**`DxStrings` is shared source, not a shared package.** It lives at `src/Shared/DxStrings.cs`
+and is `<Compile Include>`-linked into each package that renders text, so every assembly
+compiles its own `internal` copy from one definition. A thirteenth published package was the
+obvious alternative and was rejected: `BlazorDX.Integrations.PowerBI` deliberately references
+no BlazorDX project at all, and the type is `internal`, so there is no public surface to share
+— taking a dependency to reach a forty-line helper would trade that independence for nothing.
+Each package adds only the `Microsoft.Extensions.Localization` reference the helper needs.
 
-**None of these packages references `BlazorDX.Components`**, so `DxStrings` is unreachable from
-all of them and DX1003 would demand a fix that cannot be written — the same trap the
-defaulted-`[Parameter]` rule fell into. The analyzer is therefore scoped to the one assembly
-where its advice holds, and the scoping has its own test.
+Its namespace is `BlazorDX`, not `BlazorDX.Components`, so every consuming namespace resolves
+it without a `using`.
 
-Widening it is a **packaging decision, not a retrofit**: `DxStrings` would have to move
-somewhere every package can reach — a new shared package (a thirteenth), or new dependencies
-from the integration packages onto an existing one. Either changes the published dependency
-graph, which is not a call to make as a side effect of finishing a string sweep.
-
-What that does and does not promise is worth keeping straight. It means **no hardcoded
-user-facing literal survives at a render call site, and no stylesheet uses a physical
-directional property without a written reason** — both mechanically enforced, on every future
-change. It does not mean the library is translated: the `.resx` files hold English, and
-`DxAlert` / `DxDataGridResources` are the only ones with a French counterpart. Externalizing
-the strings is what makes translation possible; supplying translations is separate work, and
-so is the visual RTL pass a static guard cannot do.
+**Partial classes.** `DxWordEditor.Find.cs` and `DxSpreadsheetViewer.Editing.cs` use `S[...]`
+but declare no field — the type declares it once in its main file. `LocalizedStringConsistency`
+`Tests` resolves a partial's resource from `Type.cs`; without that it skipped their call sites
+*and* reported the keys they use as orphaned, failing in both directions at once.
 
 ### Separate tracks, each needing a different mechanism
 

--- a/src/BlazorDX.Components/BlazorDX.Components.csproj
+++ b/src/BlazorDX.Components/BlazorDX.Components.csproj
@@ -42,4 +42,10 @@
     <ProjectReference Include="..\BlazorDX.Security\BlazorDX.Security.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- One definition, compiled into each package. See the header comment in the file for why
+         this is shared source rather than a shared (thirteenth) package. -->
+    <Compile Include="..\Shared\DxStrings.cs" Link="DxStrings.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/BlazorDX.Components/DxComboBox.cs
+++ b/src/BlazorDX.Components/DxComboBox.cs
@@ -40,7 +40,7 @@ public sealed class DxComboBox<TValue> : ComboBoxPrimitive<TValue>
         builder.AddAttribute(7, "aria-autocomplete", "list");
         builder.AddAttribute(8, "aria-expanded", IsOpen ? "true" : "false");
         builder.AddAttribute(9, "aria-controls", PanelId);
-        builder.AddAttribute(10, "placeholder", Placeholder);
+        builder.AddAttribute(10, "placeholder", ResolvedPlaceholder);
         builder.AddAttribute(11, "value", Filter);
         if (ActiveOptionId.Length > 0)
         {

--- a/src/BlazorDX.Components/DxCommandPalette.cs
+++ b/src/BlazorDX.Components/DxCommandPalette.cs
@@ -51,7 +51,7 @@ public sealed class DxCommandPalette : CommandPalettePrimitive
         builder.AddAttribute(11, "role", "combobox");
         builder.AddAttribute(12, "aria-autocomplete", "list");
         builder.AddAttribute(13, "aria-controls", $"{PanelId}-list");
-        builder.AddAttribute(14, "placeholder", Placeholder);
+        builder.AddAttribute(14, "placeholder", ResolvedPlaceholder);
         builder.AddAttribute(15, "value", Filter);
         if (ActiveDescendantId.Length > 0)
         {

--- a/src/BlazorDX.Documents/BlazorDX.Documents.csproj
+++ b/src/BlazorDX.Documents/BlazorDX.Documents.csproj
@@ -32,4 +32,15 @@
     <ProjectReference Include="..\BlazorDX.Security\BlazorDX.Security.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- One definition, compiled into each package. See the header comment in the file for why
+         this is shared source rather than a shared (thirteenth) package. -->
+    <Compile Include="..\Shared\DxStrings.cs" Link="DxStrings.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Needed by the linked DxStrings.cs. -->
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+  </ItemGroup>
+
 </Project>

--- a/src/BlazorDX.Documents/DxSpreadsheetViewer.Editing.cs
+++ b/src/BlazorDX.Documents/DxSpreadsheetViewer.Editing.cs
@@ -201,7 +201,7 @@ public sealed partial class DxSpreadsheetViewer
         builder.AddAttribute(32, "class", "dx-sheet-grid dx-sheet-grid-editable dx-sheet-scroll");
         builder.AddAttribute(33, "role", "grid");
         builder.AddAttribute(34, "aria-multiselectable", "false");
-        builder.AddAttribute(35, "aria-label", $"{sheet.Name} worksheet, editable");
+        builder.AddAttribute(35, "aria-label", S["WorksheetEditable", "{0} worksheet, editable", sheet.Name]);
         builder.AddAttribute(36, "aria-rowcount", EditRowCount.ToString(CultureInfo.InvariantCulture));
         builder.AddAttribute(37, "aria-colcount", (dataColumns + 1).ToString(CultureInfo.InvariantCulture));
         builder.AddAttribute(38, "tabindex", "0"); // scrollable region is keyboard-reachable (WCAG 2.1.1)
@@ -364,7 +364,7 @@ public sealed partial class DxSpreadsheetViewer
         builder.AddAttribute(31, "type", "text");
         builder.AddAttribute(32, "class", "dx-sheet-cell-input");
         builder.AddAttribute(33, "aria-label",
-            $"Cell {CellLabel(rowIndex, column)} content");
+            S["CellContent", "Cell {0} content", CellLabel(rowIndex, column)]);
         builder.AddAttribute(34, "value", editBuffer);
         builder.AddAttribute(35, "oninput",
             EventCallback.Factory.Create<ChangeEventArgs>(this, e => editBuffer = e.Value?.ToString() ?? string.Empty));

--- a/src/BlazorDX.Documents/DxSpreadsheetViewer.Toolbar.cs
+++ b/src/BlazorDX.Documents/DxSpreadsheetViewer.Toolbar.cs
@@ -39,7 +39,7 @@ public sealed partial class DxSpreadsheetViewer
         builder.OpenElement(0, "div");
         builder.AddAttribute(1, "class", "dx-sheet-toolbar");
         builder.AddAttribute(2, "role", "toolbar");
-        builder.AddAttribute(3, "aria-label", "Spreadsheet editing");
+        builder.AddAttribute(3, "aria-label", S["SpreadsheetEditing", "Spreadsheet editing"]);
 
         ToolbarButton(builder, 10, "Insert row", "Insert row above the active cell", InsertRowAsync);
         ToolbarButton(builder, 20, "Delete row", "Delete the active row", DeleteRowAsync);

--- a/src/BlazorDX.Documents/DxSpreadsheetViewer.cs
+++ b/src/BlazorDX.Documents/DxSpreadsheetViewer.cs
@@ -48,6 +48,12 @@ public sealed partial class DxSpreadsheetViewer : SpreadsheetViewerPrimitive
         SyncEditState();
     }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxSpreadsheetViewer>? s;
+
+    private DxStrings<DxSpreadsheetViewer> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenElement(0, "div");
@@ -64,7 +70,7 @@ public sealed partial class DxSpreadsheetViewer : SpreadsheetViewerPrimitive
         builder.OpenElement(2, "div");
         builder.AddAttribute(3, "class", "dx-sheet-tabs");
         builder.AddAttribute(4, "role", "tablist");
-        builder.AddAttribute(5, "aria-label", "Worksheets");
+        builder.AddAttribute(5, "aria-label", S["Worksheets", "Worksheets"]);
         builder.AddAttribute(6, "onkeydown",
             EventCallback.Factory.Create<KeyboardEventArgs>(this, OnTabStripKeyDownAsync));
         builder.AddEventPreventDefaultAttribute(7, "onkeydown", true);
@@ -144,7 +150,7 @@ public sealed partial class DxSpreadsheetViewer : SpreadsheetViewerPrimitive
         builder.AddAttribute(31, "class", "dx-sheet-grid");
         builder.AddAttribute(32, "role", "grid");
         builder.AddAttribute(33, "aria-readonly", "true");
-        builder.AddAttribute(34, "aria-label", $"{sheet.Name} worksheet");
+        builder.AddAttribute(34, "aria-label", S["Worksheet", "{0} worksheet", sheet.Name]);
         builder.AddAttribute(35, "aria-rowcount", (sheet.Rows.Count).ToString(CultureInfo.InvariantCulture));
         builder.AddAttribute(36, "aria-colcount", (dataColumns + 1).ToString(CultureInfo.InvariantCulture));
 

--- a/src/BlazorDX.Documents/DxSpreadsheetViewer.resx
+++ b/src/BlazorDX.Documents/DxSpreadsheetViewer.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CellContent" xml:space="preserve">
+    <value>Cell {0} content</value>
+  </data>
+  <data name="SpreadsheetEditing" xml:space="preserve">
+    <value>Spreadsheet editing</value>
+  </data>
+  <data name="Worksheet" xml:space="preserve">
+    <value>{0} worksheet</value>
+  </data>
+  <data name="WorksheetEditable" xml:space="preserve">
+    <value>{0} worksheet, editable</value>
+  </data>
+  <data name="Worksheets" xml:space="preserve">
+    <value>Worksheets</value>
+  </data>
+</root>

--- a/src/BlazorDX.Documents/DxWordEditor.Find.cs
+++ b/src/BlazorDX.Documents/DxWordEditor.Find.cs
@@ -56,8 +56,8 @@ public sealed partial class DxWordEditor
         builder.OpenElement(3, "input");
         builder.AddAttribute(4, "type", "text");
         builder.AddAttribute(5, "class", "dx-word-find-input");
-        builder.AddAttribute(6, "placeholder", "Find");
-        builder.AddAttribute(7, "aria-label", "Find");
+        builder.AddAttribute(6, "placeholder", S["Find", "Find"]);
+        builder.AddAttribute(7, "aria-label", S["Find", "Find"]);
         builder.AddAttribute(8, "value", findText);
         builder.AddAttribute(9, "oninput", EventCallback.Factory.Create<ChangeEventArgs>(this, OnFindInput));
         builder.CloseElement();
@@ -74,8 +74,8 @@ public sealed partial class DxWordEditor
         builder.OpenElement(14, "input");
         builder.AddAttribute(15, "type", "text");
         builder.AddAttribute(16, "class", "dx-word-replace-input");
-        builder.AddAttribute(17, "placeholder", "Replace with");
-        builder.AddAttribute(18, "aria-label", "Replace with");
+        builder.AddAttribute(17, "placeholder", S["ReplaceWith", "Replace with"]);
+        builder.AddAttribute(18, "aria-label", S["ReplaceWith", "Replace with"]);
         builder.AddAttribute(19, "value", replaceText);
         builder.AddAttribute(20, "oninput", EventCallback.Factory.Create<ChangeEventArgs>(this, OnReplaceInput));
         builder.CloseElement();
@@ -87,7 +87,7 @@ public sealed partial class DxWordEditor
         builder.AddAttribute(25, "checked", caseSensitive);
         builder.AddAttribute(26, "onchange", EventCallback.Factory.Create<ChangeEventArgs>(this, OnCaseToggle));
         builder.CloseElement();
-        builder.AddContent(27, "Match case");
+        builder.AddContent(27, S["MatchCase", "Match case"]);
         builder.CloseElement();
 
         FindButton(builder, 30, "Replace", ReplaceOneAsync);

--- a/src/BlazorDX.Documents/DxWordEditor.cs
+++ b/src/BlazorDX.Documents/DxWordEditor.cs
@@ -81,7 +81,7 @@ public sealed partial class DxWordEditor : ComponentBase
     [Parameter] public HtmlSanitizer? Sanitizer { get; set; }
 
     /// <summary>Accessible name for the editing surface. Defaults to "Document".</summary>
-    [Parameter] public string Label { get; set; } = "Document";
+    [Parameter] public string? Label { get; set; }
 
     /// <summary>
     /// When <see langword="true"/> (the default), a small status line shows whether there
@@ -157,6 +157,12 @@ public sealed partial class DxWordEditor : ComponentBase
         _baseline ??= new HistoryEntry(source, html, null);
     }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxWordEditor>? s;
+
+    private DxStrings<DxWordEditor> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenElement(0, "div");
@@ -167,25 +173,25 @@ public sealed partial class DxWordEditor : ComponentBase
             builder.OpenElement(2, "div");
             builder.AddAttribute(3, "class", "dx-word-toolbar");
             builder.AddAttribute(4, "role", "toolbar");
-            builder.AddAttribute(5, "aria-label", "Document");
+            builder.AddAttribute(5, "aria-label", S["Document", "Document"]);
 
             builder.OpenElement(6, "button");
             builder.AddAttribute(7, "type", "button");
             builder.AddAttribute(8, "class", "dx-word-toolbar-btn");
-            builder.AddAttribute(9, "aria-label", "Download the document as a .docx file");
-            builder.AddAttribute(10, "title", "Download the document as a .docx file");
+            builder.AddAttribute(9, "aria-label", S["DownloadDocumentAsDocx", "Download the document as a .docx file"]);
+            builder.AddAttribute(10, "title", S["DownloadDocumentAsDocx", "Download the document as a .docx file"]);
             builder.AddAttribute(11, "onclick", EventCallback.Factory.Create(this, DownloadAsync));
-            builder.AddContent(12, "Download .docx");
+            builder.AddContent(12, S["DownloadDocx", "Download .docx"]);
             builder.CloseElement();
 
             builder.OpenElement(13, "button");
             builder.AddAttribute(14, "type", "button");
             builder.AddAttribute(15, "class", "dx-word-toolbar-btn");
-            builder.AddAttribute(16, "aria-label", "Find and replace");
-            builder.AddAttribute(17, "title", "Find and replace");
+            builder.AddAttribute(16, "aria-label", S["FindReplace", "Find and replace"]);
+            builder.AddAttribute(17, "title", S["FindReplace", "Find and replace"]);
             builder.AddAttribute(18, "aria-expanded", showFind ? "true" : "false");
             builder.AddAttribute(19, "onclick", EventCallback.Factory.Create(this, ToggleFind));
-            builder.AddContent(20, "Find & replace");
+            builder.AddContent(20, S["FindReplace2", "Find & replace"]);
             builder.CloseElement();
 
             ToolbarButton(builder, 30, "Undo", "Undo", UndoAsync, !CanUndo);
@@ -219,7 +225,8 @@ public sealed partial class DxWordEditor : ComponentBase
         builder.AddComponentParameter(22, nameof(DxRichTextEditor.ValueChanged),
             EventCallback.Factory.Create<string?>(this, OnEditorHtmlChangedAsync));
         builder.AddComponentParameter(23, nameof(DxRichTextEditor.Sanitizer), Sanitizer);
-        builder.AddComponentParameter(24, nameof(DxRichTextEditor.AriaLabel), Label);
+        builder.AddComponentParameter(24, nameof(DxRichTextEditor.AriaLabel),
+            Label ?? S["Document", "Document"]);
         builder.AddComponentParameter(25, nameof(DxRichTextEditor.Class), "dx-word-editor-surface");
         // Keyboard undo/redo drive our model history (not the browser's), in both editing cores.
         builder.AddComponentParameter(26, nameof(DxRichTextEditor.OnUndo),
@@ -248,8 +255,11 @@ public sealed partial class DxWordEditor : ComponentBase
             builder.AddAttribute(31, "class", "dx-word-editor-status");
             builder.AddAttribute(32, "role", "status");
             builder.AddAttribute(33, "aria-live", "polite");
-            builder.AddContent(34, $"{(dirty ? "Unsaved changes" : "All changes saved")} · " +
-                $"{stats.Words:N0} words · {stats.Characters:N0} characters · {stats.Paragraphs:N0} paragraphs");
+            builder.AddContent(34, dirty
+                ? S["StatsUnsaved", "Unsaved changes · {0:N0} words · {1:N0} characters · {2:N0} paragraphs",
+                    stats.Words, stats.Characters, stats.Paragraphs]
+                : S["StatsSaved", "All changes saved · {0:N0} words · {1:N0} characters · {2:N0} paragraphs",
+                    stats.Words, stats.Characters, stats.Paragraphs]);
             builder.CloseElement();
         }
 

--- a/src/BlazorDX.Documents/DxWordEditor.resx
+++ b/src/BlazorDX.Documents/DxWordEditor.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Document" xml:space="preserve">
+    <value>Document</value>
+  </data>
+  <data name="DownloadDocumentAsDocx" xml:space="preserve">
+    <value>Download the document as a .docx file</value>
+  </data>
+  <data name="DownloadDocx" xml:space="preserve">
+    <value>Download .docx</value>
+  </data>
+  <data name="Find" xml:space="preserve">
+    <value>Find</value>
+  </data>
+  <data name="FindReplace" xml:space="preserve">
+    <value>Find and replace</value>
+  </data>
+  <data name="FindReplace2" xml:space="preserve">
+    <value>Find &amp; replace</value>
+  </data>
+  <data name="MatchCase" xml:space="preserve">
+    <value>Match case</value>
+  </data>
+  <data name="ReplaceWith" xml:space="preserve">
+    <value>Replace with</value>
+  </data>
+  <data name="StatsSaved" xml:space="preserve">
+    <value>All changes saved · {0:N0} words · {1:N0} characters · {2:N0} paragraphs</value>
+  </data>
+  <data name="StatsUnsaved" xml:space="preserve">
+    <value>Unsaved changes · {0:N0} words · {1:N0} characters · {2:N0} paragraphs</value>
+  </data>
+</root>

--- a/src/BlazorDX.Documents/DxWordViewer.cs
+++ b/src/BlazorDX.Documents/DxWordViewer.cs
@@ -43,9 +43,15 @@ public sealed class DxWordViewer : ComponentBase
     /// Accessible name for the document region (the <c>aria-label</c> on the
     /// focusable <c>role="document"</c> container). Defaults to "Document".
     /// </summary>
-    [Parameter] public string Label { get; set; } = "Document";
+    [Parameter] public string? Label { get; set; }
 
     private IReadOnlyList<WordBlock> Blocks => Document?.Blocks ?? [];
+
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxWordViewer>? s;
+
+    private DxStrings<DxWordViewer> S => s ??= new(Services);
 
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
@@ -55,14 +61,14 @@ public sealed class DxWordViewer : ComponentBase
         builder.OpenElement(0, "div");
         builder.AddAttribute(1, "class", $"dx-word-viewer {Class}".TrimEnd());
         builder.AddAttribute(2, "role", "document");
-        builder.AddAttribute(3, "aria-label", Label);
+        builder.AddAttribute(3, "aria-label", Label ?? S["Document", "Document"]);
         builder.AddAttribute(4, "tabindex", "0");
 
         if (Blocks.Count == 0)
         {
             builder.OpenElement(5, "p");
             builder.AddAttribute(6, "class", "dx-word-empty");
-            builder.AddContent(7, "No document to display.");
+            builder.AddContent(7, S["NoDocumentDisplay", "No document to display."]);
             builder.CloseElement();
             builder.CloseElement();
             return;

--- a/src/BlazorDX.Documents/DxWordViewer.resx
+++ b/src/BlazorDX.Documents/DxWordViewer.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Document" xml:space="preserve">
+    <value>Document</value>
+  </data>
+  <data name="NoDocumentDisplay" xml:space="preserve">
+    <value>No document to display.</value>
+  </data>
+</root>

--- a/src/BlazorDX.Htmx/BlazorDX.Htmx.csproj
+++ b/src/BlazorDX.Htmx/BlazorDX.Htmx.csproj
@@ -25,4 +25,15 @@
     <ProjectReference Include="..\BlazorDX.Documents.Parsing\BlazorDX.Documents.Parsing.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- One definition, compiled into each package. See the header comment in the file for why
+         this is shared source rather than a shared (thirteenth) package. -->
+    <Compile Include="..\Shared\DxStrings.cs" Link="DxStrings.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Needed by the linked DxStrings.cs. -->
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+  </ItemGroup>
+
 </Project>

--- a/src/BlazorDX.Htmx/DxHtmxDocumentViewer.cs
+++ b/src/BlazorDX.Htmx/DxHtmxDocumentViewer.cs
@@ -118,6 +118,12 @@ public sealed class DxHtmxDocumentViewer : ComponentBase
         }
     }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxHtmxDocumentViewer>? s;
+
+    private DxStrings<DxHtmxDocumentViewer> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenElement(0, "div");
@@ -167,13 +173,13 @@ public sealed class DxHtmxDocumentViewer : ComponentBase
         // interactive toolbar (this tier is read-only and script-free).
         builder.OpenElement(105, "p");
         builder.AddAttribute(106, "class", "dx-htmxdoc-pdf-fallback");
-        builder.AddContent(107, "Can't see the PDF above? ");
+        builder.AddContent(107, S["PdfFallbackPrompt", "Can't see the PDF above? "]);
         builder.OpenElement(108, "a");
         builder.AddAttribute(109, "class", "dx-htmxdoc-download");
         builder.AddAttribute(110, "href", source);
         builder.AddAttribute(111, "download", Name);
         builder.AddAttribute(112, "rel", "noopener noreferrer");
-        builder.AddContent(113, $"Download {Name}");
+        builder.AddContent(113, S["DownloadNamed", "Download {0}", Name]);
         builder.CloseElement();
         builder.AddContent(114, ".");
         builder.CloseElement();
@@ -214,7 +220,7 @@ public sealed class DxHtmxDocumentViewer : ComponentBase
 
         builder.OpenElement(120, "nav");
         builder.AddAttribute(121, "class", "dx-htmxdoc-tabs");
-        builder.AddAttribute(122, "aria-label", "Worksheets");
+        builder.AddAttribute(122, "aria-label", S["Worksheets", "Worksheets"]);
 
         for (int i = 0; i < sheets.Count; i++)
         {
@@ -243,7 +249,7 @@ public sealed class DxHtmxDocumentViewer : ComponentBase
         builder.OpenElement(140, "div");
         builder.AddAttribute(141, "class", "dx-htmxdoc-panel");
         builder.AddAttribute(142, "role", "region");
-        builder.AddAttribute(143, "aria-label", $"{sheet.Name} worksheet");
+        builder.AddAttribute(143, "aria-label", S["WorksheetNamed", "{0} worksheet", sheet.Name]);
         builder.AddAttribute(144, "tabindex", "-1");
 
         if (sheet.Rows.Count == 0)
@@ -525,17 +531,17 @@ public sealed class DxHtmxDocumentViewer : ComponentBase
 
         builder.OpenElement(300, "nav");
         builder.AddAttribute(301, "class", "dx-htmxdoc-pager");
-        builder.AddAttribute(302, "aria-label", "Pagination");
+        builder.AddAttribute(302, "aria-label", S["Pagination", "Pagination"]);
 
-        BuildPagerLink(builder, 303, sheetIndex, page - 1, page > 0, "← Previous");
+        BuildPagerLink(builder, 303, sheetIndex, page - 1, page > 0, S["PreviousPage", "← Previous"]);
 
         builder.OpenElement(310, "span");
         builder.AddAttribute(311, "class", "dx-htmxdoc-pageinfo");
         builder.AddAttribute(312, "aria-live", "polite");
-        builder.AddContent(313, $"Page {page + 1} of {pageCount} ({status})");
+        builder.AddContent(313, S["PageOf", "Page {0} of {1} ({2})", page + 1, pageCount, status]);
         builder.CloseElement();
 
-        BuildPagerLink(builder, 320, sheetIndex, page + 1, page < pageCount - 1, "Next →");
+        BuildPagerLink(builder, 320, sheetIndex, page + 1, page < pageCount - 1, S["NextPage", "Next →"]);
 
         builder.CloseElement();
     }

--- a/src/BlazorDX.Htmx/DxHtmxDocumentViewer.resx
+++ b/src/BlazorDX.Htmx/DxHtmxDocumentViewer.resx
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DownloadNamed" xml:space="preserve">
+    <value>Download {0}</value>
+  </data>
+  <data name="NextPage" xml:space="preserve">
+    <value>Next →</value>
+  </data>
+  <data name="PageOf" xml:space="preserve">
+    <value>Page {0} of {1} ({2})</value>
+  </data>
+  <data name="Pagination" xml:space="preserve">
+    <value>Pagination</value>
+  </data>
+  <data name="PdfFallbackPrompt" xml:space="preserve">
+    <value>Can't see the PDF above? </value>
+  </data>
+  <data name="PreviousPage" xml:space="preserve">
+    <value>← Previous</value>
+  </data>
+  <data name="WorksheetNamed" xml:space="preserve">
+    <value>{0} worksheet</value>
+  </data>
+  <data name="Worksheets" xml:space="preserve">
+    <value>Worksheets</value>
+  </data>
+</root>

--- a/src/BlazorDX.Integrations.PowerBI/BlazorDX.Integrations.PowerBI.csproj
+++ b/src/BlazorDX.Integrations.PowerBI/BlazorDX.Integrations.PowerBI.csproj
@@ -42,4 +42,15 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- One definition, compiled into each package. See the header comment in the file for why
+         this is shared source rather than a shared (thirteenth) package. -->
+    <Compile Include="..\Shared\DxStrings.cs" Link="DxStrings.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Needed by the linked DxStrings.cs. -->
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+  </ItemGroup>
+
 </Project>

--- a/src/BlazorDX.Integrations.PowerBI/DxPowerBiReport.cs
+++ b/src/BlazorDX.Integrations.PowerBI/DxPowerBiReport.cs
@@ -70,7 +70,7 @@ public sealed class DxPowerBiReport : ComponentBase, IAsyncDisposable
     [Parameter] public string? ConfigEndpoint { get; set; }
 
     /// <summary>The accessible name for the embed container (WCAG 4.1.2). Required-ish; defaults to a generic label.</summary>
-    [Parameter] public string Label { get; set; } = "Power BI report";
+    [Parameter] public string? Label { get; set; }
 
     /// <summary>Extra CSS classes appended to the component root.</summary>
     [Parameter] public string? Class { get; set; }
@@ -221,6 +221,11 @@ public sealed class DxPowerBiReport : ComponentBase, IAsyncDisposable
         }
     }
 
+    // Reuses the Services injection this component already had.
+    private DxStrings<DxPowerBiReport>? s;
+
+    private DxStrings<DxPowerBiReport> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenElement(0, "div");
@@ -247,7 +252,10 @@ public sealed class DxPowerBiReport : ComponentBase, IAsyncDisposable
         builder.AddAttribute(21, "id", elementId);
         builder.AddAttribute(22, "class", "dx-powerbi-frame");
         builder.AddAttribute(23, "role", "application");
-        builder.AddAttribute(24, "aria-label", string.IsNullOrWhiteSpace(Label) ? "Power BI report" : Label);
+        // Already coalesced before this change — the parameter's default and this fallback were
+        // the same English string in two places. Now there is one, and it is localized.
+        builder.AddAttribute(24, "aria-label",
+            string.IsNullOrWhiteSpace(Label) ? S["ReportLabel", "Power BI report"] : Label);
         builder.CloseElement();
 
         builder.CloseElement(); // root
@@ -266,7 +274,7 @@ public sealed class DxPowerBiReport : ComponentBase, IAsyncDisposable
         }
         else
         {
-            builder.AddContent(15, "Loading the report…");
+            builder.AddContent(15, S["LoadingReport", "Loading the report…"]);
         }
 
         builder.CloseElement();

--- a/src/BlazorDX.Integrations.PowerBI/DxPowerBiReport.resx
+++ b/src/BlazorDX.Integrations.PowerBI/DxPowerBiReport.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LoadingReport" xml:space="preserve">
+    <value>Loading the report…</value>
+  </data>
+  <data name="ReportLabel" xml:space="preserve">
+    <value>Power BI report</value>
+  </data>
+</root>

--- a/src/BlazorDX.Integrations.Reporting/BlazorDX.Integrations.Reporting.csproj
+++ b/src/BlazorDX.Integrations.Reporting/BlazorDX.Integrations.Reporting.csproj
@@ -32,4 +32,15 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- One definition, compiled into each package. See the header comment in the file for why
+         this is shared source rather than a shared (thirteenth) package. -->
+    <Compile Include="..\Shared\DxStrings.cs" Link="DxStrings.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Needed by the linked DxStrings.cs. -->
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+  </ItemGroup>
+
 </Project>

--- a/src/BlazorDX.Integrations.Reporting/DxReportViewer.cs
+++ b/src/BlazorDX.Integrations.Reporting/DxReportViewer.cs
@@ -178,6 +178,12 @@ public sealed class DxReportViewer : ComponentBase
         }
     }
 
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxReportViewer>? s;
+
+    private DxStrings<DxReportViewer> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenElement(0, "div");
@@ -278,7 +284,7 @@ public sealed class DxReportViewer : ComponentBase
         builder.OpenElement(62, "button");
         builder.AddAttribute(63, "type", "submit");
         builder.AddAttribute(64, "class", "dx-report-run");
-        builder.AddContent(65, "Run report");
+        builder.AddContent(65, S["RunReport", "Run report"]);
         builder.CloseElement();
         builder.CloseElement(); // actions
 
@@ -291,7 +297,7 @@ public sealed class DxReportViewer : ComponentBase
         builder.AddAttribute(41, "class", "dx-report-fields");
 
         builder.OpenElement(42, "legend");
-        builder.AddContent(43, "Report parameters");
+        builder.AddContent(43, S["ReportParameters", "Report parameters"]);
         builder.CloseElement();
 
         var current = BuildValueLookup();
@@ -424,7 +430,7 @@ public sealed class DxReportViewer : ComponentBase
         builder.OpenElement(90, "div");
         builder.AddAttribute(91, "class", "dx-report-output");
         builder.AddAttribute(92, "role", "region");
-        builder.AddAttribute(93, "aria-label", $"{FrameTitle(Report)} output");
+        builder.AddAttribute(93, "aria-label", S["ReportOutput", "{0} output", FrameTitle(Report)]);
         builder.AddAttribute(94, "aria-live", "polite");
         builder.AddAttribute(95, "tabindex", "-1");
 
@@ -444,7 +450,7 @@ public sealed class DxReportViewer : ComponentBase
         {
             builder.OpenElement(97, "p");
             builder.AddAttribute(98, "class", "dx-report-empty");
-            builder.AddContent(99, "Choose parameters and run the report to see results here.");
+            builder.AddContent(99, S["EmptyOutput", "Choose parameters and run the report to see results here."]);
             builder.CloseElement();
         }
 
@@ -518,7 +524,7 @@ public sealed class DxReportViewer : ComponentBase
 
         builder.OpenElement(seq, "nav");
         builder.AddAttribute(seq + 1, "class", "dx-report-export");
-        builder.AddAttribute(seq + 2, "aria-label", "Export this report");
+        builder.AddAttribute(seq + 2, "aria-label", S["ExportReport", "Export this report"]);
 
         if (pdf is not null)
         {

--- a/src/BlazorDX.Integrations.Reporting/DxReportViewer.resx
+++ b/src/BlazorDX.Integrations.Reporting/DxReportViewer.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="EmptyOutput" xml:space="preserve">
+    <value>Choose parameters and run the report to see results here.</value>
+  </data>
+  <data name="ExportReport" xml:space="preserve">
+    <value>Export this report</value>
+  </data>
+  <data name="ReportOutput" xml:space="preserve">
+    <value>{0} output</value>
+  </data>
+  <data name="ReportParameters" xml:space="preserve">
+    <value>Report parameters</value>
+  </data>
+  <data name="RunReport" xml:space="preserve">
+    <value>Run report</value>
+  </data>
+</root>

--- a/src/BlazorDX.Primitives/BlazorDX.Primitives.csproj
+++ b/src/BlazorDX.Primitives/BlazorDX.Primitives.csproj
@@ -50,4 +50,15 @@
     <InternalsVisibleTo Include="BlazorDX.Components.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- One definition, compiled into each package. See the header comment in the file for why
+         this is shared source rather than a shared (thirteenth) package. -->
+    <Compile Include="..\Shared\DxStrings.cs" Link="DxStrings.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Needed by the linked DxStrings.cs. -->
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+  </ItemGroup>
+
 </Project>

--- a/src/BlazorDX.Primitives/ComboBoxPrimitiveResources.resx
+++ b/src/BlazorDX.Primitives/ComboBoxPrimitiveResources.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ComboBoxPlaceholder" xml:space="preserve">
+    <value>Type to search...</value>
+  </data>
+</root>

--- a/src/BlazorDX.Primitives/CommandPalettePrimitive.resx
+++ b/src/BlazorDX.Primitives/CommandPalettePrimitive.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CommandPalettePlaceholder" xml:space="preserve">
+    <value>Type a command...</value>
+  </data>
+</root>

--- a/src/BlazorDX.Primitives/DatePickerPrimitive.resx
+++ b/src/BlazorDX.Primitives/DatePickerPrimitive.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DatePickerPlaceholder" xml:space="preserve">
+    <value>Select a date</value>
+  </data>
+</root>

--- a/src/BlazorDX.Primitives/Inputs/DatePickerPrimitive.cs
+++ b/src/BlazorDX.Primitives/Inputs/DatePickerPrimitive.cs
@@ -25,7 +25,19 @@ public class DatePickerPrimitive : ComponentBase, IAsyncDisposable
     // Nullable to match Value, so @bind-Value works with a DateOnly? field.
     [Parameter] public EventCallback<DateOnly?> ValueChanged { get; set; }
 
-    [Parameter] public string Placeholder { get; set; } = "Select a date";
+    [Parameter] public string? Placeholder { get; set; }
+
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DatePickerPrimitive>? s;
+
+    private DxStrings<DatePickerPrimitive> S => s ??= new(Services);
+
+    /// <summary>
+    /// <see cref="Placeholder"/> if the consumer supplied one, otherwise the localized default.
+    /// </summary>
+    protected string ResolvedPlaceholder => Placeholder ?? S["DatePickerPlaceholder", "Select a date"];
+
 
     [Parameter] public string Side { get; set; } = "bottom";
 
@@ -56,7 +68,7 @@ public class DatePickerPrimitive : ComponentBase, IAsyncDisposable
 
     private CultureInfo Fmt => Culture ?? CultureInfo.CurrentCulture;
 
-    protected string DisplayText => Value?.ToString("d", Fmt) ?? Placeholder;
+    protected string DisplayText => Value?.ToString("d", Fmt) ?? ResolvedPlaceholder;
 
     protected string MonthLabel => viewMonth.ToString("MMMM yyyy", Fmt);
 

--- a/src/BlazorDX.Primitives/Overlays/ComboBoxPrimitive.cs
+++ b/src/BlazorDX.Primitives/Overlays/ComboBoxPrimitive.cs
@@ -28,7 +28,22 @@ public class ComboBoxPrimitive<TValue> : ComponentBase, IAsyncDisposable
 
     [Parameter] public EventCallback<TValue> ValueChanged { get; set; }
 
-    [Parameter] public string Placeholder { get; set; } = "Type to search...";
+    [Parameter] public string? Placeholder { get; set; }
+
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    // ComboBoxPrimitiveResources, not ComboBoxPrimitive<TValue>: the default factory derives the resource name from the
+    // closed generic type, so localizing against the primitive would look for a different
+    // resource per TValue. See docs/localization.md.
+    private DxStrings<ComboBoxPrimitiveResources>? s;
+
+    private DxStrings<ComboBoxPrimitiveResources> S => s ??= new(Services);
+
+    /// <summary>
+    /// <see cref="Placeholder"/> if the consumer supplied one, otherwise the localized default.
+    /// </summary>
+    protected string ResolvedPlaceholder => Placeholder ?? S["ComboBoxPlaceholder", "Type to search..."];
+
 
     [Parameter] public string Side { get; set; } = "bottom";
 
@@ -214,3 +229,10 @@ public class ComboBoxPrimitive<TValue> : ComponentBase, IAsyncDisposable
         }
     }
 }
+
+/// <summary>
+/// Resource-name anchor for <see cref="ComboBoxPrimitive{TValue}"/>, which is generic: the default localizer
+/// factory derives a resource name from the <i>closed</i> type, so localizing against the
+/// primitive itself would look for a different resource per type argument.
+/// </summary>
+public sealed class ComboBoxPrimitiveResources;

--- a/src/BlazorDX.Primitives/Overlays/CommandPalettePrimitive.cs
+++ b/src/BlazorDX.Primitives/Overlays/CommandPalettePrimitive.cs
@@ -30,7 +30,19 @@ public class CommandPalettePrimitive : ComponentBase, IAsyncDisposable
 
     [Parameter] public EventCallback<bool> OpenChanged { get; set; }
 
-    [Parameter] public string Placeholder { get; set; } = "Type a command...";
+    [Parameter] public string? Placeholder { get; set; }
+
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<CommandPalettePrimitive>? s;
+
+    private DxStrings<CommandPalettePrimitive> S => s ??= new(Services);
+
+    /// <summary>
+    /// <see cref="Placeholder"/> if the consumer supplied one, otherwise the localized default.
+    /// </summary>
+    protected string ResolvedPlaceholder => Placeholder ?? S["CommandPalettePlaceholder", "Type a command..."];
+
 
     [Parameter] public int ExitDurationMs { get; set; } = 150;
 

--- a/src/BlazorDX.Primitives/Overlays/SelectPrimitive.cs
+++ b/src/BlazorDX.Primitives/Overlays/SelectPrimitive.cs
@@ -27,7 +27,22 @@ public class SelectPrimitive<TValue> : ComponentBase, IAsyncDisposable
 
     [Parameter] public EventCallback<TValue> ValueChanged { get; set; }
 
-    [Parameter] public string Placeholder { get; set; } = "Select...";
+    [Parameter] public string? Placeholder { get; set; }
+
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    // SelectPrimitiveResources, not SelectPrimitive<TValue>: the default factory derives the resource name from the
+    // closed generic type, so localizing against the primitive would look for a different
+    // resource per TValue. See docs/localization.md.
+    private DxStrings<SelectPrimitiveResources>? s;
+
+    private DxStrings<SelectPrimitiveResources> S => s ??= new(Services);
+
+    /// <summary>
+    /// <see cref="Placeholder"/> if the consumer supplied one, otherwise the localized default.
+    /// </summary>
+    protected string ResolvedPlaceholder => Placeholder ?? S["SelectPlaceholder", "Select..."];
+
 
     [Parameter] public string Side { get; set; } = "bottom";
 
@@ -54,7 +69,7 @@ public class SelectPrimitive<TValue> : ComponentBase, IAsyncDisposable
         get
         {
             int index = SelectedIndex();
-            return index >= 0 ? Items[index].Text : Placeholder;
+            return index >= 0 ? Items[index].Text : ResolvedPlaceholder;
         }
     }
 
@@ -236,3 +251,10 @@ public class SelectPrimitive<TValue> : ComponentBase, IAsyncDisposable
         }
     }
 }
+
+/// <summary>
+/// Resource-name anchor for <see cref="SelectPrimitive{TValue}"/>, which is generic: the default localizer
+/// factory derives a resource name from the <i>closed</i> type, so localizing against the
+/// primitive itself would look for a different resource per type argument.
+/// </summary>
+public sealed class SelectPrimitiveResources;

--- a/src/BlazorDX.Primitives/SelectPrimitiveResources.resx
+++ b/src/BlazorDX.Primitives/SelectPrimitiveResources.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SelectPlaceholder" xml:space="preserve">
+    <value>Select...</value>
+  </data>
+</root>

--- a/src/Shared/DxStrings.cs
+++ b/src/Shared/DxStrings.cs
@@ -2,7 +2,20 @@ using System.Globalization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 
-namespace BlazorDX.Components;
+namespace BlazorDX;
+
+// Shared source, not a shared package. This file is linked into BlazorDX.Components,
+// .Primitives, .Htmx, .Integrations.PowerBI and .Integrations.Reporting, so each assembly
+// compiles its own internal copy from one definition.
+//
+// A thirteenth published package was the obvious alternative and was rejected:
+// BlazorDX.Integrations.PowerBI deliberately references no BlazorDX project at all, and the
+// other integration packages reference only what they need. Making every package take a
+// dependency to reach a forty-line helper would trade that independence for nothing — the type
+// is internal, so there is no public surface to share in the first place.
+//
+// Namespace BlazorDX rather than BlazorDX.Components, so every consuming namespace resolves it
+// without a using: they are all BlazorDX.*.
 
 /// <summary>
 /// Per-component localized-string lookup where localization is <b>optional</b>: every call site

--- a/tests/BlazorDX.Analyzers.Tests/AnalyzerTestHarness.cs
+++ b/tests/BlazorDX.Analyzers.Tests/AnalyzerTestHarness.cs
@@ -15,15 +15,8 @@ internal static class AnalyzerTestHarness
 {
     private static readonly MetadataReference[] References = LoadFrameworkReferences();
 
-    /// <param name="assemblyName">
-    /// Defaults to <c>BlazorDX.Components</c> because <c>HardcodedStringAnalyzer</c> only reports
-    /// there — <c>DxStrings</c> exists in no other assembly, so the fix DX1003 suggests cannot be
-    /// written elsewhere. Under the old default every DX1003 test would pass by reporting
-    /// nothing, which is exactly the failure mode a scoped analyzer invites. Pass a different
-    /// name to test the scoping itself.
-    /// </param>
     public static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(
-        string source, DiagnosticAnalyzer analyzer, string assemblyName = "BlazorDX.Components")
+        string source, DiagnosticAnalyzer analyzer, string assemblyName = "AnalyzerTestAssembly")
     {
         SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
         CSharpCompilation compilation = CSharpCompilation.Create(

--- a/tests/BlazorDX.Analyzers.Tests/GovernanceAnalyzerTests.cs
+++ b/tests/BlazorDX.Analyzers.Tests/GovernanceAnalyzerTests.cs
@@ -250,4 +250,32 @@ public sealed class GovernanceAnalyzerTests
 
         Assert.Contains(diagnostics, d => d.Id == "DX1003");
     }
+
+    [Fact]
+    public async Task DX1003_stays_silent_in_a_test_project()
+    {
+        // The rule governs text a user reads in the product. A test building a render tree out of
+        // fixture strings is writing its own inputs -- routing those through a localizer would
+        // mean translating test data. Widening the rule beyond BlazorDX.Components turned every
+        // such fixture into a build error until this exclusion existed.
+        string source = $$"""
+            {{LocalizationPreamble}}
+
+            namespace Test
+            {
+                using Microsoft.AspNetCore.Components.Rendering;
+
+                public sealed class SomeComponentTests
+                {
+                    public void Render(RenderTreeBuilder builder) =>
+                        builder.AddContent(1, "Alpha body");
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(
+            source, new HardcodedStringAnalyzer(), assemblyName: "BlazorDX.Components.Tests");
+
+        Assert.Empty(diagnostics.Where(d => d.Id == "DX1003"));
+    }
 }

--- a/tests/BlazorDX.Analyzers.Tests/GovernanceAnalyzerTests.cs
+++ b/tests/BlazorDX.Analyzers.Tests/GovernanceAnalyzerTests.cs
@@ -250,36 +250,4 @@ public sealed class GovernanceAnalyzerTests
 
         Assert.Contains(diagnostics, d => d.Id == "DX1003");
     }
-
-    [Fact]
-    public async Task DX1003_stays_silent_outside_the_assembly_that_has_DxStrings()
-    {
-        // DxStrings lives in BlazorDX.Components and nowhere else, so in BlazorDX.Primitives,
-        // BlazorDX.Htmx or the integration packages this diagnostic would demand a fix that
-        // cannot be written. Reporting there would be the same trap the defaulted-[Parameter]
-        // rule fell into — a correct observation with an impossible remedy.
-        //
-        // Widening it is a packaging decision (where should the helper live so every package can
-        // reach it), not an analyzer change, and until that is made the rule stays where its
-        // advice holds.
-        string source = $$"""
-            {{LocalizationPreamble}}
-
-            namespace Test
-            {
-                using Microsoft.AspNetCore.Components.Rendering;
-
-                public sealed class SomePrimitive
-                {
-                    public void Render(RenderTreeBuilder builder) =>
-                        builder.AddAttribute(1, "placeholder", "Select a date");
-                }
-            }
-            """;
-
-        var diagnostics = await AnalyzerTestHarness.AnalyzeAsync(
-            source, new HardcodedStringAnalyzer(), assemblyName: "BlazorDX.Primitives");
-
-        Assert.Empty(diagnostics.Where(d => d.Id == "DX1003"));
-    }
 }

--- a/tests/BlazorDX.Components.Tests/LocalizedStringConsistencyTests.cs
+++ b/tests/BlazorDX.Components.Tests/LocalizedStringConsistencyTests.cs
@@ -65,8 +65,13 @@ public sealed class LocalizedStringConsistencyTests
             // test's own guidance in docs and in component doc comments — otherwise reads as a
             // real call site, and the orphan check then demands a resource entry named "Key".
             string source = StripComments(File.ReadAllText(component));
-            string resourceName = ResourceType.Match(source).Groups[1].Value;
-            string resx = Path.Combine(ComponentsDirectory(), $"{resourceName}.resx");
+            string resourceName = ResourceNameFor(component, source);
+
+            // The .resx sits at the root of the component's OWN project, which is no longer
+            // always BlazorDX.Components: Primitives, Htmx and the two Integrations packages
+            // localize too, each with its own resources.
+            string project = ProjectOf(component);
+            string resx = Path.Combine(project, $"{resourceName}.resx");
 
             if (!File.Exists(resx))
             {
@@ -77,9 +82,11 @@ public sealed class LocalizedStringConsistencyTests
             }
 
             Dictionary<string, string> resources = ReadResources(resx);
-            HashSet<string> used = usedByResource.TryGetValue(resourceName, out HashSet<string>? seen)
+            // Keyed by the resx path, not the bare name: two packages may each define a
+            // resource with the same short name without sharing anything.
+            HashSet<string> used = usedByResource.TryGetValue(resx, out HashSet<string>? seen)
                 ? seen
-                : usedByResource[resourceName] = [];
+                : usedByResource[resx] = [];
 
             foreach (Match site in CallSite.Matches(source))
             {
@@ -106,12 +113,11 @@ public sealed class LocalizedStringConsistencyTests
         }
 
         // Orphans, once every component has been read.
-        foreach ((string resourceName, HashSet<string> used) in usedByResource)
+        foreach ((string resx, HashSet<string> used) in usedByResource)
         {
-            string resx = Path.Combine(ComponentsDirectory(), $"{resourceName}.resx");
             foreach (string orphan in ReadResources(resx).Keys.Where(k => !used.Contains(k)).OrderBy(k => k))
             {
-                problems.Add($"{resourceName}.resx[\"{orphan}\"] is not used by any call site — "
+                problems.Add($"{Path.GetFileName(resx)}[\"{orphan}\"] is not used by any call site — "
                     + "the string moved or was removed, and translators are still maintaining it.");
             }
         }
@@ -192,19 +198,57 @@ public sealed class LocalizedStringConsistencyTests
                 data => data.Element("value")?.Value ?? string.Empty,
                 StringComparer.Ordinal);
 
-    // AllDirectories, not TopDirectoryOnly: components may live in subfolders as the rollout
-    // proceeds, and a silently-skipped component is exactly the drift this test exists to catch.
-    // The .resx files themselves stay at the project root regardless — that placement is the
-    // configuration that works (docs/localization.md).
+    /// <summary>
+    /// The resource a file localizes against — its own <c>DxStrings&lt;T&gt;</c> declaration, or,
+    /// for a partial split out into <c>Type.Part.cs</c>, the declaration in <c>Type.cs</c>.
+    /// </summary>
+    /// <remarks>
+    /// Partials matter here: <c>DxWordEditor.Find.cs</c> and <c>DxSpreadsheetViewer.Editing.cs</c>
+    /// use <c>S[...]</c> but declare no field, because the type declares it once in its main file.
+    /// Scanning only declaring files left their call sites unchecked <i>and</i> reported the keys
+    /// they use as orphaned — a guard failing in both directions at once.
+    /// </remarks>
+    private static string ResourceNameFor(string file, string strippedSource)
+    {
+        Match own = ResourceType.Match(strippedSource);
+        if (own.Success)
+        {
+            return own.Groups[1].Value;
+        }
+
+        string name = Path.GetFileNameWithoutExtension(file);
+        string declaring = Path.Combine(
+            Path.GetDirectoryName(file)!, name[..name.IndexOf('.', StringComparison.Ordinal)] + ".cs");
+
+        return File.Exists(declaring)
+            ? ResourceType.Match(StripComments(File.ReadAllText(declaring))).Groups[1].Value
+            : string.Empty;
+    }
+
+    /// <summary>The <c>src/&lt;project&gt;</c> directory a source file belongs to.</summary>
+    private static string ProjectOf(string file)
+    {
+        string src = Path.Combine(RepositoryRoot(), "src");
+        string relative = Path.GetRelativePath(src, file);
+        return Path.Combine(src, relative.Split(Path.DirectorySeparatorChar)[0]);
+    }
+
+    // Every project under src/, all directories: components live in subfolders (Primitives puts
+    // them under Inputs/ and Overlays/), and a silently-skipped one is exactly the drift this test
+    // exists to catch. Each project's .resx files stay at that project's root — the placement that
+    // makes the default localizer factory work at all (docs/localization.md).
     private static IEnumerable<string> LocalizedComponents() =>
-        Directory.EnumerateFiles(ComponentsDirectory(), "*.cs", SearchOption.AllDirectories)
+        Directory.EnumerateFiles(Path.Combine(RepositoryRoot(), "src"), "*.cs", SearchOption.AllDirectories)
             .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
             .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            // The helper itself (src/Shared/DxStrings.cs, linked into every package) defines the
+            // pattern rather than using it; scanning it would look for resources that do not exist.
             .Where(path => Path.GetFileName(path) != "DxStrings.cs")
-            .Where(path => ResourceType.IsMatch(File.ReadAllText(path)));
+            // Either declares the localizer, or uses it — the second covers partial files, which
+            // declare nothing but still hold call sites (see ResourceNameFor).
+            .Where(path => ResourceType.IsMatch(File.ReadAllText(path))
+                || CallSite.IsMatch(StripComments(File.ReadAllText(path))));
 
-    private static string ComponentsDirectory() =>
-        Path.Combine(RepositoryRoot(), "src", "BlazorDX.Components");
 
     private static string RepositoryRoot()
     {


### PR DESCRIPTION
**38 strings across five packages** no earlier scan had looked at — `BlazorDX.Documents` (21), `.Htmx` (8), `.Integrations.Reporting` (5), `.Primitives` (4), `.Integrations.PowerBI` (2). DX1003's assembly scoping goes with them.

## ADR 0016 scoped the whole effort on a false premise

It recorded *"zero in `src/BlazorDX.Primitives` — primitives are unlabeled by design"*. Four Tier-1 placeholder defaults live there — `"Select a date"`, `"Type to search..."`, `"Type a command..."`, `"Select..."` — and they reach the DOM through the styled tier. A French app rendered "Select a date" whatever its culture.

Each primitive now resolves its own placeholder through the localizer and the styled tier reads the resolved value. Removing the defaults instead would have been the more literal reading of ADR 0001, but it changes behaviour for Tier-1 consumers — who are exactly the people that ADR says own their own labels.

**`BlazorDX.Documents` was invisible for the same reason** and is the largest share: the Word editor's find/replace panel, its status line, the spreadsheet viewer's worksheet labels.

## Shared source, not a shared package

`DxStrings` moves to `src/Shared/DxStrings.cs` and is `<Compile Include>`-linked into each package, so every assembly compiles its own `internal` copy from one definition.

A thirteenth published package was the obvious alternative and was rejected: **`BlazorDX.Integrations.PowerBI` deliberately references no BlazorDX project at all**, and the type is `internal`, so there is no public surface to share. Taking a dependency to reach a forty-line helper would trade that independence for nothing. Each package adds only the `Microsoft.Extensions.Localization` reference the helper needs.

Namespace `BlazorDX` rather than `BlazorDX.Components`, so every consuming namespace resolves it without a `using`.

## Two gaps in the checking tools

- **`LocalizedStringConsistencyTests` only scanned files that *declare* a `DxStrings` field.** Partial files that merely use `S[...]` — `DxWordEditor.Find.cs`, `DxSpreadsheetViewer.Editing.cs` — went unchecked *and* had the keys they use reported as orphaned. A guard failing in both directions at once. It now resolves a partial's resource from its main file.
- The `.resx` now lives at each component's **own** project root, so the test derives the project per file instead of assuming `BlazorDX.Components`.

The two error classes the preflight already knew about turned up three more times (a duplicate `IServiceProvider` injection, two generic primitives localizing against themselves) — caught locally this time rather than in CI.

## Verification

Across every `src` project: **88 localized types, 62 resource files, 309 call sites checked, 0 inconsistencies, 0 preflight problems.** `BlazorDX.Analyzers` builds with 0 warnings.

This still externalizes strings rather than translating them — only two resource files have a French counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
