### PR TITLE
Translate every string into German

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -106,13 +106,15 @@ enhancements. None of this should be read as "ready"; it is a beta with work ahe
   `Integrations` packages — 309 call sites across
   62 resource files — and DX1003's ratchet is retired, so a hardcoded label is a build error
   anywhere, not just in components that already localize. (The "~130 components" figure here
-  previously counted every file; 57 have no user-facing text at all.) **Shipped in English and French**: 65
-  resource files, 65 French counterparts, 291 strings, with tests holding the two in step on
+  previously counted every file; 57 have no user-facing text at all.) **Shipped in English, French and
+  German**: 65 resource files per language, 291 strings each, with tests holding them in step on
   the things a translation must not change — a missing key (falls back to English silently), a
-  dropped placeholder (still fluent, says nothing), and load-bearing edge whitespace — plus a
-  rendering test that the satellite assemblies are actually built and found, which a file check
-  cannot tell you. *Remaining: further languages, and a visual RTL pass a static guard cannot
-  do.*
+  dropped placeholder (still fluent, says nothing), and load-bearing edge whitespace. The test
+  infers the shipped languages from the files rather than listing them, so adding one file
+  demands the rest. Each language also has a rendering test, because satellite assemblies are
+  packaged per language and fail independently — a file check cannot tell you one was never
+  built. *Remaining: further languages, native-speaker review of the two that ship, and a visual
+  RTL pass a static guard cannot do.*
 - **Formal accessibility audit + VPAT** — automated **axe-core checks run in CI**
   (`AccessibilityE2ETests`, across Chromium/Firefox/WebKit) over **every route in the
   showcase and the TicketDesk demo app**, with zero serious/critical violations.

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -248,11 +248,14 @@ Flip the showcase with `?dir=rtl` on any route to check the result by eye.
 
 ## 3. Translations
 
-Every string ships in **English and French**: 65 invariant `.resx` files, 65 `.fr.resx`
-counterparts, 291 strings.
+Every string ships in **English, French and German**: 65 invariant `.resx` files, 65 per
+language, 291 strings each — 582 translations.
 
-`TranslationCompletenessTests` holds the two in step. It checks the three things a translation
-must not change, all of which fail invisibly:
+`TranslationCompletenessTests` holds them in step. **It infers the shipped languages from the
+files rather than listing them**, so adding one `.de.resx` immediately demands the other 64 — a
+hardcoded list has to be edited when a language is added, and whoever forgets to edit it also
+gets no failure. It checks the three things a translation must not change, all of which fail
+invisibly:
 
 - **A missing key** falls back to English. Nothing looks broken; a French user just gets one
   English string among the rest.
@@ -263,37 +266,48 @@ must not change, all of which fail invisibly:
 - **Edge whitespace**, because several strings are sentence fragments joined to a link in
   markup. `"Le PDF ne s'affiche pas ? "` needs its trailing space.
 
-It deliberately does *not* require French and English to differ. They legitimately coincide for
-*Message*, *Documents*, *Actions*, *Options*, *Pagination*, *Total*, *Normal*, *Style*,
-*Saturation* and *Document*; a rule demanding a difference would only invite someone to invent
-one.
+It deliberately does *not* require a translation to differ from the English. They legitimately
+coincide for *Message*, *Documents*, *Actions*, *Options*, *Pagination*, *Total*, *Normal*,
+*Style*, *Saturation* and *Document* in French, and for *Name*, *Alt*, *Tab*, *Operator* and
+*Sepia* in German; a rule demanding a difference would only invite someone to invent one.
 
-`FrenchRenderingTests` covers what a file check cannot: that the satellite assemblies are built
-and found. Without it the resources could line up perfectly and still render in English. It
-also pins the fallback chain by rendering under `de-DE` — an unshipped language — and asserting
-the **English** word rather than the absence of French, because a broken lookup returns the
-*key*, and a key like `Loading` looks almost right.
+`FrenchRenderingTests` and `GermanRenderingTests` cover what a file check cannot: that the
+satellite assemblies are built and found. Without them the resources could line up perfectly and
+still render in English. **Each language needs its own**, because each is packaged separately and
+can fail on its own.
+
+They also pin the fallback chain by rendering under an unshipped language and asserting the
+**English** word rather than the absence of a translation — a broken lookup returns the *key*,
+and a key like `Loading` looks almost right. That test named `de-DE` until German shipped, at
+which point it was asserting that a translated language renders in English, and passing anyway
+because the expected string was the same either way. It now names `ja-JP`, and the culture it
+names has to stay one the library genuinely does not translate.
 
 ### Conventions
 
 - Placeholders are preserved exactly, specifiers included.
 - Glyphs travel with their word (`⭳ Télécharger`, `← Précédent`) so a language can move the
   arrow.
-- French spacing: a no-break space before `:` and inside `« »`, so it cannot wrap away from the
-  word it belongs to.
-- Keyboard names follow the French convention — `Maj`, `Échap`, `Suppr`, `Entrée`,
-  `Retour arrière` — and the rich-text mnemonics follow the French word, so Bold's cap is **G**
-  for *Gras*, not **B**.
+- Keyboard names follow each language's own convention rather than translating the English
+  word: `Maj`/`Échap`/`Suppr`/`Entrée` in French, `Strg`/`Umschalt`/`Entf`/`Eingabe` in German.
+  The rich-text mnemonic caps follow the translated word too — Bold is **G** for *Gras* and
+  **F** for *Fett*, never **B**.
+- Punctuation is per-language: French takes a no-break space before `:` and uses `« »`; German
+  takes neither and uses `„ “`.
 - Product and format names are not translated: Power BI, PDF, CSV, Excel, Markdown, QR,
   EAN-13, Code 128, `.docx`, Sankey.
 
 ### Adding another language
 
-Copy the `.fr.resx` files to `.<culture>.resx`, translate the values, and the two tests above
-start covering it — `TranslationCompletenessTests` currently checks French specifically, so
-widen its counterpart lookup at the same time. Nothing else needs to change: the resource
-lookup, the fallback chain and the AOT satellite-assembly path are all culture-agnostic
-already.
+Copy the `.fr.resx` files to `.<culture>.resx` and translate the values.
+`TranslationCompletenessTests` picks the language up on its own — it reads the shipped set off
+the files — so the moment one file exists, the missing 64 fail the build. Add a rendering test
+for the new language alongside the French and German ones, since each language's satellite
+assembly can fail independently, and check whether the unshipped culture in
+`FrenchRenderingTests` is still unshipped.
+
+Nothing else needs to change: the resource lookup, the fallback chain and the AOT
+satellite-assembly path are all culture-agnostic already.
 
 ---
 

--- a/src/BlazorDX.Components/DxAlert.de.resx
+++ b/src/BlazorDX.Components/DxAlert.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Dismiss" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxBarcode.de.resx
+++ b/src/BlazorDX.Components/DxBarcode.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CannotEncodeAsCode" xml:space="preserve">
+    <value>Kodierung als Code 128 nicht möglich: „{0}“</value>
+  </data>
+  <data name="CodeBarcode" xml:space="preserve">
+    <value>Code-128-Barcode: {0}</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxBreadcrumbs.de.resx
+++ b/src/BlazorDX.Components/DxBreadcrumbs.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BreadcrumbLabel" xml:space="preserve">
+    <value>Navigationspfad</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxCalendar.de.resx
+++ b/src/BlazorDX.Components/DxCalendar.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CalendarLabel" xml:space="preserve">
+    <value>Kalender</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxCarousel.de.resx
+++ b/src/BlazorDX.Components/DxCarousel.de.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Carousel" xml:space="preserve">
+    <value>Karussell</value>
+  </data>
+  <data name="CarouselLabel" xml:space="preserve">
+    <value>Karussell</value>
+  </data>
+  <data name="GoToSlide" xml:space="preserve">
+    <value>Zu Folie {0} wechseln</value>
+  </data>
+  <data name="Slide" xml:space="preserve">
+    <value>Folie</value>
+  </data>
+  <data name="SlidePosition" xml:space="preserve">
+    <value>{0} von {1}</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxChartResources.de.resx
+++ b/src/BlazorDX.Components/DxChartResources.de.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BarChartLabel" xml:space="preserve">
+    <value>Balkendiagramm mit {0} Kategorien</value>
+  </data>
+  <data name="BoxPlotLabel" xml:space="preserve">
+    <value>Boxplot mit {0} Gruppen</value>
+  </data>
+  <data name="BoxPlotPointLabel" xml:space="preserve">
+    <value>{0}: Median {1}, Q1 {2}, Q3 {3}, Spannweite {4}–{5}</value>
+  </data>
+  <data name="BulletChartLabel" xml:space="preserve">
+    <value>Bullet-Diagramm mit {0} Kennzahlen</value>
+  </data>
+  <data name="CandlestickChartLabel" xml:space="preserve">
+    <value>Kerzendiagramm mit {0} Kerzen</value>
+  </data>
+  <data name="ChordDiagramLabel" xml:space="preserve">
+    <value>Chord-Diagramm mit {0} Knoten und {1} Flüssen</value>
+  </data>
+  <data name="FunnelChartLabel" xml:space="preserve">
+    <value>Trichterdiagramm mit {0} Stufen</value>
+  </data>
+  <data name="GanttTaskLabel" xml:space="preserve">
+    <value>{0}, {1} bis {2}, {3:0} % abgeschlossen</value>
+  </data>
+  <data name="GanttTaskRole" xml:space="preserve">
+    <value>Aufgabe</value>
+  </data>
+  <data name="GroupedBarChartLabel" xml:space="preserve">
+    <value>Gruppiertes Balkendiagramm, {0} Reihen über {1} Kategorien</value>
+  </data>
+  <data name="HeatmapLabel" xml:space="preserve">
+    <value>Heatmap mit {0} Zeilen und {1} Spalten</value>
+  </data>
+  <data name="HistogramCaption" xml:space="preserve">
+    <value>{0:N0} Werte · {1} Klassen · Spannweite {2}–{3} · {4}</value>
+  </data>
+  <data name="HistogramLabel" xml:space="preserve">
+    <value>Histogramm mit {0} Klassen</value>
+  </data>
+  <data name="NetworkGraphLabel" xml:space="preserve">
+    <value>Netzwerkgraph mit {0} Knoten und {1} Kanten</value>
+  </data>
+  <data name="ParallelCoordinatesLabel" xml:space="preserve">
+    <value>Parallele-Koordinaten-Diagramm mit {0} Zeilen über {1} Achsen</value>
+  </data>
+  <data name="PieChartLabel" xml:space="preserve">
+    <value>Kreisdiagramm mit {0} Segmenten</value>
+  </data>
+  <data name="PointsCaption" xml:space="preserve">
+    <value>{0:N0} von {1:N0} Punkten · {2}</value>
+  </data>
+  <data name="RadarChartLabel" xml:space="preserve">
+    <value>Netzdiagramm mit {0} Reihen über {1} Achsen</value>
+  </data>
+  <data name="ResetZoom" xml:space="preserve">
+    <value>Zoom zurücksetzen</value>
+  </data>
+  <data name="SankeyChartLabel" xml:space="preserve">
+    <value>Sankey-Diagramm mit {0} Knoten und {1} Flüssen</value>
+  </data>
+  <data name="SparklineLabel" xml:space="preserve">
+    <value>Sparkline mit {0} Punkten</value>
+  </data>
+  <data name="StackedBarChartLabel" xml:space="preserve">
+    <value>Gestapeltes Balkendiagramm, {0} Reihen über {1} Kategorien</value>
+  </data>
+  <data name="SunburstLabel" xml:space="preserve">
+    <value>Sunburst-Diagramm mit {0} Segmenten</value>
+  </data>
+  <data name="TreemapLabel" xml:space="preserve">
+    <value>Treemap mit {0} Zellen</value>
+  </data>
+  <data name="WaterfallChartLabel" xml:space="preserve">
+    <value>Wasserfalldiagramm mit {0} Balken</value>
+  </data>
+  <data name="WordCloudLabel" xml:space="preserve">
+    <value>Wortwolke: {0} von {1} Wörtern platziert</value>
+  </data>
+  <data name="ZoomStatus" xml:space="preserve">
+    <value>Zoom auf {0}–{1} von {2}–{3}</value>
+  </data>
+  <data name="ZoomStatusPoint" xml:space="preserve">
+    <value>Zoom auf Punkt {0}–{1} von {2}–{3}</value>
+  </data>
+  <data name="ZoomStatusXY" xml:space="preserve">
+    <value>Zoom auf X {0}–{1}, Y {2}–{3}</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxChat.de.resx
+++ b/src/BlazorDX.Components/DxChat.de.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AssistantTyping" xml:space="preserve">
+    <value>Assistent schreibt</value>
+  </data>
+  <data name="ComposerPlaceholder" xml:space="preserve">
+    <value>Nachricht senden…  (Strg+Eingabe)</value>
+  </data>
+  <data name="Message" xml:space="preserve">
+    <value>Nachricht</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Senden</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxChip.de.resx
+++ b/src/BlazorDX.Components/DxChip.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Remove" xml:space="preserve">
+    <value>Entfernen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxColorPicker.de.resx
+++ b/src/BlazorDX.Components/DxColorPicker.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Use" xml:space="preserve">
+    <value>{0} verwenden</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxComboBoxResources.de.resx
+++ b/src/BlazorDX.Components/DxComboBoxResources.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="NoMatches" xml:space="preserve">
+    <value>Keine Treffer</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxCommandPalette.de.resx
+++ b/src/BlazorDX.Components/DxCommandPalette.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CommandPalette" xml:space="preserve">
+    <value>Befehlspalette</value>
+  </data>
+  <data name="NoCommands" xml:space="preserve">
+    <value>Keine Befehle</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxDataGridResources.de.resx
+++ b/src/BlazorDX.Components/DxDataGridResources.de.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BlankValue" xml:space="preserve">
+    <value>(leer)</value>
+  </data>
+  <data name="ClearFilter" xml:space="preserve">
+    <value>Filter löschen</value>
+  </data>
+  <data name="CollapseDetails" xml:space="preserve">
+    <value>Details einklappen</value>
+  </data>
+  <data name="ColumnsToggle" xml:space="preserve">
+    <value>Spalten ({0}/{1})</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Kopieren</value>
+  </data>
+  <data name="DoubleClickToEdit" xml:space="preserve">
+    <value>Doppelklicken zum Bearbeiten</value>
+  </data>
+  <data name="DragToReorder" xml:space="preserve">
+    <value>Ziehen oder Strg+Pfeil zum Neuanordnen</value>
+  </data>
+  <data name="DragToResize" xml:space="preserve">
+    <value>Ziehen zum Ändern der Breite</value>
+  </data>
+  <data name="EditColumn" xml:space="preserve">
+    <value>{0} bearbeiten</value>
+  </data>
+  <data name="ExpandDetails" xml:space="preserve">
+    <value>Details ausklappen</value>
+  </data>
+  <data name="ExportCsv" xml:space="preserve">
+    <value>CSV exportieren</value>
+  </data>
+  <data name="ExportExcel" xml:space="preserve">
+    <value>Excel exportieren</value>
+  </data>
+  <data name="ExportPdf" xml:space="preserve">
+    <value>PDF exportieren</value>
+  </data>
+  <data name="FilterColumn" xml:space="preserve">
+    <value>{0} filtern</value>
+  </data>
+  <data name="FilterPlaceholder" xml:space="preserve">
+    <value>Filtern…</value>
+  </data>
+  <data name="MoveColumnLeft" xml:space="preserve">
+    <value>{0} nach links verschieben</value>
+  </data>
+  <data name="MoveColumnRight" xml:space="preserve">
+    <value>{0} nach rechts verschieben</value>
+  </data>
+  <data name="SelectAllRows" xml:space="preserve">
+    <value>Alle Zeilen auswählen</value>
+  </data>
+  <data name="SelectRow" xml:space="preserve">
+    <value>Zeile auswählen</value>
+  </data>
+  <data name="SortTitle" xml:space="preserve">
+    <value>Klicken zum Sortieren; Umschalt+Klick für mehrspaltige Sortierung</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxDatePicker.de.resx
+++ b/src/BlazorDX.Components/DxDatePicker.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="NextMonth" xml:space="preserve">
+    <value>Nächster Monat</value>
+  </data>
+  <data name="PreviousMonth" xml:space="preserve">
+    <value>Vorheriger Monat</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxDocumentViewer.de.resx
+++ b/src/BlazorDX.Components/DxDocumentViewer.de.resx
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DocumentActions" xml:space="preserve">
+    <value>Dokumentaktionen</value>
+  </data>
+  <data name="DocumentList" xml:space="preserve">
+    <value>Dokumente</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Herunterladen</value>
+  </data>
+  <data name="DownloadButton" xml:space="preserve">
+    <value>⭳ Herunterladen</value>
+  </data>
+  <data name="DownloadNamed" xml:space="preserve">
+    <value>{0} herunterladen</value>
+  </data>
+  <data name="DownloadThePdf" xml:space="preserve">
+    <value>PDF herunterladen</value>
+  </data>
+  <data name="NoDocument" xml:space="preserve">
+    <value>Kein Dokument</value>
+  </data>
+  <data name="NoPreview" xml:space="preserve">
+    <value>Keine Vorschau für diesen Dateityp verfügbar. </value>
+  </data>
+  <data name="OpenButton" xml:space="preserve">
+    <value>↗ Öffnen</value>
+  </data>
+  <data name="OpenNamed" xml:space="preserve">
+    <value>{0} in neuem Tab öffnen</value>
+  </data>
+  <data name="PdfFallbackPrompt" xml:space="preserve">
+    <value>PDF wird oben nicht angezeigt? </value>
+  </data>
+  <data name="PrintButton" xml:space="preserve">
+    <value>⎙ Drucken</value>
+  </data>
+  <data name="PrintNamed" xml:space="preserve">
+    <value>{0} drucken</value>
+  </data>
+  <data name="SourceUnavailable" xml:space="preserve">
+    <value>Dokumentquelle nicht verfügbar</value>
+  </data>
+  <data name="ZoomIn" xml:space="preserve">
+    <value>Vergrößern</value>
+  </data>
+  <data name="ZoomOut" xml:space="preserve">
+    <value>Verkleinern</value>
+  </data>
+  <data name="ZoomReset" xml:space="preserve">
+    <value>Zoom zurücksetzen</value>
+  </data>
+  <data name="ZoomResetGlyph" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxDrawer.de.resx
+++ b/src/BlazorDX.Components/DxDrawer.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DrawerLabel" xml:space="preserve">
+    <value>Seitenbereich</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEan13.de.resx
+++ b/src/BlazorDX.Components/DxEan13.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="EanBarcode" xml:space="preserve">
+    <value>EAN-13-Barcode {0}</value>
+  </data>
+  <data name="InvalidEan" xml:space="preserve">
+    <value>Ungültiger EAN-13: „{0}“</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEditorialDissipation.de.resx
+++ b/src/BlazorDX.Components/DxEditorialDissipation.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DissipationLabel" xml:space="preserve">
+    <value>Eine Illustration vergänglicher Inhalte, die mit dem Ende der Sitzung verblassen.</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEditorialFootnoteRef.de.resx
+++ b/src/BlazorDX.Components/DxEditorialFootnoteRef.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="JumpFootnote" xml:space="preserve">
+    <value>Zu Fußnote {0} springen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEditorialFootnotes.de.resx
+++ b/src/BlazorDX.Components/DxEditorialFootnotes.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BackReference" xml:space="preserve">
+    <value>Zurück zu Verweis {0}</value>
+  </data>
+  <data name="Footnotes" xml:space="preserve">
+    <value>Fußnoten</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEditorialLayout.de.resx
+++ b/src/BlazorDX.Components/DxEditorialLayout.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ReadingTime" xml:space="preserve">
+    <value>{0} Min. Lesezeit</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEditorialListen.de.resx
+++ b/src/BlazorDX.Components/DxEditorialListen.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ListenLabel" xml:space="preserve">
+    <value>Diesen Artikel anhören</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEditorialNewsletterSignup.de.resx
+++ b/src/BlazorDX.Components/DxEditorialNewsletterSignup.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="NewsletterHeading" xml:space="preserve">
+    <value>Mehr davon erhalten</value>
+  </data>
+  <data name="Subscribe" xml:space="preserve">
+    <value>Abonnieren</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEditorialRelated.de.resx
+++ b/src/BlazorDX.Components/DxEditorialRelated.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="RelatedHeading" xml:space="preserve">
+    <value>Mehr aus Insights</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEditorialSeriesNav.de.resx
+++ b/src/BlazorDX.Components/DxEditorialSeriesNav.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SeriesNavigation" xml:space="preserve">
+    <value>Navigation innerhalb der Serie</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEditorialShareBar.de.resx
+++ b/src/BlazorDX.Components/DxEditorialShareBar.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ShareArticle" xml:space="preserve">
+    <value>Diesen Artikel teilen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEditorialTableOfContents.de.resx
+++ b/src/BlazorDX.Components/DxEditorialTableOfContents.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ContentsHeading" xml:space="preserve">
+    <value>Inhalt</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxEditorialTagList.de.resx
+++ b/src/BlazorDX.Components/DxEditorialTagList.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Topics" xml:space="preserve">
+    <value>Themen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxErrorBoundary.de.resx
+++ b/src/BlazorDX.Components/DxErrorBoundary.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FallbackTitle" xml:space="preserve">
+    <value>Etwas ist schiefgelaufen.</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Erneut versuchen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxFieldListResources.de.resx
+++ b/src/BlazorDX.Components/DxFieldListResources.de.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Add" xml:space="preserve">
+    <value>Hinzufügen</value>
+  </data>
+  <data name="MoveItemDown" xml:space="preserve">
+    <value>Element nach unten</value>
+  </data>
+  <data name="MoveItemUp" xml:space="preserve">
+    <value>Element nach oben</value>
+  </data>
+  <data name="RemoveItem" xml:space="preserve">
+    <value>Element entfernen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxFileManager.de.resx
+++ b/src/BlazorDX.Components/DxFileManager.de.resx
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Breadcrumb" xml:space="preserve">
+    <value>Pfad</value>
+  </data>
+  <data name="Collapse" xml:space="preserve">
+    <value>Einklappen</value>
+  </data>
+  <data name="ColumnActions" xml:space="preserve">
+    <value>Aktionen</value>
+  </data>
+  <data name="ColumnModified" xml:space="preserve">
+    <value>Geändert</value>
+  </data>
+  <data name="ColumnName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ColumnSize" xml:space="preserve">
+    <value>Größe</value>
+  </data>
+  <data name="ContentsLabel" xml:space="preserve">
+    <value>Ordnerinhalt. Dateien zum Hochladen hier ablegen.</value>
+  </data>
+  <data name="EmptyFolder" xml:space="preserve">
+    <value>Dieser Ordner ist leer. Dateien hier ablegen oder „Dateien hochladen“ verwenden.</value>
+  </data>
+  <data name="Expand" xml:space="preserve">
+    <value>Ausklappen</value>
+  </data>
+  <data name="MoveHere" xml:space="preserve">
+    <value>Hierher verschieben</value>
+  </data>
+  <data name="MoveInto" xml:space="preserve">
+    <value>{0} nach {1} verschieben</value>
+  </data>
+  <data name="MoveToRoot" xml:space="preserve">
+    <value>{0} nach Dateien verschieben</value>
+  </data>
+  <data name="RootName" xml:space="preserve">
+    <value>Dateien</value>
+  </data>
+  <data name="UploadFiles" xml:space="preserve">
+    <value>Dateien hochladen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxFileUpload.de.resx
+++ b/src/BlazorDX.Components/DxFileUpload.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DropPrompt" xml:space="preserve">
+    <value>Dateien hier ablegen oder zum Durchsuchen klicken</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>{0} entfernen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxFormBody.de.resx
+++ b/src/BlazorDX.Components/DxFormBody.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Submit" xml:space="preserve">
+    <value>Absenden</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxImageEditor.de.resx
+++ b/src/BlazorDX.Components/DxImageEditor.de.resx
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Brightness" xml:space="preserve">
+    <value>Helligkeit</value>
+  </data>
+  <data name="CanvasLabel" xml:space="preserve">
+    <value>Vorschau des bearbeiteten Bildes</value>
+  </data>
+  <data name="Contrast" xml:space="preserve">
+    <value>Kontrast</value>
+  </data>
+  <data name="DownloadGlyph" xml:space="preserve">
+    <value>⭳ Herunterladen</value>
+  </data>
+  <data name="DownloadImage" xml:space="preserve">
+    <value>Bild herunterladen</value>
+  </data>
+  <data name="EmptyState" xml:space="preserve">
+    <value>Bild öffnen, um zu beginnen</value>
+  </data>
+  <data name="FlipHorizontal" xml:space="preserve">
+    <value>Horizontal spiegeln</value>
+  </data>
+  <data name="FlipVertical" xml:space="preserve">
+    <value>Vertikal spiegeln</value>
+  </data>
+  <data name="Grayscale" xml:space="preserve">
+    <value>Graustufen</value>
+  </data>
+  <data name="Invert" xml:space="preserve">
+    <value>Invertieren</value>
+  </data>
+  <data name="OpenImage" xml:space="preserve">
+    <value>Bild öffnen</value>
+  </data>
+  <data name="ReplaceImage" xml:space="preserve">
+    <value>Bild ersetzen</value>
+  </data>
+  <data name="ResetEdits" xml:space="preserve">
+    <value>Bearbeitungen zurücksetzen</value>
+  </data>
+  <data name="ResetGlyph" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="RotateLeft" xml:space="preserve">
+    <value>Nach links drehen</value>
+  </data>
+  <data name="RotateRight" xml:space="preserve">
+    <value>Nach rechts drehen</value>
+  </data>
+  <data name="Saturation" xml:space="preserve">
+    <value>Sättigung</value>
+  </data>
+  <data name="Sepia" xml:space="preserve">
+    <value>Sepia</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxKbd.de.resx
+++ b/src/BlazorDX.Components/DxKbd.de.resx
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ComboJoiner" xml:space="preserve">
+    <value> plus </value>
+  </data>
+  <data name="KeyCapAlt" xml:space="preserve">
+    <value>Alt</value>
+  </data>
+  <data name="KeyCapControl" xml:space="preserve">
+    <value>Strg</value>
+  </data>
+  <data name="KeyCapDelete" xml:space="preserve">
+    <value>Entf</value>
+  </data>
+  <data name="KeyCapEnter" xml:space="preserve">
+    <value>Eingabe</value>
+  </data>
+  <data name="KeyCapEscape" xml:space="preserve">
+    <value>Esc</value>
+  </data>
+  <data name="KeyCapShift" xml:space="preserve">
+    <value>Umschalt</value>
+  </data>
+  <data name="KeyCapSpace" xml:space="preserve">
+    <value>Leer</value>
+  </data>
+  <data name="KeyCapTab" xml:space="preserve">
+    <value>Tab</value>
+  </data>
+  <data name="SpokenAlt" xml:space="preserve">
+    <value>Alt</value>
+  </data>
+  <data name="SpokenBackspace" xml:space="preserve">
+    <value>Rücktaste</value>
+  </data>
+  <data name="SpokenCommand" xml:space="preserve">
+    <value>Befehl</value>
+  </data>
+  <data name="SpokenControl" xml:space="preserve">
+    <value>Steuerung</value>
+  </data>
+  <data name="SpokenDownArrow" xml:space="preserve">
+    <value>Pfeil nach unten</value>
+  </data>
+  <data name="SpokenLeftArrow" xml:space="preserve">
+    <value>Pfeil nach links</value>
+  </data>
+  <data name="SpokenRightArrow" xml:space="preserve">
+    <value>Pfeil nach rechts</value>
+  </data>
+  <data name="SpokenShift" xml:space="preserve">
+    <value>Umschalttaste</value>
+  </data>
+  <data name="SpokenUpArrow" xml:space="preserve">
+    <value>Pfeil nach oben</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxKeyboardShortcuts.de.resx
+++ b/src/BlazorDX.Components/DxKeyboardShortcuts.de.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Close" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
+  <data name="NoShortcuts" xml:space="preserve">
+    <value>Keine Tastenkürzel</value>
+  </data>
+  <data name="ShortcutsTitle" xml:space="preserve">
+    <value>Tastenkürzel</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxListboxResources.de.resx
+++ b/src/BlazorDX.Components/DxListboxResources.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ListboxLabel" xml:space="preserve">
+    <value>Optionen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxMarkdownEditor.de.resx
+++ b/src/BlazorDX.Components/DxMarkdownEditor.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="MarkdownSource" xml:space="preserve">
+    <value>Markdown-Quelltext</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxPager.de.resx
+++ b/src/BlazorDX.Components/DxPager.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Pagination" xml:space="preserve">
+    <value>Seitennavigation</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxPivotGridResources.de.resx
+++ b/src/BlazorDX.Components/DxPivotGridResources.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PivotCaption" xml:space="preserve">
+    <value>{0} von {1} · {2}</value>
+  </data>
+  <data name="Total" xml:space="preserve">
+    <value>Gesamt</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxProgress.de.resx
+++ b/src/BlazorDX.Components/DxProgress.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ProgressLabel" xml:space="preserve">
+    <value>Fortschritt</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxQrCode.de.resx
+++ b/src/BlazorDX.Components/DxQrCode.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CannotEncodeAsQr" xml:space="preserve">
+    <value>Kodierung als QR (1–4) nicht möglich: „{0}“</value>
+  </data>
+  <data name="QrCode" xml:space="preserve">
+    <value>QR-Code: {0}</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxQueryBuilder.de.resx
+++ b/src/BlazorDX.Components/DxQueryBuilder.de.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Field" xml:space="preserve">
+    <value>Feld</value>
+  </data>
+  <data name="Operator" xml:space="preserve">
+    <value>Operator</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Entfernen</value>
+  </data>
+  <data name="Value" xml:space="preserve">
+    <value>Wert</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxRating.de.resx
+++ b/src/BlazorDX.Components/DxRating.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Rating" xml:space="preserve">
+    <value>Bewertung: {0} von {1}</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxRichTextEditor.de.resx
+++ b/src/BlazorDX.Components/DxRichTextEditor.de.resx
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BlockStyleHeading1" xml:space="preserve">
+    <value>Überschrift 1</value>
+  </data>
+  <data name="BlockStyleHeading2" xml:space="preserve">
+    <value>Überschrift 2</value>
+  </data>
+  <data name="BlockStyleHeading3" xml:space="preserve">
+    <value>Überschrift 3</value>
+  </data>
+  <data name="BlockStyleNormal" xml:space="preserve">
+    <value>Standard</value>
+  </data>
+  <data name="CellShading" xml:space="preserve">
+    <value>Zellenschattierung</value>
+  </data>
+  <data name="FontFamily" xml:space="preserve">
+    <value>Schriftart</value>
+  </data>
+  <data name="FontFamilyShort" xml:space="preserve">
+    <value>Schrift</value>
+  </data>
+  <data name="FontSize" xml:space="preserve">
+    <value>Schriftgröße</value>
+  </data>
+  <data name="FontSizeShort" xml:space="preserve">
+    <value>Größe</value>
+  </data>
+  <data name="HighlightColor" xml:space="preserve">
+    <value>Hervorhebungsfarbe</value>
+  </data>
+  <data name="LineSpacing" xml:space="preserve">
+    <value>Zeilenabstand</value>
+  </data>
+  <data name="LineSpacingShort" xml:space="preserve">
+    <value>Abstand</value>
+  </data>
+  <data name="ParagraphStyle" xml:space="preserve">
+    <value>Absatzformat</value>
+  </data>
+  <data name="ParagraphStyleShort" xml:space="preserve">
+    <value>Format</value>
+  </data>
+  <data name="TextColor" xml:space="preserve">
+    <value>Textfarbe</value>
+  </data>
+  <data name="ToolAlignCenter" xml:space="preserve">
+    <value>Zentriert</value>
+  </data>
+  <data name="ToolAlignLeft" xml:space="preserve">
+    <value>Linksbündig</value>
+  </data>
+  <data name="ToolAlignRight" xml:space="preserve">
+    <value>Rechtsbündig</value>
+  </data>
+  <data name="ToolBold" xml:space="preserve">
+    <value>Fett</value>
+  </data>
+  <data name="ToolBoldGlyph" xml:space="preserve">
+    <value>F</value>
+  </data>
+  <data name="ToolBulletList" xml:space="preserve">
+    <value>Aufzählung</value>
+  </data>
+  <data name="ToolClearFormatting" xml:space="preserve">
+    <value>Formatierung entfernen</value>
+  </data>
+  <data name="ToolDecreaseIndent" xml:space="preserve">
+    <value>Einzug verkleinern</value>
+  </data>
+  <data name="ToolHeading" xml:space="preserve">
+    <value>Überschrift</value>
+  </data>
+  <data name="ToolHeadingGlyph" xml:space="preserve">
+    <value>Ü</value>
+  </data>
+  <data name="ToolIncreaseIndent" xml:space="preserve">
+    <value>Einzug vergrößern</value>
+  </data>
+  <data name="ToolInsertLink" xml:space="preserve">
+    <value>Link einfügen</value>
+  </data>
+  <data name="ToolItalic" xml:space="preserve">
+    <value>Kursiv</value>
+  </data>
+  <data name="ToolItalicGlyph" xml:space="preserve">
+    <value>K</value>
+  </data>
+  <data name="ToolJustify" xml:space="preserve">
+    <value>Blocksatz</value>
+  </data>
+  <data name="ToolNumberedList" xml:space="preserve">
+    <value>Nummerierung</value>
+  </data>
+  <data name="ToolStrikethrough" xml:space="preserve">
+    <value>Durchgestrichen</value>
+  </data>
+  <data name="ToolStrikethroughGlyph" xml:space="preserve">
+    <value>D</value>
+  </data>
+  <data name="ToolSubscript" xml:space="preserve">
+    <value>Tiefgestellt</value>
+  </data>
+  <data name="ToolSuperscript" xml:space="preserve">
+    <value>Hochgestellt</value>
+  </data>
+  <data name="ToolUnderline" xml:space="preserve">
+    <value>Unterstrichen</value>
+  </data>
+  <data name="ToolUnderlineGlyph" xml:space="preserve">
+    <value>U</value>
+  </data>
+  <data name="ToolbarLabel" xml:space="preserve">
+    <value>Formatierung</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxScheduler.de.resx
+++ b/src/BlazorDX.Components/DxScheduler.de.resx
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CalendarView" xml:space="preserve">
+    <value>Kalenderansicht</value>
+  </data>
+  <data name="GoToToday" xml:space="preserve">
+    <value>Zu heute wechseln</value>
+  </data>
+  <data name="GridLabel" xml:space="preserve">
+    <value>Terminplan {0}</value>
+  </data>
+  <data name="NextDay" xml:space="preserve">
+    <value>Nächster Tag</value>
+  </data>
+  <data name="NextMonth" xml:space="preserve">
+    <value>Nächster Monat</value>
+  </data>
+  <data name="NextWeek" xml:space="preserve">
+    <value>Nächste Woche</value>
+  </data>
+  <data name="PreviousDay" xml:space="preserve">
+    <value>Vorheriger Tag</value>
+  </data>
+  <data name="PreviousMonth" xml:space="preserve">
+    <value>Vorheriger Monat</value>
+  </data>
+  <data name="PreviousWeek" xml:space="preserve">
+    <value>Vorherige Woche</value>
+  </data>
+  <data name="TimeRange" xml:space="preserve">
+    <value>{0} bis {1}</value>
+  </data>
+  <data name="Today" xml:space="preserve">
+    <value>Heute</value>
+  </data>
+  <data name="ViewAnnouncement" xml:space="preserve">
+    <value>Ansicht {0}, {1}</value>
+  </data>
+  <data name="ViewDay" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="ViewMonth" xml:space="preserve">
+    <value>Monat</value>
+  </data>
+  <data name="ViewWeek" xml:space="preserve">
+    <value>Woche</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxSkipLink.de.resx
+++ b/src/BlazorDX.Components/DxSkipLink.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SkipToMainContent" xml:space="preserve">
+    <value>Zum Hauptinhalt springen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxSortableList.de.resx
+++ b/src/BlazorDX.Components/DxSortableList.de.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="MoveDown" xml:space="preserve">
+    <value>{0} nach unten</value>
+  </data>
+  <data name="MoveUp" xml:space="preserve">
+    <value>{0} nach oben</value>
+  </data>
+  <data name="PressAltPlusArrow" xml:space="preserve">
+    <value>{0}. Alt plus Pfeiltasten drücken, um neu anzuordnen.</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxSpinner.de.resx
+++ b/src/BlazorDX.Components/DxSpinner.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Loading" xml:space="preserve">
+    <value>Wird geladen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxSplitButton.de.resx
+++ b/src/BlazorDX.Components/DxSplitButton.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="MoreActions" xml:space="preserve">
+    <value>Weitere Aktionen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxStepper.de.resx
+++ b/src/BlazorDX.Components/DxStepper.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Back" xml:space="preserve">
+    <value>Zurück</value>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>Weiter</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxTileLayout.de.resx
+++ b/src/BlazorDX.Components/DxTileLayout.de.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DragAltArrowReorder" xml:space="preserve">
+    <value>Ziehen oder Alt+Pfeil zum Neuanordnen</value>
+  </data>
+  <data name="MoveEarlier" xml:space="preserve">
+    <value>{0} nach vorne verschieben</value>
+  </data>
+  <data name="MoveLater" xml:space="preserve">
+    <value>{0} nach hinten verschieben</value>
+  </data>
+  <data name="TileReorderHint" xml:space="preserve">
+    <value>{0} — ziehen oder Alt+Pfeil zum Neuanordnen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxTimePicker.de.resx
+++ b/src/BlazorDX.Components/DxTimePicker.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TimePickerLabel" xml:space="preserve">
+    <value>Uhrzeit</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxToastHost.de.resx
+++ b/src/BlazorDX.Components/DxToastHost.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Dismiss" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxTransferList.de.resx
+++ b/src/BlazorDX.Components/DxTransferList.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Available" xml:space="preserve">
+    <value>Verfügbar</value>
+  </data>
+  <data name="Selected" xml:space="preserve">
+    <value>Ausgewählt</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxVirtualKeyboard.de.resx
+++ b/src/BlazorDX.Components/DxVirtualKeyboard.de.resx
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Backspace" xml:space="preserve">
+    <value>Rücktaste</value>
+  </data>
+  <data name="Enter" xml:space="preserve">
+    <value>Eingabe</value>
+  </data>
+  <data name="EnterKeyCap" xml:space="preserve">
+    <value>↵ Eingabe</value>
+  </data>
+  <data name="ScreenKeyboard" xml:space="preserve">
+    <value>Bildschirmtastatur</value>
+  </data>
+  <data name="Shift" xml:space="preserve">
+    <value>Umschalt</value>
+  </data>
+  <data name="ShiftKeyCap" xml:space="preserve">
+    <value>⇧ Umschalt</value>
+  </data>
+  <data name="Space" xml:space="preserve">
+    <value>Leertaste</value>
+  </data>
+</root>

--- a/src/BlazorDX.Documents/DxSpreadsheetViewer.de.resx
+++ b/src/BlazorDX.Documents/DxSpreadsheetViewer.de.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CellContent" xml:space="preserve">
+    <value>Inhalt von Zelle {0}</value>
+  </data>
+  <data name="SpreadsheetEditing" xml:space="preserve">
+    <value>Tabellenbearbeitung</value>
+  </data>
+  <data name="Worksheet" xml:space="preserve">
+    <value>Arbeitsblatt {0}</value>
+  </data>
+  <data name="WorksheetEditable" xml:space="preserve">
+    <value>Arbeitsblatt {0}, bearbeitbar</value>
+  </data>
+  <data name="Worksheets" xml:space="preserve">
+    <value>Arbeitsblätter</value>
+  </data>
+</root>

--- a/src/BlazorDX.Documents/DxWordEditor.de.resx
+++ b/src/BlazorDX.Documents/DxWordEditor.de.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Document" xml:space="preserve">
+    <value>Dokument</value>
+  </data>
+  <data name="DownloadDocumentAsDocx" xml:space="preserve">
+    <value>Dokument als .docx-Datei herunterladen</value>
+  </data>
+  <data name="DownloadDocx" xml:space="preserve">
+    <value>.docx herunterladen</value>
+  </data>
+  <data name="Find" xml:space="preserve">
+    <value>Suchen</value>
+  </data>
+  <data name="FindReplace" xml:space="preserve">
+    <value>Suchen und Ersetzen</value>
+  </data>
+  <data name="FindReplace2" xml:space="preserve">
+    <value>Suchen und Ersetzen</value>
+  </data>
+  <data name="MatchCase" xml:space="preserve">
+    <value>Groß-/Kleinschreibung beachten</value>
+  </data>
+  <data name="ReplaceWith" xml:space="preserve">
+    <value>Ersetzen durch</value>
+  </data>
+  <data name="StatsSaved" xml:space="preserve">
+    <value>Alle Änderungen gespeichert · {0:N0} Wörter · {1:N0} Zeichen · {2:N0} Absätze</value>
+  </data>
+  <data name="StatsUnsaved" xml:space="preserve">
+    <value>Nicht gespeicherte Änderungen · {0:N0} Wörter · {1:N0} Zeichen · {2:N0} Absätze</value>
+  </data>
+</root>

--- a/src/BlazorDX.Documents/DxWordViewer.de.resx
+++ b/src/BlazorDX.Documents/DxWordViewer.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Document" xml:space="preserve">
+    <value>Dokument</value>
+  </data>
+  <data name="NoDocumentDisplay" xml:space="preserve">
+    <value>Kein Dokument zum Anzeigen.</value>
+  </data>
+</root>

--- a/src/BlazorDX.Htmx/DxHtmxDocumentViewer.de.resx
+++ b/src/BlazorDX.Htmx/DxHtmxDocumentViewer.de.resx
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DownloadNamed" xml:space="preserve">
+    <value>{0} herunterladen</value>
+  </data>
+  <data name="NextPage" xml:space="preserve">
+    <value>Weiter →</value>
+  </data>
+  <data name="PageOf" xml:space="preserve">
+    <value>Seite {0} von {1} ({2})</value>
+  </data>
+  <data name="Pagination" xml:space="preserve">
+    <value>Seitennavigation</value>
+  </data>
+  <data name="PdfFallbackPrompt" xml:space="preserve">
+    <value>PDF wird oben nicht angezeigt? </value>
+  </data>
+  <data name="PreviousPage" xml:space="preserve">
+    <value>← Zurück</value>
+  </data>
+  <data name="WorksheetNamed" xml:space="preserve">
+    <value>Arbeitsblatt {0}</value>
+  </data>
+  <data name="Worksheets" xml:space="preserve">
+    <value>Arbeitsblätter</value>
+  </data>
+</root>

--- a/src/BlazorDX.Integrations.PowerBI/DxPowerBiReport.de.resx
+++ b/src/BlazorDX.Integrations.PowerBI/DxPowerBiReport.de.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LoadingReport" xml:space="preserve">
+    <value>Bericht wird geladen…</value>
+  </data>
+  <data name="ReportLabel" xml:space="preserve">
+    <value>Power-BI-Bericht</value>
+  </data>
+</root>

--- a/src/BlazorDX.Integrations.Reporting/DxReportViewer.de.resx
+++ b/src/BlazorDX.Integrations.Reporting/DxReportViewer.de.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="EmptyOutput" xml:space="preserve">
+    <value>Parameter wählen und den Bericht ausführen, um hier Ergebnisse zu sehen.</value>
+  </data>
+  <data name="ExportReport" xml:space="preserve">
+    <value>Diesen Bericht exportieren</value>
+  </data>
+  <data name="ReportOutput" xml:space="preserve">
+    <value>Ausgabe von {0}</value>
+  </data>
+  <data name="ReportParameters" xml:space="preserve">
+    <value>Berichtsparameter</value>
+  </data>
+  <data name="RunReport" xml:space="preserve">
+    <value>Bericht ausführen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Primitives/ComboBoxPrimitiveResources.de.resx
+++ b/src/BlazorDX.Primitives/ComboBoxPrimitiveResources.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ComboBoxPlaceholder" xml:space="preserve">
+    <value>Zum Suchen tippen…</value>
+  </data>
+</root>

--- a/src/BlazorDX.Primitives/CommandPalettePrimitive.de.resx
+++ b/src/BlazorDX.Primitives/CommandPalettePrimitive.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CommandPalettePlaceholder" xml:space="preserve">
+    <value>Befehl eingeben…</value>
+  </data>
+</root>

--- a/src/BlazorDX.Primitives/DatePickerPrimitive.de.resx
+++ b/src/BlazorDX.Primitives/DatePickerPrimitive.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DatePickerPlaceholder" xml:space="preserve">
+    <value>Datum auswählen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Primitives/SelectPrimitiveResources.de.resx
+++ b/src/BlazorDX.Primitives/SelectPrimitiveResources.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SelectPlaceholder" xml:space="preserve">
+    <value>Auswählen…</value>
+  </data>
+</root>

--- a/tests/BlazorDX.Components.Tests/FrenchRenderingTests.cs
+++ b/tests/BlazorDX.Components.Tests/FrenchRenderingTests.cs
@@ -85,10 +85,15 @@ public sealed class FrenchRenderingTests : TestContext
     [Fact]
     public void An_unsupported_culture_falls_back_to_English_rather_than_a_key()
     {
-        // The chain that matters when a language is not shipped: de-DE has no satellite assembly,
+        // The chain that matters when a language is not shipped: ja-JP has no satellite assembly,
         // so resolution walks to the invariant resource. Rendering the key ("Loading") would look
         // almost right here, which is why the assertion is on the English word and not on absence.
-        using CultureScope _ = CultureScope.For("de-DE");
+        //
+        // This said de-DE until German shipped, at which point it started asserting that a
+        // translated language renders in English — and passed anyway, because "Loading" is what
+        // the missing satellite would also have produced. Any culture named here has to be one
+        // the library genuinely does not translate.
+        using CultureScope _ = CultureScope.For("ja-JP");
 
         IRenderedComponent<DxSpinner> spinner = RenderComponent<DxSpinner>();
 

--- a/tests/BlazorDX.Components.Tests/GermanRenderingTests.cs
+++ b/tests/BlazorDX.Components.Tests/GermanRenderingTests.cs
@@ -1,0 +1,96 @@
+using BlazorDX.Components;
+using BlazorDX.Interop;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// Renders components under a German UI culture and asserts the German text — the counterpart to
+/// <see cref="FrenchRenderingTests"/>, and for the same reason.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>TranslationCompletenessTests</c> proves the <c>.de.resx</c> files line up with the invariant
+/// ones. That is a check on the files: it would still pass if the German satellite assemblies were
+/// never produced, or produced and never found, and every string here would quietly render in
+/// English. Each language needs its own rendering test, because each is packaged separately and
+/// can therefore fail on its own.
+/// </para>
+/// <para>
+/// The cases cover the ways a resource can be reached, which fail independently: a plain component
+/// resource, a shared marker type, a composite-format string, and a value coalesced from a nullable
+/// parameter.
+/// </para>
+/// </remarks>
+public sealed class GermanRenderingTests : TestContext
+{
+    public GermanRenderingTests()
+    {
+        Services.AddLocalization();
+        Services.AddScoped<IChartZoomInterop, NullChartZoomInterop>();
+    }
+
+    [Fact]
+    public void A_plain_component_resource_resolves_in_German()
+    {
+        using CultureScope _ = CultureScope.For("de-DE");
+
+        IRenderedComponent<DxSpinner> spinner = RenderComponent<DxSpinner>();
+
+        Assert.Equal("Wird geladen", spinner.Find("[aria-label]").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void A_shared_marker_resource_resolves_in_German()
+    {
+        // DxChartResources is reached through a marker type rather than the component's own name.
+        using CultureScope _ = CultureScope.For("de-DE");
+
+        IRenderedComponent<DxSparkline> spark = RenderComponent<DxSparkline>(p => p
+            .Add(c => c.Points, [new ChartPoint(X: 1, Y: 1), new ChartPoint(X: 2, Y: 2)]));
+
+        Assert.Contains("Sparkline mit 2 Punkten", spark.Markup);
+    }
+
+    [Fact]
+    public void A_composite_format_string_keeps_its_arguments_in_German()
+    {
+        // Drop the {0} and "Kreisdiagramm mit Segmenten" is still fluent German that says nothing.
+        using CultureScope _ = CultureScope.For("de-DE");
+
+        IRenderedComponent<DxPieChart> pie = RenderComponent<DxPieChart>(p => p
+            .Add(c => c.Points, [
+                new ChartPoint(X: 1, Y: 1, Category: "A"),
+                new ChartPoint(X: 2, Y: 2, Category: "B"),
+                new ChartPoint(X: 3, Y: 3, Category: "C"),
+            ]));
+
+        Assert.Contains("Kreisdiagramm mit 3 Segmenten", pie.Markup);
+    }
+
+    [Fact]
+    public void A_coalesced_parameter_default_resolves_in_German()
+    {
+        using CultureScope _ = CultureScope.For("de-DE");
+
+        IRenderedComponent<DxSkipLink> link = RenderComponent<DxSkipLink>();
+
+        Assert.Contains("Zum Hauptinhalt springen", link.Markup);
+    }
+
+    [Fact]
+    public void Key_names_use_the_German_keyboard_convention()
+    {
+        // Not a translation of the English word but the name on a German keyboard: Strg, not
+        // "Kontrolle". The spoken form differs from the key cap on purpose, so both are asserted.
+        using CultureScope _ = CultureScope.For("de-DE");
+
+        IRenderedComponent<DxKbd> kbd = RenderComponent<DxKbd>(p => p.Add(c => c.Combo, "Ctrl+Shift"));
+
+        Assert.Equal("Strg", kbd.FindAll("kbd.dx-kbd")[0].TextContent);
+        Assert.Equal("Umschalt", kbd.FindAll("kbd.dx-kbd")[1].TextContent);
+        Assert.Equal("Steuerung plus Umschalttaste", kbd.Find(".dx-kbd-combo").GetAttribute("aria-label"));
+    }
+}

--- a/tests/BlazorDX.Components.Tests/TranslationCompletenessTests.cs
+++ b/tests/BlazorDX.Components.Tests/TranslationCompletenessTests.cs
@@ -6,8 +6,8 @@ using Xunit;
 namespace BlazorDX.Components.Tests;
 
 /// <summary>
-/// Every invariant <c>.resx</c> has a French counterpart, and the two agree on the things a
-/// translation must not change.
+/// Every invariant <c>.resx</c> is complete in every language the library ships, and each
+/// translation agrees with the English on the things a translation must not change.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -31,9 +31,10 @@ namespace BlazorDX.Components.Tests;
 ///   </item>
 /// </list>
 /// <para>
-/// What this deliberately does not check is whether French and English differ. They legitimately
+/// What this deliberately does not check is whether a translation differs from the English. They legitimately
 /// coincide for <i>Message</i>, <i>Documents</i>, <i>Actions</i>, <i>Options</i>, <i>Pagination</i>,
-/// <i>Total</i>, <i>Normal</i>, <i>Style</i>, <i>Saturation</i> and <i>Document</i>, and a rule
+/// <i>Total</i>, <i>Normal</i>, <i>Style</i>, <i>Saturation</i> and <i>Document</i> in French, and
+/// for <i>Name</i>, <i>Alt</i>, <i>Tab</i>, <i>Operator</i> and <i>Sepia</i> in German. A rule
 /// demanding a difference would only invite someone to invent one.
 /// </para>
 /// </remarks>
@@ -44,42 +45,53 @@ public sealed class TranslationCompletenessTests
     private static readonly Regex Placeholder = new(@"\{\d+(?::[^}]*)?\}", RegexOptions.Compiled);
 
     [Fact]
-    public void Every_resource_has_a_complete_French_counterpart()
+    public void Every_resource_is_complete_in_every_shipped_language()
     {
         List<string> problems = [];
+        string[] cultures = ShippedCultures();
         int compared = 0;
+
+        // Inferred, not hardcoded: the shipped set is whatever culture files exist, and every
+        // invariant resource must then carry all of them. Translating a new string into French
+        // and forgetting German fails here rather than shipping one English string to Germany.
+        Assert.True(cultures.Length > 0, "No culture-qualified .resx files found at all.");
 
         foreach (string invariant in InvariantResources())
         {
-            string french = invariant[..^".resx".Length] + ".fr.resx";
             string name = Path.GetFileName(invariant);
-
-            if (!File.Exists(french))
-            {
-                problems.Add($"{name} has no .fr.resx. Every string the library ships is "
-                    + "translated; a new resource file needs one too (docs/localization.md).");
-                continue;
-            }
-
             Dictionary<string, string> source = Read(invariant);
-            Dictionary<string, string> target = Read(french);
 
-            foreach (string key in source.Keys.Where(k => !target.ContainsKey(k)).OrderBy(k => k))
+            foreach (string culture in cultures)
             {
-                problems.Add($"{name}[\"{key}\"] has no French value, so it renders in English "
-                    + $"to a French user: \"{source[key]}\"");
-            }
+                string translated = $"{invariant[..^".resx".Length]}.{culture}.resx";
 
-            foreach (string key in target.Keys.Where(k => !source.ContainsKey(k)).OrderBy(k => k))
-            {
-                problems.Add($"{name}[\"{key}\"] exists only in French — the English string moved "
-                    + "or was removed, and the translation is now dead weight.");
-            }
+                if (!File.Exists(translated))
+                {
+                    problems.Add($"{name} has no .{culture}.resx. Every string the library ships is "
+                        + $"translated into {string.Join(", ", cultures)}; a new resource file needs "
+                        + "one per language (docs/localization.md).");
+                    continue;
+                }
 
-            foreach (string key in source.Keys.Where(target.ContainsKey).OrderBy(k => k))
-            {
-                compared++;
-                CompareOne(name, key, source[key], target[key], problems);
+                Dictionary<string, string> target = Read(translated);
+
+                foreach (string key in source.Keys.Where(k => !target.ContainsKey(k)).OrderBy(k => k))
+                {
+                    problems.Add($"{name}[\"{key}\"] has no {culture} value, so it renders in English "
+                        + $"to that user: \"{source[key]}\"");
+                }
+
+                foreach (string key in target.Keys.Where(k => !source.ContainsKey(k)).OrderBy(k => k))
+                {
+                    problems.Add($"{name}[\"{key}\"] exists only in {culture} — the English string "
+                        + "moved or was removed, and the translation is now dead weight.");
+                }
+
+                foreach (string key in source.Keys.Where(target.ContainsKey).OrderBy(k => k))
+                {
+                    compared++;
+                    CompareOne($"{name} [{culture}]", key, source[key], target[key], problems);
+                }
             }
         }
 
@@ -87,27 +99,27 @@ public sealed class TranslationCompletenessTests
         Assert.True(compared > 0, "No translated strings found. Have the .resx files moved?");
 
         Assert.True(problems.Count == 0,
-            "French resources do not line up with the invariant ones:" + Environment.NewLine
+            "Translated resources do not line up with the invariant ones:" + Environment.NewLine
             + string.Join(Environment.NewLine, problems.Select(p => "  " + p)));
     }
 
-    private static void CompareOne(string file, string key, string english, string french, List<string> problems)
+    private static void CompareOne(string file, string key, string english, string translated, List<string> problems)
     {
         string[] sourceHoles = [.. Placeholder.Matches(english).Select(m => m.Value).OrderBy(v => v, StringComparer.Ordinal)];
-        string[] targetHoles = [.. Placeholder.Matches(french).Select(m => m.Value).OrderBy(v => v, StringComparer.Ordinal)];
+        string[] targetHoles = [.. Placeholder.Matches(translated).Select(m => m.Value).OrderBy(v => v, StringComparer.Ordinal)];
 
         if (!sourceHoles.SequenceEqual(targetHoles, StringComparer.Ordinal))
         {
             problems.Add($"{file}[\"{key}\"] changes its placeholders, so the translated text loses "
                 + $"or misplaces its values.{Environment.NewLine}      en \"{english}\""
-                + $"{Environment.NewLine}      fr \"{french}\"");
+                + $"{Environment.NewLine}      ->  \"{translated}\"");
         }
 
-        if (StartsWithSpace(english) != StartsWithSpace(french) || EndsWithSpace(english) != EndsWithSpace(french))
+        if (StartsWithSpace(english) != StartsWithSpace(translated) || EndsWithSpace(english) != EndsWithSpace(translated))
         {
             problems.Add($"{file}[\"{key}\"] changes its leading or trailing space. These strings are "
                 + $"joined to adjacent markup, so the space is load-bearing.{Environment.NewLine}"
-                + $"      en \"{english}\"{Environment.NewLine}      fr \"{french}\"");
+                + $"      en \"{english}\"{Environment.NewLine}      ->  \"{translated}\"");
         }
     }
 
@@ -123,6 +135,24 @@ public sealed class TranslationCompletenessTests
                 data => data.Attribute("name")!.Value,
                 data => data.Element("value")?.Value ?? string.Empty,
                 StringComparer.Ordinal);
+
+    /// <summary>
+    /// The languages this library actually ships, read off the files rather than listed here.
+    /// </summary>
+    /// <remarks>
+    /// Keeping the list out of the test is what makes it catch the realistic mistake. A hardcoded
+    /// set has to be edited when a language is added, and whoever forgets to edit it also gets no
+    /// failure; inferring it means adding one <c>.de.resx</c> immediately demands the other 64.
+    /// </remarks>
+    private static string[] ShippedCultures() =>
+        [.. Directory.EnumerateFiles(Path.Combine(RepositoryRoot(), "src"), "*.resx", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Select(path => Path.GetFileNameWithoutExtension(path))
+            .Where(name => name.Contains('.', StringComparison.Ordinal))
+            .Select(name => name[(name.LastIndexOf('.') + 1)..])
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(culture => culture, StringComparer.Ordinal)];
 
     private static IEnumerable<string> InvariantResources() =>
         Directory.EnumerateFiles(Path.Combine(RepositoryRoot(), "src"), "*.resx", SearchOption.AllDirectories)


### PR DESCRIPTION
**65 `.de.resx` files, 291 strings**, alongside the French set — 582 translations over 65 invariant resources.

## The completeness test stops naming a language

`TranslationCompletenessTests` now **infers the shipped languages from the files that exist** and requires every invariant resource to carry all of them.

That's what catches the realistic mistake. A hardcoded list has to be edited when a language is added — and whoever forgets to edit it also gets no failure. Inferring it meant adding one `.de.resx` immediately demanded the other 64.

## Adding German broke a test silently, which is worth recording

`FrenchRenderingTests` pinned the fallback chain by rendering under **`de-DE`** — an unshipped language — and asserting the English word.

Once German shipped, that test was asserting *that a translated language renders in English*. **It still passed**, because the expected string was `"Loading"` either way. It now names `ja-JP`, with a comment saying the culture named there has to stay one the library genuinely doesn't translate.

## Why German gets its own rendering test

`GermanRenderingTests` mirrors the French one rather than extending it: satellite assemblies are packaged **per language and fail independently**, so each language needs its own proof that its resources are actually built and found.

It also covers the keyboard vocabulary, which is the part most easily got wrong by *translating* rather than *localizing* — the German key is `Strg`, not "Kontrolle", and the spoken form (`Steuerung`) differs from the cap on purpose.

## Conventions are per-language, not inherited from French

- No space before `:` (that's French typography); `„ “` rather than `« »`.
- Keyboard names follow the German keyboard: `Strg`, `Umschalt`, `Entf`, `Eingabe`, `Rücktaste`, `Leertaste`.
- Rich-text mnemonic caps follow the German word: **F** for *Fett*, **K** for *Kursiv*, **U** for *Unterstrichen*, **Ü** for *Überschrift* — never the English **B**/**I**.
- Buttons take the infinitive (`Herunterladen`), the German UI convention.
- Product and format names untouched: Power BI, PDF, CSV, Excel, Markdown, QR, EAN-13, Code 128, `.docx`, Sankey, Heatmap, Treemap, Sparkline, Boxplot.

## Verification

The generator refused to write until every invariant key was translated, every placeholder set matched, and edge whitespace lined up — and it now also refuses if any invariant file has no translations supplied at all, so a whole missed file can't slip through. **65 files, 291 strings, 0 problems**; the cross-culture check reports 582 comparisons clean.

Same caveat as the French pass, and it now applies twice: **I wrote these translations and they have not had native-speaker review.** That review is the difference between "translated" and "shipped in German" for a library making accessibility claims — it's now called out in the roadmap as remaining work rather than implied to be done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
