### PR TITLE
Translate every string into French

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -106,10 +106,13 @@ enhancements. None of this should be read as "ready"; it is a beta with work ahe
   `Integrations` packages — 309 call sites across
   62 resource files — and DX1003's ratchet is retired, so a hardcoded label is a build error
   anywhere, not just in components that already localize. (The "~130 components" figure here
-  previously counted every file; 57 have no user-facing text at all.) *Remaining: this externalizes the strings, it
-  does not translate them — the `.resx` files hold English, and
-  only two carry a French counterpart. Shipping translations, and a visual RTL pass that a
-  static guard cannot do, are the parts left.*
+  previously counted every file; 57 have no user-facing text at all.) **Shipped in English and French**: 65
+  resource files, 65 French counterparts, 291 strings, with tests holding the two in step on
+  the things a translation must not change — a missing key (falls back to English silently), a
+  dropped placeholder (still fluent, says nothing), and load-bearing edge whitespace — plus a
+  rendering test that the satellite assemblies are actually built and found, which a file check
+  cannot tell you. *Remaining: further languages, and a visual RTL pass a static guard cannot
+  do.*
 - **Formal accessibility audit + VPAT** — automated **axe-core checks run in CI**
   (`AccessibilityE2ETests`, across Chromium/Firefox/WebKit) over **every route in the
   showcase and the TicketDesk demo app**, with zero serious/critical violations.

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -246,7 +246,58 @@ Flip the showcase with `?dir=rtl` on any route to check the result by eye.
 
 ---
 
-## 3. What is left
+## 3. Translations
+
+Every string ships in **English and French**: 65 invariant `.resx` files, 65 `.fr.resx`
+counterparts, 291 strings.
+
+`TranslationCompletenessTests` holds the two in step. It checks the three things a translation
+must not change, all of which fail invisibly:
+
+- **A missing key** falls back to English. Nothing looks broken; a French user just gets one
+  English string among the rest.
+- **A dropped placeholder** is worse. "Graphique en secteurs avec {0} parts" without its `{0}`
+  is still fluent French and says nothing — and a screen-reader user hears a chart described
+  with no numbers in it. Format specifiers count too: losing `:N0` loses the thousands
+  separators that make a large count readable.
+- **Edge whitespace**, because several strings are sentence fragments joined to a link in
+  markup. `"Le PDF ne s'affiche pas ? "` needs its trailing space.
+
+It deliberately does *not* require French and English to differ. They legitimately coincide for
+*Message*, *Documents*, *Actions*, *Options*, *Pagination*, *Total*, *Normal*, *Style*,
+*Saturation* and *Document*; a rule demanding a difference would only invite someone to invent
+one.
+
+`FrenchRenderingTests` covers what a file check cannot: that the satellite assemblies are built
+and found. Without it the resources could line up perfectly and still render in English. It
+also pins the fallback chain by rendering under `de-DE` — an unshipped language — and asserting
+the **English** word rather than the absence of French, because a broken lookup returns the
+*key*, and a key like `Loading` looks almost right.
+
+### Conventions
+
+- Placeholders are preserved exactly, specifiers included.
+- Glyphs travel with their word (`⭳ Télécharger`, `← Précédent`) so a language can move the
+  arrow.
+- French spacing: a no-break space before `:` and inside `« »`, so it cannot wrap away from the
+  word it belongs to.
+- Keyboard names follow the French convention — `Maj`, `Échap`, `Suppr`, `Entrée`,
+  `Retour arrière` — and the rich-text mnemonics follow the French word, so Bold's cap is **G**
+  for *Gras*, not **B**.
+- Product and format names are not translated: Power BI, PDF, CSV, Excel, Markdown, QR,
+  EAN-13, Code 128, `.docx`, Sankey.
+
+### Adding another language
+
+Copy the `.fr.resx` files to `.<culture>.resx`, translate the values, and the two tests above
+start covering it — `TranslationCompletenessTests` currently checks French specifically, so
+widen its counterpart lookup at the same time. Nothing else needs to change: the resource
+lookup, the fallback chain and the AOT satellite-assembly path are all culture-agnostic
+already.
+
+---
+
+## 4. What is left
 
 Measured, not estimated. (The roadmap previously said "~130 components"; that counted every
 file rather than the ones with user-facing text.)

--- a/src/BlazorDX.Components/DxBarcode.fr.resx
+++ b/src/BlazorDX.Components/DxBarcode.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="CannotEncodeAsCode" xml:space="preserve">
+    <value>Impossible d’encoder en Code 128 : « {0} »</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="CodeBarcode" xml:space="preserve">
+    <value>Code-barres Code 128 : {0}</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxBreadcrumbs.fr.resx
+++ b/src/BlazorDX.Components/DxBreadcrumbs.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="BreadcrumbLabel" xml:space="preserve">
+    <value>Fil d’Ariane</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxCalendar.fr.resx
+++ b/src/BlazorDX.Components/DxCalendar.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="CalendarLabel" xml:space="preserve">
+    <value>Calendrier</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxCarousel.fr.resx
+++ b/src/BlazorDX.Components/DxCarousel.fr.resx
@@ -30,10 +30,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="Carousel" xml:space="preserve">
+    <value>carrousel</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="CarouselLabel" xml:space="preserve">
+    <value>Carrousel</value>
+  </data>
+  <data name="GoToSlide" xml:space="preserve">
+    <value>Aller à la diapositive {0}</value>
+  </data>
+  <data name="Slide" xml:space="preserve">
+    <value>diapositive</value>
+  </data>
+  <data name="SlidePosition" xml:space="preserve">
+    <value>{0} sur {1}</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxChartResources.fr.resx
+++ b/src/BlazorDX.Components/DxChartResources.fr.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BarChartLabel" xml:space="preserve">
+    <value>Graphique à barres avec {0} catégories</value>
+  </data>
+  <data name="BoxPlotLabel" xml:space="preserve">
+    <value>Boîte à moustaches avec {0} groupes</value>
+  </data>
+  <data name="BoxPlotPointLabel" xml:space="preserve">
+    <value>{0} : médiane {1}, Q1 {2}, Q3 {3}, étendue {4}–{5}</value>
+  </data>
+  <data name="BulletChartLabel" xml:space="preserve">
+    <value>Graphique à puces avec {0} indicateurs</value>
+  </data>
+  <data name="CandlestickChartLabel" xml:space="preserve">
+    <value>Graphique en chandeliers avec {0} chandeliers</value>
+  </data>
+  <data name="ChordDiagramLabel" xml:space="preserve">
+    <value>Diagramme en accords avec {0} nœuds et {1} flux</value>
+  </data>
+  <data name="FunnelChartLabel" xml:space="preserve">
+    <value>Graphique en entonnoir avec {0} étapes</value>
+  </data>
+  <data name="GanttTaskLabel" xml:space="preserve">
+    <value>{0}, du {1} au {2}, {3:0} % terminé</value>
+  </data>
+  <data name="GanttTaskRole" xml:space="preserve">
+    <value>Tâche</value>
+  </data>
+  <data name="GroupedBarChartLabel" xml:space="preserve">
+    <value>Graphique à barres groupées, {0} séries sur {1} catégories</value>
+  </data>
+  <data name="HeatmapLabel" xml:space="preserve">
+    <value>Carte de chaleur avec {0} lignes et {1} colonnes</value>
+  </data>
+  <data name="HistogramCaption" xml:space="preserve">
+    <value>{0:N0} valeurs · {1} classes · étendue {2}–{3} · {4}</value>
+  </data>
+  <data name="HistogramLabel" xml:space="preserve">
+    <value>Histogramme avec {0} classes</value>
+  </data>
+  <data name="NetworkGraphLabel" xml:space="preserve">
+    <value>Graphe de réseau avec {0} nœuds et {1} liens</value>
+  </data>
+  <data name="ParallelCoordinatesLabel" xml:space="preserve">
+    <value>Graphique en coordonnées parallèles de {0} lignes sur {1} axes</value>
+  </data>
+  <data name="PieChartLabel" xml:space="preserve">
+    <value>Graphique en secteurs avec {0} parts</value>
+  </data>
+  <data name="PointsCaption" xml:space="preserve">
+    <value>{0:N0} points sur {1:N0} · {2}</value>
+  </data>
+  <data name="RadarChartLabel" xml:space="preserve">
+    <value>Graphique radar de {0} séries sur {1} axes</value>
+  </data>
+  <data name="ResetZoom" xml:space="preserve">
+    <value>Réinitialiser le zoom</value>
+  </data>
+  <data name="SankeyChartLabel" xml:space="preserve">
+    <value>Diagramme de Sankey avec {0} nœuds et {1} flux</value>
+  </data>
+  <data name="SparklineLabel" xml:space="preserve">
+    <value>Graphique sparkline de {0} points</value>
+  </data>
+  <data name="StackedBarChartLabel" xml:space="preserve">
+    <value>Graphique à barres empilées, {0} séries sur {1} catégories</value>
+  </data>
+  <data name="SunburstLabel" xml:space="preserve">
+    <value>Graphique en anneaux avec {0} segments</value>
+  </data>
+  <data name="TreemapLabel" xml:space="preserve">
+    <value>Carte proportionnelle avec {0} cellules</value>
+  </data>
+  <data name="WaterfallChartLabel" xml:space="preserve">
+    <value>Graphique en cascade avec {0} barres</value>
+  </data>
+  <data name="WordCloudLabel" xml:space="preserve">
+    <value>Nuage de mots : {0} mots placés sur {1}</value>
+  </data>
+  <data name="ZoomStatus" xml:space="preserve">
+    <value>Zoom sur {0}–{1} de {2}–{3}</value>
+  </data>
+  <data name="ZoomStatusPoint" xml:space="preserve">
+    <value>Zoom sur le point {0}–{1} de {2}–{3}</value>
+  </data>
+  <data name="ZoomStatusXY" xml:space="preserve">
+    <value>Zoom sur X {0}–{1}, Y {2}–{3}</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxChat.fr.resx
+++ b/src/BlazorDX.Components/DxChat.fr.resx
@@ -30,10 +30,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="AssistantTyping" xml:space="preserve">
+    <value>L’assistant est en train d’écrire</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="ComposerPlaceholder" xml:space="preserve">
+    <value>Envoyer un message…  (Ctrl+Entrée)</value>
+  </data>
+  <data name="Message" xml:space="preserve">
+    <value>Message</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Envoyer</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxChip.fr.resx
+++ b/src/BlazorDX.Components/DxChip.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Remove" xml:space="preserve">
+    <value>Supprimer</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxColorPicker.fr.resx
+++ b/src/BlazorDX.Components/DxColorPicker.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Use" xml:space="preserve">
+    <value>Utiliser {0}</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxComboBoxResources.fr.resx
+++ b/src/BlazorDX.Components/DxComboBoxResources.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="NoMatches" xml:space="preserve">
+    <value>Aucun résultat</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxCommandPalette.fr.resx
+++ b/src/BlazorDX.Components/DxCommandPalette.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="CommandPalette" xml:space="preserve">
+    <value>Palette de commandes</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="NoCommands" xml:space="preserve">
+    <value>Aucune commande</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxDatePicker.cs
+++ b/src/BlazorDX.Components/DxDatePicker.cs
@@ -46,7 +46,10 @@ public sealed class DxDatePicker : DatePickerPrimitive
         builder.OpenElement(14, "span");
         builder.AddAttribute(15, "class", "dx-date-icon");
         builder.AddAttribute(16, "aria-hidden", "true");
-        builder.AddContent(17, S["UFC", "\U0001F4C5"]);
+        // A calendar glyph carries no language, and it is aria-hidden besides. The automated pass
+        // wrapped it by mistake: it tests the source literal for letters, and the escape sequence
+        // "\U0001F4C5" is full of them — which is also where the nonsense key "UFC" came from.
+        builder.AddContent(17, "\U0001F4C5");
         builder.CloseElement();
 
         builder.CloseElement();

--- a/src/BlazorDX.Components/DxDatePicker.fr.resx
+++ b/src/BlazorDX.Components/DxDatePicker.fr.resx
@@ -31,9 +31,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+    <value>Mois suivant</value>
   </data>
   <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+    <value>Mois précédent</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxDocumentViewer.fr.resx
+++ b/src/BlazorDX.Components/DxDocumentViewer.fr.resx
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DocumentActions" xml:space="preserve">
+    <value>Actions du document</value>
+  </data>
+  <data name="DocumentList" xml:space="preserve">
+    <value>Documents</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Télécharger</value>
+  </data>
+  <data name="DownloadButton" xml:space="preserve">
+    <value>⭳ Télécharger</value>
+  </data>
+  <data name="DownloadNamed" xml:space="preserve">
+    <value>Télécharger {0}</value>
+  </data>
+  <data name="DownloadThePdf" xml:space="preserve">
+    <value>Télécharger le PDF</value>
+  </data>
+  <data name="NoDocument" xml:space="preserve">
+    <value>Aucun document</value>
+  </data>
+  <data name="NoPreview" xml:space="preserve">
+    <value>Aperçu indisponible pour ce type de fichier. </value>
+  </data>
+  <data name="OpenButton" xml:space="preserve">
+    <value>↗ Ouvrir</value>
+  </data>
+  <data name="OpenNamed" xml:space="preserve">
+    <value>Ouvrir {0} dans un nouvel onglet</value>
+  </data>
+  <data name="PdfFallbackPrompt" xml:space="preserve">
+    <value>Le PDF ne s’affiche pas ? </value>
+  </data>
+  <data name="PrintButton" xml:space="preserve">
+    <value>⎙ Imprimer</value>
+  </data>
+  <data name="PrintNamed" xml:space="preserve">
+    <value>Imprimer {0}</value>
+  </data>
+  <data name="SourceUnavailable" xml:space="preserve">
+    <value>Source du document indisponible</value>
+  </data>
+  <data name="ZoomIn" xml:space="preserve">
+    <value>Zoom avant</value>
+  </data>
+  <data name="ZoomOut" xml:space="preserve">
+    <value>Zoom arrière</value>
+  </data>
+  <data name="ZoomReset" xml:space="preserve">
+    <value>Réinitialiser le zoom</value>
+  </data>
+  <data name="ZoomResetGlyph" xml:space="preserve">
+    <value>Réinit.</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxDrawer.fr.resx
+++ b/src/BlazorDX.Components/DxDrawer.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="DrawerLabel" xml:space="preserve">
+    <value>Panneau latéral</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEan13.fr.resx
+++ b/src/BlazorDX.Components/DxEan13.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="EanBarcode" xml:space="preserve">
+    <value>Code-barres EAN-13 {0}</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="InvalidEan" xml:space="preserve">
+    <value>EAN-13 invalide : « {0} »</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEditorialDissipation.fr.resx
+++ b/src/BlazorDX.Components/DxEditorialDissipation.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="DissipationLabel" xml:space="preserve">
+    <value>Une illustration de contenu éphémère qui s’estompe à la fin de la session.</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEditorialFootnoteRef.fr.resx
+++ b/src/BlazorDX.Components/DxEditorialFootnoteRef.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="JumpFootnote" xml:space="preserve">
+    <value>Aller à la note {0}</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEditorialFootnotes.fr.resx
+++ b/src/BlazorDX.Components/DxEditorialFootnotes.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="BackReference" xml:space="preserve">
+    <value>Retour à l’appel de note {0}</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Footnotes" xml:space="preserve">
+    <value>Notes</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEditorialLayout.fr.resx
+++ b/src/BlazorDX.Components/DxEditorialLayout.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="ReadingTime" xml:space="preserve">
+    <value>{0} min de lecture</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEditorialListen.fr.resx
+++ b/src/BlazorDX.Components/DxEditorialListen.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="ListenLabel" xml:space="preserve">
+    <value>Écouter cet article</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEditorialNewsletterSignup.fr.resx
+++ b/src/BlazorDX.Components/DxEditorialNewsletterSignup.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="NewsletterHeading" xml:space="preserve">
+    <value>Recevez d’autres contenus comme celui-ci</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Subscribe" xml:space="preserve">
+    <value>S’abonner</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEditorialRelated.fr.resx
+++ b/src/BlazorDX.Components/DxEditorialRelated.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="RelatedHeading" xml:space="preserve">
+    <value>Plus d’articles Insights</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEditorialSeriesNav.fr.resx
+++ b/src/BlazorDX.Components/DxEditorialSeriesNav.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="SeriesNavigation" xml:space="preserve">
+    <value>Navigation dans la série</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEditorialShareBar.fr.resx
+++ b/src/BlazorDX.Components/DxEditorialShareBar.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="ShareArticle" xml:space="preserve">
+    <value>Partager cet article</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEditorialTableOfContents.fr.resx
+++ b/src/BlazorDX.Components/DxEditorialTableOfContents.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="ContentsHeading" xml:space="preserve">
+    <value>Sommaire</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxEditorialTagList.fr.resx
+++ b/src/BlazorDX.Components/DxEditorialTagList.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Topics" xml:space="preserve">
+    <value>Thèmes</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxErrorBoundary.fr.resx
+++ b/src/BlazorDX.Components/DxErrorBoundary.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="FallbackTitle" xml:space="preserve">
+    <value>Une erreur s’est produite.</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Retry" xml:space="preserve">
+    <value>Réessayer</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxFieldListResources.fr.resx
+++ b/src/BlazorDX.Components/DxFieldListResources.fr.resx
@@ -30,10 +30,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="Add" xml:space="preserve">
+    <value>Ajouter</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="MoveItemDown" xml:space="preserve">
+    <value>Descendre l’élément</value>
+  </data>
+  <data name="MoveItemUp" xml:space="preserve">
+    <value>Monter l’élément</value>
+  </data>
+  <data name="RemoveItem" xml:space="preserve">
+    <value>Supprimer l’élément</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxFileManager.fr.resx
+++ b/src/BlazorDX.Components/DxFileManager.fr.resx
@@ -30,10 +30,46 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="Breadcrumb" xml:space="preserve">
+    <value>Chemin</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Collapse" xml:space="preserve">
+    <value>Réduire</value>
+  </data>
+  <data name="ColumnActions" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+  <data name="ColumnModified" xml:space="preserve">
+    <value>Modifié le</value>
+  </data>
+  <data name="ColumnName" xml:space="preserve">
+    <value>Nom</value>
+  </data>
+  <data name="ColumnSize" xml:space="preserve">
+    <value>Taille</value>
+  </data>
+  <data name="ContentsLabel" xml:space="preserve">
+    <value>Contenu du dossier. Déposez des fichiers ici pour les téléverser.</value>
+  </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Ce dossier est vide. Déposez des fichiers ici ou utilisez Téléverser des fichiers.</value>
+  </data>
+  <data name="Expand" xml:space="preserve">
+    <value>Développer</value>
+  </data>
+  <data name="MoveHere" xml:space="preserve">
+    <value>Déplacer ici</value>
+  </data>
+  <data name="MoveInto" xml:space="preserve">
+    <value>Déplacer {0} dans {1}</value>
+  </data>
+  <data name="MoveToRoot" xml:space="preserve">
+    <value>Déplacer {0} vers Fichiers</value>
+  </data>
+  <data name="RootName" xml:space="preserve">
+    <value>Fichiers</value>
+  </data>
+  <data name="UploadFiles" xml:space="preserve">
+    <value>Téléverser des fichiers</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxFileUpload.fr.resx
+++ b/src/BlazorDX.Components/DxFileUpload.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="DropPrompt" xml:space="preserve">
+    <value>Déposez des fichiers ici ou cliquez pour parcourir</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Remove" xml:space="preserve">
+    <value>Supprimer {0}</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxFormBody.fr.resx
+++ b/src/BlazorDX.Components/DxFormBody.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Submit" xml:space="preserve">
+    <value>Envoyer</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxImageEditor.fr.resx
+++ b/src/BlazorDX.Components/DxImageEditor.fr.resx
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Brightness" xml:space="preserve">
+    <value>Luminosité</value>
+  </data>
+  <data name="CanvasLabel" xml:space="preserve">
+    <value>Aperçu de l’image modifiée</value>
+  </data>
+  <data name="Contrast" xml:space="preserve">
+    <value>Contraste</value>
+  </data>
+  <data name="DownloadGlyph" xml:space="preserve">
+    <value>⭳ Télécharger</value>
+  </data>
+  <data name="DownloadImage" xml:space="preserve">
+    <value>Télécharger l’image</value>
+  </data>
+  <data name="EmptyState" xml:space="preserve">
+    <value>Ouvrez une image pour commencer</value>
+  </data>
+  <data name="FlipHorizontal" xml:space="preserve">
+    <value>Retourner horizontalement</value>
+  </data>
+  <data name="FlipVertical" xml:space="preserve">
+    <value>Retourner verticalement</value>
+  </data>
+  <data name="Grayscale" xml:space="preserve">
+    <value>Niveaux de gris</value>
+  </data>
+  <data name="Invert" xml:space="preserve">
+    <value>Inverser</value>
+  </data>
+  <data name="OpenImage" xml:space="preserve">
+    <value>Ouvrir une image</value>
+  </data>
+  <data name="ReplaceImage" xml:space="preserve">
+    <value>Remplacer l’image</value>
+  </data>
+  <data name="ResetEdits" xml:space="preserve">
+    <value>Réinitialiser les modifications</value>
+  </data>
+  <data name="ResetGlyph" xml:space="preserve">
+    <value>Réinit.</value>
+  </data>
+  <data name="RotateLeft" xml:space="preserve">
+    <value>Pivoter à gauche</value>
+  </data>
+  <data name="RotateRight" xml:space="preserve">
+    <value>Pivoter à droite</value>
+  </data>
+  <data name="Saturation" xml:space="preserve">
+    <value>Saturation</value>
+  </data>
+  <data name="Sepia" xml:space="preserve">
+    <value>Sépia</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxKbd.fr.resx
+++ b/src/BlazorDX.Components/DxKbd.fr.resx
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ComboJoiner" xml:space="preserve">
+    <value> plus </value>
+  </data>
+  <data name="KeyCapAlt" xml:space="preserve">
+    <value>Alt</value>
+  </data>
+  <data name="KeyCapControl" xml:space="preserve">
+    <value>Ctrl</value>
+  </data>
+  <data name="KeyCapDelete" xml:space="preserve">
+    <value>Suppr</value>
+  </data>
+  <data name="KeyCapEnter" xml:space="preserve">
+    <value>Entrée</value>
+  </data>
+  <data name="KeyCapEscape" xml:space="preserve">
+    <value>Échap</value>
+  </data>
+  <data name="KeyCapShift" xml:space="preserve">
+    <value>Maj</value>
+  </data>
+  <data name="KeyCapSpace" xml:space="preserve">
+    <value>Espace</value>
+  </data>
+  <data name="KeyCapTab" xml:space="preserve">
+    <value>Tab</value>
+  </data>
+  <data name="SpokenAlt" xml:space="preserve">
+    <value>Alt</value>
+  </data>
+  <data name="SpokenBackspace" xml:space="preserve">
+    <value>Retour arrière</value>
+  </data>
+  <data name="SpokenCommand" xml:space="preserve">
+    <value>Commande</value>
+  </data>
+  <data name="SpokenControl" xml:space="preserve">
+    <value>Contrôle</value>
+  </data>
+  <data name="SpokenDownArrow" xml:space="preserve">
+    <value>Flèche bas</value>
+  </data>
+  <data name="SpokenLeftArrow" xml:space="preserve">
+    <value>Flèche gauche</value>
+  </data>
+  <data name="SpokenRightArrow" xml:space="preserve">
+    <value>Flèche droite</value>
+  </data>
+  <data name="SpokenShift" xml:space="preserve">
+    <value>Majuscule</value>
+  </data>
+  <data name="SpokenUpArrow" xml:space="preserve">
+    <value>Flèche haut</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxKeyboardShortcuts.fr.resx
+++ b/src/BlazorDX.Components/DxKeyboardShortcuts.fr.resx
@@ -30,10 +30,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="Close" xml:space="preserve">
+    <value>Fermer</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="NoShortcuts" xml:space="preserve">
+    <value>Aucun raccourci</value>
+  </data>
+  <data name="ShortcutsTitle" xml:space="preserve">
+    <value>Raccourcis clavier</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxListboxResources.fr.resx
+++ b/src/BlazorDX.Components/DxListboxResources.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="ListboxLabel" xml:space="preserve">
+    <value>Options</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxMarkdownEditor.fr.resx
+++ b/src/BlazorDX.Components/DxMarkdownEditor.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="MarkdownSource" xml:space="preserve">
+    <value>Source Markdown</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxPager.fr.resx
+++ b/src/BlazorDX.Components/DxPager.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Pagination" xml:space="preserve">
+    <value>Pagination</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxPivotGridResources.fr.resx
+++ b/src/BlazorDX.Components/DxPivotGridResources.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="PivotCaption" xml:space="preserve">
+    <value>{0} sur {1} · {2}</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Total" xml:space="preserve">
+    <value>Total</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxProgress.fr.resx
+++ b/src/BlazorDX.Components/DxProgress.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="ProgressLabel" xml:space="preserve">
+    <value>Progression</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxQrCode.fr.resx
+++ b/src/BlazorDX.Components/DxQrCode.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="CannotEncodeAsQr" xml:space="preserve">
+    <value>Impossible d’encoder en QR (1–4) : « {0} »</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="QrCode" xml:space="preserve">
+    <value>Code QR : {0}</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxQueryBuilder.fr.resx
+++ b/src/BlazorDX.Components/DxQueryBuilder.fr.resx
@@ -30,10 +30,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="Field" xml:space="preserve">
+    <value>Champ</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Operator" xml:space="preserve">
+    <value>Opérateur</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="Value" xml:space="preserve">
+    <value>Valeur</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxRating.fr.resx
+++ b/src/BlazorDX.Components/DxRating.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Rating" xml:space="preserve">
+    <value>Note : {0} sur {1}</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxRichTextEditor.fr.resx
+++ b/src/BlazorDX.Components/DxRichTextEditor.fr.resx
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BlockStyleHeading1" xml:space="preserve">
+    <value>Titre 1</value>
+  </data>
+  <data name="BlockStyleHeading2" xml:space="preserve">
+    <value>Titre 2</value>
+  </data>
+  <data name="BlockStyleHeading3" xml:space="preserve">
+    <value>Titre 3</value>
+  </data>
+  <data name="BlockStyleNormal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="CellShading" xml:space="preserve">
+    <value>Ombrage de cellule</value>
+  </data>
+  <data name="FontFamily" xml:space="preserve">
+    <value>Police</value>
+  </data>
+  <data name="FontFamilyShort" xml:space="preserve">
+    <value>Police</value>
+  </data>
+  <data name="FontSize" xml:space="preserve">
+    <value>Taille de police</value>
+  </data>
+  <data name="FontSizeShort" xml:space="preserve">
+    <value>Taille</value>
+  </data>
+  <data name="HighlightColor" xml:space="preserve">
+    <value>Couleur de surlignage</value>
+  </data>
+  <data name="LineSpacing" xml:space="preserve">
+    <value>Interligne</value>
+  </data>
+  <data name="LineSpacingShort" xml:space="preserve">
+    <value>Interligne</value>
+  </data>
+  <data name="ParagraphStyle" xml:space="preserve">
+    <value>Style de paragraphe</value>
+  </data>
+  <data name="ParagraphStyleShort" xml:space="preserve">
+    <value>Style</value>
+  </data>
+  <data name="TextColor" xml:space="preserve">
+    <value>Couleur du texte</value>
+  </data>
+  <data name="ToolAlignCenter" xml:space="preserve">
+    <value>Centrer</value>
+  </data>
+  <data name="ToolAlignLeft" xml:space="preserve">
+    <value>Aligner à gauche</value>
+  </data>
+  <data name="ToolAlignRight" xml:space="preserve">
+    <value>Aligner à droite</value>
+  </data>
+  <data name="ToolBold" xml:space="preserve">
+    <value>Gras</value>
+  </data>
+  <data name="ToolBoldGlyph" xml:space="preserve">
+    <value>G</value>
+  </data>
+  <data name="ToolBulletList" xml:space="preserve">
+    <value>Liste à puces</value>
+  </data>
+  <data name="ToolClearFormatting" xml:space="preserve">
+    <value>Effacer la mise en forme</value>
+  </data>
+  <data name="ToolDecreaseIndent" xml:space="preserve">
+    <value>Diminuer le retrait</value>
+  </data>
+  <data name="ToolHeading" xml:space="preserve">
+    <value>Titre</value>
+  </data>
+  <data name="ToolHeadingGlyph" xml:space="preserve">
+    <value>T</value>
+  </data>
+  <data name="ToolIncreaseIndent" xml:space="preserve">
+    <value>Augmenter le retrait</value>
+  </data>
+  <data name="ToolInsertLink" xml:space="preserve">
+    <value>Insérer un lien</value>
+  </data>
+  <data name="ToolItalic" xml:space="preserve">
+    <value>Italique</value>
+  </data>
+  <data name="ToolItalicGlyph" xml:space="preserve">
+    <value>I</value>
+  </data>
+  <data name="ToolJustify" xml:space="preserve">
+    <value>Justifier</value>
+  </data>
+  <data name="ToolNumberedList" xml:space="preserve">
+    <value>Liste numérotée</value>
+  </data>
+  <data name="ToolStrikethrough" xml:space="preserve">
+    <value>Barré</value>
+  </data>
+  <data name="ToolStrikethroughGlyph" xml:space="preserve">
+    <value>B</value>
+  </data>
+  <data name="ToolSubscript" xml:space="preserve">
+    <value>Indice</value>
+  </data>
+  <data name="ToolSuperscript" xml:space="preserve">
+    <value>Exposant</value>
+  </data>
+  <data name="ToolUnderline" xml:space="preserve">
+    <value>Souligné</value>
+  </data>
+  <data name="ToolUnderlineGlyph" xml:space="preserve">
+    <value>S</value>
+  </data>
+  <data name="ToolbarLabel" xml:space="preserve">
+    <value>Mise en forme</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxScheduler.fr.resx
+++ b/src/BlazorDX.Components/DxScheduler.fr.resx
@@ -30,10 +30,49 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CalendarView" xml:space="preserve">
+    <value>Vue du calendrier</value>
+  </data>
+  <data name="GoToToday" xml:space="preserve">
+    <value>Aller à aujourd’hui</value>
+  </data>
+  <data name="GridLabel" xml:space="preserve">
+    <value>Planning {0}</value>
+  </data>
+  <data name="NextDay" xml:space="preserve">
+    <value>Jour suivant</value>
+  </data>
   <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+    <value>Mois suivant</value>
+  </data>
+  <data name="NextWeek" xml:space="preserve">
+    <value>Semaine suivante</value>
+  </data>
+  <data name="PreviousDay" xml:space="preserve">
+    <value>Jour précédent</value>
   </data>
   <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+    <value>Mois précédent</value>
+  </data>
+  <data name="PreviousWeek" xml:space="preserve">
+    <value>Semaine précédente</value>
+  </data>
+  <data name="TimeRange" xml:space="preserve">
+    <value>de {0} à {1}</value>
+  </data>
+  <data name="Today" xml:space="preserve">
+    <value>Aujourd’hui</value>
+  </data>
+  <data name="ViewAnnouncement" xml:space="preserve">
+    <value>Vue {0}, {1}</value>
+  </data>
+  <data name="ViewDay" xml:space="preserve">
+    <value>Jour</value>
+  </data>
+  <data name="ViewMonth" xml:space="preserve">
+    <value>Mois</value>
+  </data>
+  <data name="ViewWeek" xml:space="preserve">
+    <value>Semaine</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxSkipLink.fr.resx
+++ b/src/BlazorDX.Components/DxSkipLink.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="SkipToMainContent" xml:space="preserve">
+    <value>Aller au contenu principal</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxSortableList.fr.resx
+++ b/src/BlazorDX.Components/DxSortableList.fr.resx
@@ -30,10 +30,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="MoveDown" xml:space="preserve">
+    <value>Descendre {0}</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="MoveUp" xml:space="preserve">
+    <value>Monter {0}</value>
+  </data>
+  <data name="PressAltPlusArrow" xml:space="preserve">
+    <value>{0}. Appuyez sur Alt plus les touches fléchées pour réorganiser.</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxSpinner.fr.resx
+++ b/src/BlazorDX.Components/DxSpinner.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Loading" xml:space="preserve">
+    <value>Chargement</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxSplitButton.fr.resx
+++ b/src/BlazorDX.Components/DxSplitButton.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="MoreActions" xml:space="preserve">
+    <value>Plus d’actions</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxStepper.fr.resx
+++ b/src/BlazorDX.Components/DxStepper.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="Back" xml:space="preserve">
+    <value>Précédent</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Next" xml:space="preserve">
+    <value>Suivant</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxTileLayout.fr.resx
+++ b/src/BlazorDX.Components/DxTileLayout.fr.resx
@@ -30,10 +30,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="DragAltArrowReorder" xml:space="preserve">
+    <value>Faites glisser, ou Alt+Flèche, pour réorganiser</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="MoveEarlier" xml:space="preserve">
+    <value>Déplacer {0} vers le début</value>
+  </data>
+  <data name="MoveLater" xml:space="preserve">
+    <value>Déplacer {0} vers la fin</value>
+  </data>
+  <data name="TileReorderHint" xml:space="preserve">
+    <value>{0} — faites glisser ou Alt+Flèche pour réorganiser</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxTimePicker.fr.resx
+++ b/src/BlazorDX.Components/DxTimePicker.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="TimePickerLabel" xml:space="preserve">
+    <value>Heure</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxToastHost.fr.resx
+++ b/src/BlazorDX.Components/DxToastHost.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Dismiss" xml:space="preserve">
+    <value>Ignorer</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxTransferList.fr.resx
+++ b/src/BlazorDX.Components/DxTransferList.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="Available" xml:space="preserve">
+    <value>Disponibles</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Selected" xml:space="preserve">
+    <value>Sélectionnés</value>
   </data>
 </root>

--- a/src/BlazorDX.Components/DxVirtualKeyboard.fr.resx
+++ b/src/BlazorDX.Components/DxVirtualKeyboard.fr.resx
@@ -30,10 +30,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="Backspace" xml:space="preserve">
+    <value>Retour arrière</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="Enter" xml:space="preserve">
+    <value>Entrée</value>
+  </data>
+  <data name="EnterKeyCap" xml:space="preserve">
+    <value>↵ Entrée</value>
+  </data>
+  <data name="ScreenKeyboard" xml:space="preserve">
+    <value>Clavier virtuel</value>
+  </data>
+  <data name="Shift" xml:space="preserve">
+    <value>Maj</value>
+  </data>
+  <data name="ShiftKeyCap" xml:space="preserve">
+    <value>⇧ Maj</value>
+  </data>
+  <data name="Space" xml:space="preserve">
+    <value>Espace</value>
   </data>
 </root>

--- a/src/BlazorDX.Documents/DxSpreadsheetViewer.fr.resx
+++ b/src/BlazorDX.Documents/DxSpreadsheetViewer.fr.resx
@@ -30,10 +30,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="CellContent" xml:space="preserve">
+    <value>Contenu de la cellule {0}</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="SpreadsheetEditing" xml:space="preserve">
+    <value>Modification du classeur</value>
+  </data>
+  <data name="Worksheet" xml:space="preserve">
+    <value>Feuille {0}</value>
+  </data>
+  <data name="WorksheetEditable" xml:space="preserve">
+    <value>Feuille {0}, modifiable</value>
+  </data>
+  <data name="Worksheets" xml:space="preserve">
+    <value>Feuilles</value>
   </data>
 </root>

--- a/src/BlazorDX.Documents/DxWordEditor.fr.resx
+++ b/src/BlazorDX.Documents/DxWordEditor.fr.resx
@@ -30,10 +30,34 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="Document" xml:space="preserve">
+    <value>Document</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="DownloadDocumentAsDocx" xml:space="preserve">
+    <value>Télécharger le document au format .docx</value>
+  </data>
+  <data name="DownloadDocx" xml:space="preserve">
+    <value>Télécharger .docx</value>
+  </data>
+  <data name="Find" xml:space="preserve">
+    <value>Rechercher</value>
+  </data>
+  <data name="FindReplace" xml:space="preserve">
+    <value>Rechercher et remplacer</value>
+  </data>
+  <data name="FindReplace2" xml:space="preserve">
+    <value>Rechercher et remplacer</value>
+  </data>
+  <data name="MatchCase" xml:space="preserve">
+    <value>Respecter la casse</value>
+  </data>
+  <data name="ReplaceWith" xml:space="preserve">
+    <value>Remplacer par</value>
+  </data>
+  <data name="StatsSaved" xml:space="preserve">
+    <value>Toutes les modifications sont enregistrées · {0:N0} mots · {1:N0} caractères · {2:N0} paragraphes</value>
+  </data>
+  <data name="StatsUnsaved" xml:space="preserve">
+    <value>Modifications non enregistrées · {0:N0} mots · {1:N0} caractères · {2:N0} paragraphes</value>
   </data>
 </root>

--- a/src/BlazorDX.Documents/DxWordViewer.fr.resx
+++ b/src/BlazorDX.Documents/DxWordViewer.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="Document" xml:space="preserve">
+    <value>Document</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="NoDocumentDisplay" xml:space="preserve">
+    <value>Aucun document à afficher.</value>
   </data>
 </root>

--- a/src/BlazorDX.Htmx/DxHtmxDocumentViewer.fr.resx
+++ b/src/BlazorDX.Htmx/DxHtmxDocumentViewer.fr.resx
@@ -30,10 +30,28 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="DownloadNamed" xml:space="preserve">
+    <value>Télécharger {0}</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="NextPage" xml:space="preserve">
+    <value>Suivant →</value>
+  </data>
+  <data name="PageOf" xml:space="preserve">
+    <value>Page {0} sur {1} ({2})</value>
+  </data>
+  <data name="Pagination" xml:space="preserve">
+    <value>Pagination</value>
+  </data>
+  <data name="PdfFallbackPrompt" xml:space="preserve">
+    <value>Le PDF ne s’affiche pas ? </value>
+  </data>
+  <data name="PreviousPage" xml:space="preserve">
+    <value>← Précédent</value>
+  </data>
+  <data name="WorksheetNamed" xml:space="preserve">
+    <value>Feuille {0}</value>
+  </data>
+  <data name="Worksheets" xml:space="preserve">
+    <value>Feuilles</value>
   </data>
 </root>

--- a/src/BlazorDX.Integrations.PowerBI/DxPowerBiReport.fr.resx
+++ b/src/BlazorDX.Integrations.PowerBI/DxPowerBiReport.fr.resx
@@ -30,10 +30,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="LoadingReport" xml:space="preserve">
+    <value>Chargement du rapport…</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="ReportLabel" xml:space="preserve">
+    <value>Rapport Power BI</value>
   </data>
 </root>

--- a/src/BlazorDX.Integrations.Reporting/DxReportViewer.fr.resx
+++ b/src/BlazorDX.Integrations.Reporting/DxReportViewer.fr.resx
@@ -30,10 +30,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
+  <data name="EmptyOutput" xml:space="preserve">
+    <value>Choisissez des paramètres et lancez le rapport pour voir les résultats ici.</value>
   </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="ExportReport" xml:space="preserve">
+    <value>Exporter ce rapport</value>
+  </data>
+  <data name="ReportOutput" xml:space="preserve">
+    <value>Résultat de {0}</value>
+  </data>
+  <data name="ReportParameters" xml:space="preserve">
+    <value>Paramètres du rapport</value>
+  </data>
+  <data name="RunReport" xml:space="preserve">
+    <value>Lancer le rapport</value>
   </data>
 </root>

--- a/src/BlazorDX.Primitives/ComboBoxPrimitiveResources.fr.resx
+++ b/src/BlazorDX.Primitives/ComboBoxPrimitiveResources.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="ComboBoxPlaceholder" xml:space="preserve">
+    <value>Saisissez pour rechercher…</value>
   </data>
 </root>

--- a/src/BlazorDX.Primitives/CommandPalettePrimitive.fr.resx
+++ b/src/BlazorDX.Primitives/CommandPalettePrimitive.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="CommandPalettePlaceholder" xml:space="preserve">
+    <value>Saisissez une commande…</value>
   </data>
 </root>

--- a/src/BlazorDX.Primitives/DatePickerPrimitive.fr.resx
+++ b/src/BlazorDX.Primitives/DatePickerPrimitive.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="DatePickerPlaceholder" xml:space="preserve">
+    <value>Sélectionner une date</value>
   </data>
 </root>

--- a/src/BlazorDX.Primitives/SelectPrimitiveResources.fr.resx
+++ b/src/BlazorDX.Primitives/SelectPrimitiveResources.fr.resx
@@ -30,10 +30,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="NextMonth" xml:space="preserve">
-    <value>Next month</value>
-  </data>
-  <data name="PreviousMonth" xml:space="preserve">
-    <value>Previous month</value>
+  <data name="SelectPlaceholder" xml:space="preserve">
+    <value>Sélectionner…</value>
   </data>
 </root>

--- a/tests/BlazorDX.Components.Tests/FrenchRenderingTests.cs
+++ b/tests/BlazorDX.Components.Tests/FrenchRenderingTests.cs
@@ -1,0 +1,97 @@
+using BlazorDX.Components;
+using BlazorDX.Interop;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// Renders components under a French UI culture and asserts the French text.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>TranslationCompletenessTests</c> proves the <c>.fr.resx</c> files line up with the invariant
+/// ones. That is a check on the files, not on the build: it would still pass if the satellite
+/// assemblies were never produced, or produced and never found, in which case every one of these
+/// strings would quietly render in English. This is the test that fails in that case.
+/// </para>
+/// <para>
+/// The components below are chosen to cover the ways a resource can be reached, because they fail
+/// independently: a plain component resource, a shared marker type (<c>DxChartResources</c>), a
+/// composite-format string whose arguments have to survive translation, and a value coalesced from
+/// a nullable parameter.
+/// </para>
+/// </remarks>
+public sealed class FrenchRenderingTests : TestContext
+{
+    public FrenchRenderingTests()
+    {
+        Services.AddLocalization();
+        Services.AddScoped<IChartZoomInterop, NullChartZoomInterop>();
+    }
+
+    [Fact]
+    public void A_plain_component_resource_resolves_in_French()
+    {
+        using CultureScope _ = CultureScope.For("fr-FR");
+
+        IRenderedComponent<DxSpinner> spinner = RenderComponent<DxSpinner>();
+
+        Assert.Equal("Chargement", spinner.Find("[aria-label]").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void A_shared_marker_resource_resolves_in_French()
+    {
+        // DxChartResources is reached through a marker type rather than the component's own name,
+        // so it is packaged and resolved by a different path than DxSpinner's.
+        using CultureScope _ = CultureScope.For("fr-FR");
+
+        IRenderedComponent<DxSparkline> spark = RenderComponent<DxSparkline>(p => p
+            .Add(c => c.Points, [new ChartPoint(X: 1, Y: 1), new ChartPoint(X: 2, Y: 2)]));
+
+        Assert.Contains("Graphique sparkline de 2 points", spark.Markup);
+    }
+
+    [Fact]
+    public void A_composite_format_string_keeps_its_arguments_in_French()
+    {
+        // The failure this catches is a translation that reads correctly and says nothing: drop
+        // the {0} and "Graphique en secteurs avec parts" is still fluent French.
+        using CultureScope _ = CultureScope.For("fr-FR");
+
+        IRenderedComponent<DxPieChart> pie = RenderComponent<DxPieChart>(p => p
+            .Add(c => c.Points, [
+                new ChartPoint(X: 1, Y: 1, Category: "A"),
+                new ChartPoint(X: 2, Y: 2, Category: "B"),
+                new ChartPoint(X: 3, Y: 3, Category: "C"),
+            ]));
+
+        Assert.Contains("Graphique en secteurs avec 3 parts", pie.Markup);
+    }
+
+    [Fact]
+    public void A_coalesced_parameter_default_resolves_in_French()
+    {
+        // The nullable-[Parameter] pattern: nothing supplied, so the localized default is used.
+        using CultureScope _ = CultureScope.For("fr-FR");
+
+        IRenderedComponent<DxSkipLink> link = RenderComponent<DxSkipLink>();
+
+        Assert.Contains("Aller au contenu principal", link.Markup);
+    }
+
+    [Fact]
+    public void An_unsupported_culture_falls_back_to_English_rather_than_a_key()
+    {
+        // The chain that matters when a language is not shipped: de-DE has no satellite assembly,
+        // so resolution walks to the invariant resource. Rendering the key ("Loading") would look
+        // almost right here, which is why the assertion is on the English word and not on absence.
+        using CultureScope _ = CultureScope.For("de-DE");
+
+        IRenderedComponent<DxSpinner> spinner = RenderComponent<DxSpinner>();
+
+        Assert.Equal("Loading", spinner.Find("[aria-label]").GetAttribute("aria-label"));
+    }
+}

--- a/tests/BlazorDX.Components.Tests/TranslationCompletenessTests.cs
+++ b/tests/BlazorDX.Components.Tests/TranslationCompletenessTests.cs
@@ -1,0 +1,145 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// Every invariant <c>.resx</c> has a French counterpart, and the two agree on the things a
+/// translation must not change.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A translation cannot be checked for meaning, but three of its failure modes are mechanical and
+/// all three are invisible at a glance:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     A <b>missing key</b> silently falls back to English. The UI still renders, so nothing looks
+///     broken — the French user simply gets one English string among the rest.
+///   </item>
+///   <item>
+///     A <b>dropped placeholder</b> is worse. "Graphique en secteurs avec {0} parts" without its
+///     <c>{0}</c> reads as perfectly good French and tells the reader nothing; a screen-reader user
+///     hears a chart described with no numbers in it.
+///   </item>
+///   <item>
+///     <b>Edge whitespace</b> matters because several strings are sentence fragments joined to a
+///     link in markup — "Le PDF ne s'affiche pas ? " has a trailing space that holds it off the
+///     anchor that follows.
+///   </item>
+/// </list>
+/// <para>
+/// What this deliberately does not check is whether French and English differ. They legitimately
+/// coincide for <i>Message</i>, <i>Documents</i>, <i>Actions</i>, <i>Options</i>, <i>Pagination</i>,
+/// <i>Total</i>, <i>Normal</i>, <i>Style</i>, <i>Saturation</i> and <i>Document</i>, and a rule
+/// demanding a difference would only invite someone to invent one.
+/// </para>
+/// </remarks>
+public sealed class TranslationCompletenessTests
+{
+    // {0}, {1:N0}, {3:0} — the specifier is part of the identity: dropping :N0 loses the
+    // thousands separators that make a large count readable.
+    private static readonly Regex Placeholder = new(@"\{\d+(?::[^}]*)?\}", RegexOptions.Compiled);
+
+    [Fact]
+    public void Every_resource_has_a_complete_French_counterpart()
+    {
+        List<string> problems = [];
+        int compared = 0;
+
+        foreach (string invariant in InvariantResources())
+        {
+            string french = invariant[..^".resx".Length] + ".fr.resx";
+            string name = Path.GetFileName(invariant);
+
+            if (!File.Exists(french))
+            {
+                problems.Add($"{name} has no .fr.resx. Every string the library ships is "
+                    + "translated; a new resource file needs one too (docs/localization.md).");
+                continue;
+            }
+
+            Dictionary<string, string> source = Read(invariant);
+            Dictionary<string, string> target = Read(french);
+
+            foreach (string key in source.Keys.Where(k => !target.ContainsKey(k)).OrderBy(k => k))
+            {
+                problems.Add($"{name}[\"{key}\"] has no French value, so it renders in English "
+                    + $"to a French user: \"{source[key]}\"");
+            }
+
+            foreach (string key in target.Keys.Where(k => !source.ContainsKey(k)).OrderBy(k => k))
+            {
+                problems.Add($"{name}[\"{key}\"] exists only in French — the English string moved "
+                    + "or was removed, and the translation is now dead weight.");
+            }
+
+            foreach (string key in source.Keys.Where(target.ContainsKey).OrderBy(k => k))
+            {
+                compared++;
+                CompareOne(name, key, source[key], target[key], problems);
+            }
+        }
+
+        // A guard that finds nothing to compare is not passing, it is broken.
+        Assert.True(compared > 0, "No translated strings found. Have the .resx files moved?");
+
+        Assert.True(problems.Count == 0,
+            "French resources do not line up with the invariant ones:" + Environment.NewLine
+            + string.Join(Environment.NewLine, problems.Select(p => "  " + p)));
+    }
+
+    private static void CompareOne(string file, string key, string english, string french, List<string> problems)
+    {
+        string[] sourceHoles = [.. Placeholder.Matches(english).Select(m => m.Value).OrderBy(v => v, StringComparer.Ordinal)];
+        string[] targetHoles = [.. Placeholder.Matches(french).Select(m => m.Value).OrderBy(v => v, StringComparer.Ordinal)];
+
+        if (!sourceHoles.SequenceEqual(targetHoles, StringComparer.Ordinal))
+        {
+            problems.Add($"{file}[\"{key}\"] changes its placeholders, so the translated text loses "
+                + $"or misplaces its values.{Environment.NewLine}      en \"{english}\""
+                + $"{Environment.NewLine}      fr \"{french}\"");
+        }
+
+        if (StartsWithSpace(english) != StartsWithSpace(french) || EndsWithSpace(english) != EndsWithSpace(french))
+        {
+            problems.Add($"{file}[\"{key}\"] changes its leading or trailing space. These strings are "
+                + $"joined to adjacent markup, so the space is load-bearing.{Environment.NewLine}"
+                + $"      en \"{english}\"{Environment.NewLine}      fr \"{french}\"");
+        }
+    }
+
+    private static bool StartsWithSpace(string value) => value.Length > 0 && char.IsWhiteSpace(value[0]);
+
+    private static bool EndsWithSpace(string value) => value.Length > 0 && char.IsWhiteSpace(value[^1]);
+
+    private static Dictionary<string, string> Read(string path) =>
+        XDocument.Load(path).Root!
+            .Elements("data")
+            .Where(data => data.Attribute("name") is not null)
+            .ToDictionary(
+                data => data.Attribute("name")!.Value,
+                data => data.Element("value")?.Value ?? string.Empty,
+                StringComparer.Ordinal);
+
+    private static IEnumerable<string> InvariantResources() =>
+        Directory.EnumerateFiles(Path.Combine(RepositoryRoot(), "src"), "*.resx", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            // A culture-qualified file (Name.fr.resx) is a counterpart, not an invariant.
+            .Where(path => !Path.GetFileNameWithoutExtension(path).Contains('.', StringComparison.Ordinal));
+
+    private static string RepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "BlazorDX.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.True(directory is not null, $"No BlazorDX.slnx above {AppContext.BaseDirectory}.");
+        return directory!.FullName;
+    }
+}


### PR DESCRIPTION
**63 new `.fr.resx` files**, joining the two the ADR 0016 pilot left behind: 65 invariant resources, 65 French counterparts, **291 strings**.

The library shipped its strings externalized but untranslated, which made "localization done" a claim about mechanism rather than about what a French user actually sees.

## Two tests, because meaning can't be checked but three failure modes can

All three are invisible at a glance, which is the point:

- **A missing key** falls back to English. Nothing looks broken — a French user simply gets one English string among the rest.
- **A dropped placeholder** is worse. `"Graphique en secteurs avec {0} parts"` without its `{0}` is still fluent French and says *nothing*; a screen-reader user hears a chart described with no numbers in it. Specifiers count too — losing `:N0` loses the separators that make a large count readable.
- **Edge whitespace**, because several strings are sentence fragments joined to a link in markup. `"Le PDF ne s'affiche pas ? "` needs its trailing space.

`TranslationCompletenessTests` checks those three, and **deliberately does not require French to differ from English**. *Message, Documents, Actions, Options, Pagination, Total, Normal, Style, Saturation* and *Document* legitimately coincide; a rule demanding a difference would only invite someone to invent one.

`FrenchRenderingTests` covers what a file check cannot: that the satellite assemblies are **built and found**. The resources could line up perfectly and still render in English. It also renders under `de-DE` — an unshipped language — and asserts the **English** word rather than the absence of French, because a broken lookup returns the *key*, and a key like `Loading` looks almost right.

## Conventions held throughout

- Placeholders preserved exactly, specifiers included.
- Glyphs travel with their word (`⭳ Télécharger`, `← Précédent`) so a language can move the arrow.
- French spacing: no-break space before `:` and inside `« »`, so it can't wrap away.
- Keyboard names follow French usage — `Maj`, `Échap`, `Suppr`, `Entrée`, `Retour arrière`.
- Rich-text mnemonic caps follow the **French** word: Bold's cap is **G** for *Gras*, not **B**; Underline is **S** for *Souligné*.
- Product and format names left alone: Power BI, PDF, CSV, Excel, Markdown, QR, EAN-13, Code 128, `.docx`, Sankey.

## A bug the translation pass exposed

`DxDatePicker`'s calendar emoji had been localized, under the nonsense key `UFC`. My automated pass tests the *source literal* for letters, and the escape sequence `"\U0001F4C5"` is full of them. It's `aria-hidden` and carries no language, so it's a plain literal again.

## Verification

The generator refused to write anything until every invariant key had a translation, every placeholder set matched, and edge whitespace lined up — 291 strings, 0 problems. It also confirmed the two pre-existing French files are complete.

Worth being plain: I wrote these translations. They're careful and idiomatic, but they have not been reviewed by a native speaker, and that review is the difference between "translated" and "shipped in French" for a product making accessibility claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
