### PR TITLE
Expose a grid's data source to an assistant as a read-only AI tool

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,7 +51,8 @@ Raw component count is explicitly **not** the target — see *Out of scope*.
 - **Forms as AI tools**: one source-generated model renders a `DxForm` *and* projects a
   JSON-Schema tool definition served over the **Model Context Protocol** (incl. interop with
   standard `System.ComponentModel.DataAnnotations` models), with a runnable stdio server
-  ([`samples/BlazorDX.McpServer`](../samples/BlazorDX.McpServer)). The tool surface is **secured**:
+  ([`samples/BlazorDX.McpServer`](../samples/BlazorDX.McpServer), which also exposes a grid's
+  `IGridDataSource` as the matching read-only tool). The tool surface is **secured**:
   per-tool authorization, audit via the diagnostics sink, cancellation, and `[AiHidden]` /
   `[DxField(Sensitive)]` redaction of PII. See [docs/ai-integration.md](ai-integration.md).
 - **Packaging & delivery**: twelve NuGet packages (incl. analyzer/source-gen, and the opt-in
@@ -140,9 +141,11 @@ enhancements. None of this should be read as "ready"; it is a beta with work ahe
 
 ### Depth & breadth enhancements
 
-- **AI access** — the secured tool core, the stdio transport, and an HTTP (request/response)
-  endpoint are done; next are HTTP+SSE/sessions for server-initiated streaming, the DataGrid as
-  a read tool over `IGridDataSource`, and the wider MCP surface (resources / prompts). See
+- **AI access** — the secured tool core, the stdio transport, an HTTP (request/response) endpoint,
+  and both directions of the tool surface are done: an assistant writes through a `[DxFormModel]`
+  (`FormAiTool`) and reads through a grid's `IGridDataSource` (`GridAiTool`, read-only, columns as
+  a JSON-Schema `enum`, honest `totalCount`). Next are HTTP+SSE/sessions for server-initiated
+  streaming and the wider MCP surface (resources / prompts). See
   [docs/ai-integration.md](ai-integration.md).
 - **Chart interactivity** — shipped in full. Point selection, hover, and legend toggling
   (title-tag tooltips only, not a rich hover card). Zoom/pan for `DxLineChart`/`DxAreaChart`

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -102,6 +102,65 @@ app.MapPost("/mcp", async (HttpContext http) =>
 }).RequireAuthorization();   // HTTPS + auth in production
 ```
 
+## Reading: the grid as a tool
+
+A form is how an assistant *acts*. `GridAiTool<TRow>` is how it *looks something up* — it exposes
+an `IGridDataSource<TRow>` (the same server-side source `DxDataGrid` binds to for paging, sorting
+and filtering) as a read-only tool:
+
+```csharp
+server.Add(new GridAiTool<StockRow>(
+    "query_stock",
+    "Warehouse stock levels. Filter by SKU, product name or warehouse; sort by any column.",
+    new StockRowGridAccessor(),   // source-generated
+    new StockDataSource(),        // the same IGridDataSource the grid binds to
+    maxRows: 25));
+```
+
+The pair is the point. A write-only tool surface makes an assistant guess at its arguments; a
+read-only one leaves it narrating instead of acting. Together they close the loop, and neither is
+a bespoke AI endpoint — both are declarations the UI already uses.
+
+### The columns are the contract
+
+Schema, filtering, sorting and output all come from the generated `IGridRowAccessor<TRow>`, so the
+tool reaches exactly the properties marked `[GridColumn]` and nothing else. A property without the
+attribute appears in neither the grid nor the tool, which means **narrowing what an assistant may
+read is the same edit as narrowing what the grid shows** — not a second permission model kept in
+sync by hand. It also inherits [ADR 0002](adr/0002-zero-reflection-identity.md): there is no
+reflection, so no unlisted property can be reached at runtime.
+
+Because the column set is known at compile time, the schema names the columns as a JSON-Schema
+`enum` rather than asking for a free-text field name. A model cannot invent a column, and a wrong
+guess is a schema violation the host rejects rather than a query that quietly matches nothing. A
+guess that arrives anyway is answered with an error naming the real columns, so the model can
+correct itself instead of retrying blind.
+
+### Honest partial answers
+
+`maxRows` caps what one call can return, and `take` is **clamped rather than rejected** — a model
+asking for 1000 rows wants as many as it can have. What stops it reporting a page as if it were
+the whole answer is that the reply always carries the unclamped `totalCount`:
+
+```json
+{"totalCount":4210,"skip":0,"take":25,"rows":[…]}
+```
+
+Numeric columns are emitted as JSON numbers rather than display text, so a model can total or
+compare a column without re-parsing what it was just handed.
+
+### Always read-only
+
+`IGridDataSource` has no write path and this tool adds none, so `IsReadOnly` is hard-coded rather
+than a constructor flag — it cannot be set wrongly, and it reaches the client as
+`annotations.readOnlyHint` in `tools/list`. A host that wants a writable grid tool has to write
+one deliberately.
+
+The corollary belongs with the security model below: the data source is reached with the
+*server's* permissions, so an `IAiToolAuthorizer` is what stops an assistant reading rows its user
+could not have seen in the grid. A read tool is what makes that gate load-bearing rather than
+merely advisable.
+
 ## Security model
 
 Opening a system to AI is the highest-risk surface, so it inherits BlazorDX's security
@@ -234,6 +293,7 @@ malicious tool calls — and the errors are returned to the AI so it can self-co
 
 ## What's next
 
-The secured core and stdio transport are in place. Planned: the HTTP/SSE transport, exposing the
-DataGrid as a read tool over `IGridDataSource`, and the broader MCP surface (resources, prompts).
-See [ROADMAP.md](ROADMAP.md).
+The secured core, the stdio and HTTP transports, and both directions of the tool surface — writing
+through a form, reading through a grid — are in place. Planned: HTTP+SSE with sessions for
+server-initiated streaming, and the broader MCP surface (resources, prompts). See
+[ROADMAP.md](ROADMAP.md).

--- a/samples/BlazorDX.McpServer/Inventory.cs
+++ b/samples/BlazorDX.McpServer/Inventory.cs
@@ -1,0 +1,100 @@
+using BlazorDX.Primitives.Grid;
+
+namespace BlazorDX.McpServer;
+
+/// <summary>
+/// A row in the sample's stock list. The <c>[GridColumn]</c> attributes are what a
+/// <c>DxDataGrid</c> would render — and, through <see cref="BlazorDX.Primitives.Forms.GridAiTool{TRow}"/>,
+/// they are also exactly what an assistant can see.
+/// </summary>
+/// <remarks>
+/// <see cref="Cost"/> is deliberately not a column. It is a plain property with no attribute, so
+/// it appears in neither the grid nor the tool schema, and no query can reach it. Narrowing what
+/// an assistant may read is the same edit as narrowing what the grid shows, rather than a second
+/// permission model kept in sync by hand.
+/// </remarks>
+[GridRow]
+public sealed class StockRow
+{
+    [GridColumn("Sku", Order = 0)]
+    public string Sku { get; set; } = string.Empty;
+
+    [GridColumn("Product", Order = 1)]
+    public string Product { get; set; } = string.Empty;
+
+    [GridColumn("Warehouse", Order = 2)]
+    public string Warehouse { get; set; } = string.Empty;
+
+    [GridColumn("OnHand", Order = 3)]
+    public int OnHand { get; set; }
+
+    /// <summary>Not a <c>[GridColumn]</c>, so it is unreachable from the tool. See the remarks.</summary>
+    public decimal Cost { get; set; }
+}
+
+/// <summary>
+/// An in-memory stand-in for the server-side source a real grid would bind to — a database query,
+/// a search index, an upstream API.
+/// </summary>
+/// <remarks>
+/// The point of the sample is that this class is unchanged by being exposed to an assistant. It
+/// implements <see cref="IGridDataSource{TRow}"/> because a grid needs paging and filtering on the
+/// server; the AI tool then reuses that same contract, so the model is answered by the identical
+/// code path — and the identical authorization — that renders the page.
+/// </remarks>
+internal sealed class StockDataSource : IGridDataSource<StockRow>
+{
+    private static readonly StockRow[] All =
+    [
+        new() { Sku = "AX-1001", Product = "Hex bolt M6", Warehouse = "Leeds", OnHand = 4820, Cost = 0.04m },
+        new() { Sku = "AX-1002", Product = "Hex bolt M8", Warehouse = "Leeds", OnHand = 1290, Cost = 0.06m },
+        new() { Sku = "AX-1044", Product = "Hex nut M8", Warehouse = "Leeds", OnHand = 0, Cost = 0.03m },
+        new() { Sku = "BR-2201", Product = "Bearing 608ZZ", Warehouse = "Rotterdam", OnHand = 340, Cost = 1.15m },
+        new() { Sku = "BR-2208", Product = "Bearing 6202", Warehouse = "Rotterdam", OnHand = 12, Cost = 1.80m },
+        new() { Sku = "CB-3010", Product = "Cable tie 200mm", Warehouse = "Leeds", OnHand = 15600, Cost = 0.01m },
+        new() { Sku = "CB-3015", Product = "Cable gland M20", Warehouse = "Rotterdam", OnHand = 870, Cost = 0.44m },
+        new() { Sku = "SL-4400", Product = "Slide rail 300mm", Warehouse = "Gdansk", OnHand = 58, Cost = 7.90m },
+        new() { Sku = "SL-4406", Product = "Slide rail 450mm", Warehouse = "Gdansk", OnHand = 6, Cost = 9.40m },
+        new() { Sku = "WS-5000", Product = "Washer M6", Warehouse = "Gdansk", OnHand = 22400, Cost = 0.01m },
+    ];
+
+    public Task<GridDataPage<StockRow>> GetRowsAsync(GridDataRequest request, CancellationToken cancellationToken)
+    {
+        IEnumerable<StockRow> rows = All;
+
+        foreach (GridColumnFilter filter in request.Filters)
+        {
+            string text = filter.Text;
+            rows = rows.Where(row => Text(row, filter.Field).Contains(text, StringComparison.OrdinalIgnoreCase));
+        }
+
+        // Applied in reverse so the first key is the outermost sort, matching what the grid does
+        // with a multi-column header click.
+        foreach (GridSortKey key in request.Sort.Reverse())
+        {
+            rows = key.Descending
+                ? rows.OrderByDescending(row => Text(row, key.Field), StringComparer.OrdinalIgnoreCase)
+                : rows.OrderBy(row => Text(row, key.Field), StringComparer.OrdinalIgnoreCase);
+        }
+
+        StockRow[] materialized = [.. rows];
+
+        // The count is of the whole filtered set, not the page. The tool passes it straight
+        // through, which is what lets a model say "12 matched, here are the first 5" instead of
+        // reporting a page as if it were the answer.
+        return Task.FromResult(new GridDataPage<StockRow>(
+            [.. materialized.Skip(request.Skip).Take(request.Take)],
+            materialized.Length));
+    }
+
+    private static string Text(StockRow row, string field) => field switch
+    {
+        "Sku" => row.Sku,
+        "Product" => row.Product,
+        "Warehouse" => row.Warehouse,
+        // Padded so an ordinal comparison orders numbers numerically; a real source would sort in
+        // the database and would not need this.
+        "OnHand" => row.OnHand.ToString("D8", System.Globalization.CultureInfo.InvariantCulture),
+        _ => string.Empty,
+    };
+}

--- a/samples/BlazorDX.McpServer/Program.cs
+++ b/samples/BlazorDX.McpServer/Program.cs
@@ -1,15 +1,26 @@
 using BlazorDX.McpServer;
 using BlazorDX.Primitives.Forms;
 
-// Register the [DxFormModel] as a callable tool and serve MCP over stdio. A real server would
-// also pass an IAiToolAuthorizer (to gate tools per caller) and an IDxDiagnostics sink (to
-// audit calls); both are optional and omitted here to keep the sample minimal.
+// Two tools, because the pair is the point: the grid the app already renders becomes the
+// assistant's way to look something up, and the form the app already validates becomes its way
+// to act on what it found. Neither is a bespoke AI surface — both are declarations the UI uses.
+//
+// A real server would also pass an IAiToolAuthorizer (to gate tools per caller) and an
+// IDxDiagnostics sink (to audit calls); both are optional and omitted here to keep the sample
+// minimal.
 var server = new McpToolServer { ServerName = "BlazorDX MCP sample" }
     .Add(new FormAiTool<MeetingRequest>(
         new MeetingRequestFormModel(),
         () => new MeetingRequest(),
         (meeting, cancellationToken) =>
-            Task.FromResult($"Scheduled \"{meeting.Title}\" for {meeting.Attendees} attendee(s).")));
+            Task.FromResult($"Scheduled \"{meeting.Title}\" for {meeting.Attendees} attendee(s).")))
+    .Add(new GridAiTool<StockRow>(
+        "query_stock",
+        "Warehouse stock levels. Filter by SKU, product name or warehouse; sort by any column. "
+            + "Consult this before answering questions about what is in stock or running low.",
+        new StockRowGridAccessor(),
+        new StockDataSource(),
+        maxRows: 25));
 
 // Stop cleanly on Ctrl+C.
 using var cts = new CancellationTokenSource();

--- a/samples/BlazorDX.McpServer/README.md
+++ b/samples/BlazorDX.McpServer/README.md
@@ -1,12 +1,21 @@
 # BlazorDX MCP server (stdio sample)
 
-A runnable [Model Context Protocol](https://modelcontextprotocol.io) server that exposes a
-BlazorDX `[DxFormModel]` as an AI tool over **stdio**. It's the proof that *forms are AI
-tools*: the same annotated model `DxForm` renders for a human is the tool an assistant calls.
+A runnable [Model Context Protocol](https://modelcontextprotocol.io) server that exposes two
+BlazorDX declarations as AI tools over **stdio**: a `[DxFormModel]` and a `[GridRow]` bound to an
+`IGridDataSource`. It's the proof that *your UI is already the tool surface* — the annotated model
+`DxForm` renders and the columns `DxDataGrid` shows are what the assistant can respectively write
+and read.
 
 ```
-assistant ──spawns──► dotnet run (this) ──MCP/stdio──► McpToolServer ──► schedule_meeting tool
+                                        ┌─► query_stock       (read)  ← [GridRow] + IGridDataSource
+assistant ──spawns──► dotnet run ──MCP──┤
+                                        └─► schedule_meeting  (write) ← [DxFormModel]
 ```
+
+The pair is deliberate. A tool that only writes makes an assistant guess at its arguments; a tool
+that only reads leaves it narrating instead of acting. Together they are the whole loop: look
+something up in the same data source the grid binds to, then act on it through the same validation
+the form enforces.
 
 ## Run it
 
@@ -18,14 +27,31 @@ It then reads newline-delimited JSON-RPC on stdin and writes responses on stdout
 hand:
 
 ```bash
-printf '%s\n%s\n' \
+printf '%s\n%s\n%s\n' \
   '{"jsonrpc":"2.0","id":1,"method":"initialize"}' \
   '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"query_stock","arguments":{"filters":[{"column":"Warehouse","contains":"leeds"}],"sort":[{"column":"OnHand"}],"take":3}}}' \
   | dotnet run --project samples/BlazorDX.McpServer
 ```
 
-You'll get the `initialize` result and a `tools/list` containing `schedule_meeting` with its
-JSON-Schema (generated from the model's `[DxField]` attributes).
+You'll get the `initialize` result, a `tools/list` containing both tools with their JSON-Schemas,
+and a page of stock rows carrying the full `totalCount` alongside the three returned.
+
+## What the model can and cannot see
+
+`query_stock` derives everything — its schema, its filters, its sort keys, its output — from the
+generated `IGridRowAccessor<StockRow>`. So it reaches exactly the properties marked
+`[GridColumn]`, and `StockRow.Cost` (deliberately unmarked) is unreachable: it appears in neither
+the grid nor the tool. Narrowing what an assistant may read is the same edit as narrowing what the
+grid shows, not a second permission model kept in sync by hand.
+
+Because the column set is known, the schema names the columns as a JSON-Schema `enum` rather than
+asking for a free-text field name — a model cannot invent a column, and a wrong guess is a schema
+violation the host rejects rather than a query that quietly matches nothing.
+
+The tool is read-only and says so (`annotations.readOnlyHint`), because `IGridDataSource` has no
+write path. Rows per call are capped, and the reply always carries the unclamped `totalCount`, so
+a model that asked for everything is told plainly how much it did not see.
 
 ## Wire it into Claude Desktop
 
@@ -43,8 +69,9 @@ absolute path to the project, then restart Claude Desktop:
 }
 ```
 
-Ask the assistant to "schedule a meeting titled Q3 planning for 8 people" and it will call the
-tool — its arguments are validated by the *same* rules the rendered form uses.
+Then ask something that needs both tools — "which Leeds items are nearly out of stock? book me 30
+minutes to reorder them" — and watch it read through the grid's data source before writing through
+the form's validation.
 
 ## How it's wired (`Program.cs`)
 
@@ -53,11 +80,22 @@ var server = new McpToolServer { ServerName = "BlazorDX MCP sample" }
     .Add(new FormAiTool<MeetingRequest>(
         new MeetingRequestFormModel(),          // source-generated descriptor
         () => new MeetingRequest(),
-        (meeting, ct) => Task.FromResult($"Scheduled \"{meeting.Title}\".")));
+        (meeting, ct) => Task.FromResult($"Scheduled \"{meeting.Title}\".")))
+    .Add(new GridAiTool<StockRow>(
+        "query_stock",
+        "Warehouse stock levels. Filter by SKU, product name or warehouse…",
+        new StockRowGridAccessor(),             // source-generated accessor
+        new StockDataSource(),                  // the same IGridDataSource a grid would bind to
+        maxRows: 25));
 
 await McpStdioHost.RunAsync(server, Console.In, Console.Out, cts.Token);
 ```
 
+The description is the one part worth writing carefully: it is all the model has to decide *when*
+this tool is the right one to reach for.
+
 For production, also pass an `IAiToolAuthorizer` (to gate tools per caller) and an
 `IDxDiagnostics` sink (to audit every call) to the `McpToolServer` — both are optional and
-omitted here to keep the sample minimal.
+omitted here to keep the sample minimal. Authorization matters more once a read tool is present:
+the data source is reached with the server's own permissions, so a per-caller gate is what stops
+an assistant reading rows its user could not have seen in the grid.

--- a/src/BlazorDX.Primitives/Forms/GridAiTool.cs
+++ b/src/BlazorDX.Primitives/Forms/GridAiTool.cs
@@ -1,0 +1,305 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using BlazorDX.Primitives.Grid;
+
+namespace BlazorDX.Primitives.Forms;
+
+/// <summary>
+/// Exposes an <see cref="IGridDataSource{TRow}"/> to an assistant as a read-only
+/// <see cref="IAiTool"/>: the model can filter, sort and page the same server-side source the
+/// grid binds to, and gets back the same rows the grid would have shown.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The columns are the contract.</b> Schema, filtering, sorting and output all come from the
+/// generated <see cref="IGridRowAccessor{TRow}"/>, so the tool exposes exactly the columns the row
+/// type declares with <c>[GridColumn]</c> and nothing else — no reflection, and no way for a
+/// property that is not a column to reach the model. Narrowing what an assistant can see is
+/// therefore the same act as narrowing what the grid shows.
+/// </para>
+/// <para>
+/// Because the column set is known, the schema names the columns as an <c>enum</c> rather than
+/// asking for a free-text field name. A model cannot then invent a column, and a wrong guess is a
+/// schema violation the host rejects instead of a query that quietly matches nothing.
+/// </para>
+/// <para>
+/// <b>Always read-only.</b> <see cref="IGridDataSource{TRow}"/> has no write path, and this tool
+/// adds none. <see cref="IsReadOnly"/> is hard-coded rather than a constructor flag so it cannot be
+/// set wrongly — a host that wants a writable grid tool has to write one deliberately.
+/// </para>
+/// <para>
+/// <b>Rows are capped</b> by <c>maxRows</c>, and the reply always carries the unclamped
+/// <c>totalCount</c>. A model that asks for everything gets a page plus an honest statement of how
+/// much it did not see, which is what stops it reporting a partial answer as a complete one.
+/// </para>
+/// </remarks>
+/// <typeparam name="TRow">The row type, bound through its generated accessor.</typeparam>
+public sealed class GridAiTool<TRow> : IAiTool
+{
+    private readonly IGridRowAccessor<TRow> accessor;
+    private readonly IGridDataSource<TRow> source;
+    private readonly int maxRows;
+
+    /// <param name="name">The tool name an assistant calls, e.g. <c>query_orders</c>.</param>
+    /// <param name="description">What the data is. Worth writing well: it is the only thing
+    /// telling the model when this tool is the right one to reach for.</param>
+    /// <param name="accessor">The generated accessor for <typeparamref name="TRow"/>.</param>
+    /// <param name="source">The same data source the grid binds to.</param>
+    /// <param name="maxRows">Upper bound on rows per call, whatever the model asks for.</param>
+    public GridAiTool(
+        string name,
+        string? description,
+        IGridRowAccessor<TRow> accessor,
+        IGridDataSource<TRow> source,
+        int maxRows = 50)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(accessor);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxRows, 1);
+
+        Name = name;
+        Description = description;
+        this.accessor = accessor;
+        this.source = source;
+        this.maxRows = maxRows;
+    }
+
+    public string Name { get; }
+
+    public string? Description { get; }
+
+    /// <summary>Always <see langword="true"/>: this tool only reads.</summary>
+    public bool IsReadOnly => true;
+
+    public string InputSchemaJson
+    {
+        get
+        {
+            StringBuilder sb = new();
+            sb.Append("{\"type\":\"object\",\"properties\":{");
+
+            sb.Append("\"filters\":{\"type\":\"array\",\"description\":");
+            AppendString(sb, "Case-insensitive substring matches, combined with AND.");
+            sb.Append(",\"items\":{\"type\":\"object\",\"properties\":{\"column\":{");
+            AppendColumnEnum(sb);
+            sb.Append("},\"contains\":{\"type\":\"string\"}},\"required\":[\"column\",\"contains\"]}}");
+
+            sb.Append(",\"sort\":{\"type\":\"array\",\"description\":");
+            AppendString(sb, "Sort keys in priority order.");
+            sb.Append(",\"items\":{\"type\":\"object\",\"properties\":{\"column\":{");
+            AppendColumnEnum(sb);
+            sb.Append("},\"descending\":{\"type\":\"boolean\",\"default\":false}},\"required\":[\"column\"]}}");
+
+            sb.Append(",\"skip\":{\"type\":\"integer\",\"minimum\":0,\"default\":0,\"description\":");
+            AppendString(sb, "Rows to skip, for paging through a larger result.");
+
+            sb.Append("},\"take\":{\"type\":\"integer\",\"minimum\":1,\"maximum\":");
+            sb.Append(maxRows.ToString(CultureInfo.InvariantCulture));
+            sb.Append(",\"description\":");
+            AppendString(sb, $"Rows to return, at most {maxRows}.");
+            sb.Append("}}}");
+
+            return sb.ToString();
+        }
+    }
+
+    public async Task<AiToolResult> InvokeAsync(string argumentsJson, CancellationToken cancellationToken)
+    {
+        List<GridColumnFilter> filters = [];
+        List<GridSortKey> sort = [];
+        int skip = 0;
+        int take = Math.Min(20, maxRows);
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(
+                string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson);
+            JsonElement root = document.RootElement;
+
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return new AiToolResult(true, "Arguments must be a JSON object.");
+            }
+
+            if (root.TryGetProperty("filters", out JsonElement filterElement)
+                && filterElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement item in filterElement.EnumerateArray())
+                {
+                    string column = item.TryGetProperty("column", out JsonElement c) ? c.GetString() ?? string.Empty : string.Empty;
+                    string text = item.TryGetProperty("contains", out JsonElement t) ? t.GetString() ?? string.Empty : string.Empty;
+
+                    int index = IndexOfColumn(column);
+                    if (index < 0)
+                    {
+                        return new AiToolResult(true, UnknownColumn(column));
+                    }
+
+                    filters.Add(new GridColumnFilter(index, accessor.Columns[index].Header, text));
+                }
+            }
+
+            if (root.TryGetProperty("sort", out JsonElement sortElement)
+                && sortElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement item in sortElement.EnumerateArray())
+                {
+                    string column = item.TryGetProperty("column", out JsonElement c) ? c.GetString() ?? string.Empty : string.Empty;
+                    bool descending = item.TryGetProperty("descending", out JsonElement d)
+                        && d.ValueKind == JsonValueKind.True;
+
+                    int index = IndexOfColumn(column);
+                    if (index < 0)
+                    {
+                        return new AiToolResult(true, UnknownColumn(column));
+                    }
+
+                    sort.Add(new GridSortKey(index, accessor.Columns[index].Header, descending));
+                }
+            }
+
+            if (root.TryGetProperty("skip", out JsonElement skipElement)
+                && skipElement.TryGetInt32(out int parsedSkip))
+            {
+                skip = Math.Max(0, parsedSkip);
+            }
+
+            if (root.TryGetProperty("take", out JsonElement takeElement)
+                && takeElement.TryGetInt32(out int parsedTake))
+            {
+                // Clamped, not rejected: a model asking for 1000 rows wants as many as it can
+                // have, and the reply's totalCount tells it what it is still missing.
+                take = Math.Clamp(parsedTake, 1, maxRows);
+            }
+        }
+        catch (JsonException ex)
+        {
+            return new AiToolResult(true, "Arguments are not valid JSON: " + ex.Message);
+        }
+
+        GridDataPage<TRow> page = await source
+            .GetRowsAsync(new GridDataRequest(skip, take, sort, filters), cancellationToken)
+            .ConfigureAwait(false);
+
+        return new AiToolResult(false, Render(page, skip, take));
+    }
+
+    private string Render(GridDataPage<TRow> page, int skip, int take)
+    {
+        StringBuilder sb = new();
+        sb.Append("{\"totalCount\":").Append(page.TotalCount.ToString(CultureInfo.InvariantCulture));
+        sb.Append(",\"skip\":").Append(skip.ToString(CultureInfo.InvariantCulture));
+        sb.Append(",\"take\":").Append(take.ToString(CultureInfo.InvariantCulture));
+        sb.Append(",\"rows\":[");
+
+        bool firstRow = true;
+        foreach (TRow row in page.Rows)
+        {
+            if (!firstRow)
+            {
+                sb.Append(',');
+            }
+
+            firstRow = false;
+            sb.Append('{');
+
+            for (int column = 0; column < accessor.Columns.Count; column++)
+            {
+                if (column > 0)
+                {
+                    sb.Append(',');
+                }
+
+                AppendString(sb, accessor.Columns[column].Header);
+                sb.Append(':');
+
+                // Numeric columns are emitted as JSON numbers so a model can compare and total
+                // them without re-parsing text it was handed. GetCellValue answers NaN for
+                // anything it cannot express that way, which falls back to the display text.
+                double value = accessor.Columns[column].IsNumeric
+                    ? accessor.GetCellValue(row, column)
+                    : double.NaN;
+
+                if (double.IsFinite(value))
+                {
+                    sb.Append(value.ToString("R", CultureInfo.InvariantCulture));
+                }
+                else
+                {
+                    AppendString(sb, accessor.GetCellText(row, column));
+                }
+            }
+
+            sb.Append('}');
+        }
+
+        sb.Append("]}");
+        return sb.ToString();
+    }
+
+    private int IndexOfColumn(string header)
+    {
+        for (int i = 0; i < accessor.Columns.Count; i++)
+        {
+            if (string.Equals(accessor.Columns[i].Header, header, StringComparison.OrdinalIgnoreCase))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    // Naming the real columns back: a model that guessed wrong can correct itself from the error
+    // rather than retrying blind.
+    private string UnknownColumn(string column) =>
+        $"Unknown column \"{column}\". Available columns: "
+        + string.Join(", ", accessor.Columns.Select(c => c.Header)) + ".";
+
+    private void AppendColumnEnum(StringBuilder sb)
+    {
+        sb.Append("\"type\":\"string\",\"enum\":[");
+        for (int i = 0; i < accessor.Columns.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(',');
+            }
+
+            AppendString(sb, accessor.Columns[i].Header);
+        }
+
+        sb.Append(']');
+    }
+
+    private static void AppendString(StringBuilder sb, string value)
+    {
+        sb.Append('"');
+        foreach (char c in value)
+        {
+            switch (c)
+            {
+                case '"': sb.Append("\\\""); break;
+                case '\\': sb.Append("\\\\"); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                default:
+                    if (c < 0x20)
+                    {
+                        sb.Append("\\u").Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+
+                    break;
+            }
+        }
+
+        sb.Append('"');
+    }
+}

--- a/src/BlazorDX.Primitives/Forms/GridAiTool.cs
+++ b/src/BlazorDX.Primitives/Forms/GridAiTool.cs
@@ -128,8 +128,8 @@ public sealed class GridAiTool<TRow> : IAiTool
             {
                 foreach (JsonElement item in filterElement.EnumerateArray())
                 {
-                    string column = item.TryGetProperty("column", out JsonElement c) ? c.GetString() ?? string.Empty : string.Empty;
-                    string text = item.TryGetProperty("contains", out JsonElement t) ? t.GetString() ?? string.Empty : string.Empty;
+                    string column = TextOf(item, "column");
+                    string text = TextOf(item, "contains");
 
                     int index = IndexOfColumn(column);
                     if (index < 0)
@@ -146,7 +146,7 @@ public sealed class GridAiTool<TRow> : IAiTool
             {
                 foreach (JsonElement item in sortElement.EnumerateArray())
                 {
-                    string column = item.TryGetProperty("column", out JsonElement c) ? c.GetString() ?? string.Empty : string.Empty;
+                    string column = TextOf(item, "column");
                     bool descending = item.TryGetProperty("descending", out JsonElement d)
                         && d.ValueKind == JsonValueKind.True;
 
@@ -161,12 +161,14 @@ public sealed class GridAiTool<TRow> : IAiTool
             }
 
             if (root.TryGetProperty("skip", out JsonElement skipElement)
+                && skipElement.ValueKind == JsonValueKind.Number
                 && skipElement.TryGetInt32(out int parsedSkip))
             {
                 skip = Math.Max(0, parsedSkip);
             }
 
             if (root.TryGetProperty("take", out JsonElement takeElement)
+                && takeElement.ValueKind == JsonValueKind.Number
                 && takeElement.TryGetInt32(out int parsedTake))
             {
                 // Clamped, not rejected: a model asking for 1000 rows wants as many as it can
@@ -237,6 +239,29 @@ public sealed class GridAiTool<TRow> : IAiTool
 
         sb.Append("]}");
         return sb.ToString();
+    }
+
+    // Reads a property as text without trusting its JSON type. JsonElement.GetString() throws on
+    // anything but a string, and the models calling this tool do send {"column": 3} and
+    // {"contains": 2024} — a wrongly typed argument has to come back as a readable error the
+    // model can retry from, not as an exception surfacing at the transport as a dead call.
+    //
+    // A number is taken at its raw text, because that is what the caller meant; anything else
+    // becomes empty, which for a column name then fails with the "unknown column" error that
+    // lists the real ones.
+    private static string TextOf(JsonElement parent, string name)
+    {
+        if (!parent.TryGetProperty(name, out JsonElement value))
+        {
+            return string.Empty;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString() ?? string.Empty,
+            JsonValueKind.Number => value.GetRawText(),
+            _ => string.Empty,
+        };
     }
 
     private int IndexOfColumn(string header)

--- a/tests/BlazorDX.Components.Tests/GridAiToolTests.cs
+++ b/tests/BlazorDX.Components.Tests/GridAiToolTests.cs
@@ -175,6 +175,48 @@ public sealed class GridAiToolTests
     }
 
     [Fact]
+    public async Task A_wrongly_typed_argument_is_an_error_rather_than_an_exception()
+    {
+        // JsonElement.GetString() and TryGetInt32() both throw on a mismatched kind, and the
+        // caller here is a language model, which does send {"column": 3}. Escaping as an
+        // exception would surface at the transport as a dead call rather than something the
+        // model could read and correct, so every read is kind-checked first.
+        AiToolResult result = await NewTool(new RecordingSource()).InvokeAsync(
+            """{"filters":[{"column":3,"contains":"x"}]}""", CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Name, Quantity", result.Text);
+    }
+
+    [Fact]
+    public async Task A_string_where_a_number_belongs_falls_back_to_the_default()
+    {
+        RecordingSource source = new();
+
+        // {"take":"5"} used to throw out of TryGetInt32. Ignoring the bad value and answering the
+        // default page is the recoverable behaviour: the reply's totalCount still tells the model
+        // what it did not see, so it can ask again properly.
+        await NewTool(source).InvokeAsync("""{"take":"5","skip":"2"}""", CancellationToken.None);
+
+        Assert.Equal(20, source.Last!.Take);
+        Assert.Equal(0, source.Last.Skip);
+    }
+
+    [Fact]
+    public async Task A_numeric_filter_value_is_matched_as_its_text()
+    {
+        RecordingSource source = new();
+
+        // A model filtering a numeric column naturally sends a number, not a string. Dropping it
+        // would silently widen the query to every row, which is worse than either erroring or
+        // matching — so the raw text is used.
+        await NewTool(source).InvokeAsync(
+            """{"filters":[{"column":"Quantity","contains":20}]}""", CancellationToken.None);
+
+        Assert.Equal("20", Assert.Single(source.Last!.Filters).Text);
+    }
+
+    [Fact]
     public async Task Cell_text_is_escaped_so_the_reply_stays_parseable()
     {
         RecordingSource source = new()

--- a/tests/BlazorDX.Components.Tests/GridAiToolTests.cs
+++ b/tests/BlazorDX.Components.Tests/GridAiToolTests.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using System.Threading.Tasks;
+using BlazorDX.Primitives.Forms;
+using BlazorDX.Primitives.Grid;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// A server-side grid data source exposed to an assistant as a read-only tool: the model filters,
+/// sorts and pages the same source the grid binds to.
+/// </summary>
+/// <remarks>
+/// The schema and the reply are hand-built strings (zero-reflection, AOT-safe, per ADR 0002), so
+/// several of these tests parse the output rather than matching substrings. A stray comma or an
+/// unbalanced brace in a StringBuilder is exactly the defect this component can have, and it is
+/// one a substring assertion would sail straight past.
+/// </remarks>
+public sealed class GridAiToolTests
+{
+    // Recording source: the point of most of these tests is what reached the data source, not what
+    // came back, because translating the model's request is where this tool can be wrong.
+    private sealed class RecordingSource : IGridDataSource<WidgetRow>
+    {
+        public GridDataRequest? Last { get; private set; }
+
+        public List<WidgetRow> Rows { get; init; } =
+        [
+            new() { Name = "Alpha", Quantity = 10 },
+            new() { Name = "Beta", Quantity = 20 },
+        ];
+
+        public int TotalCount { get; init; } = 2;
+
+        public Task<GridDataPage<WidgetRow>> GetRowsAsync(GridDataRequest request, CancellationToken cancellationToken)
+        {
+            Last = request;
+            return Task.FromResult(new GridDataPage<WidgetRow>(Rows, TotalCount));
+        }
+    }
+
+    private static GridAiTool<WidgetRow> NewTool(RecordingSource source, int maxRows = 50) =>
+        new("query_widgets", "Widget inventory.", new WidgetRowGridAccessor(), source, maxRows);
+
+    [Fact]
+    public void The_tool_is_read_only()
+    {
+        // Not a constructor flag: IGridDataSource has no write path, so a writable grid tool is a
+        // thing someone has to build deliberately rather than switch on here by accident.
+        Assert.True(NewTool(new RecordingSource()).IsReadOnly);
+    }
+
+    [Fact]
+    public void The_schema_is_valid_json_and_names_the_real_columns()
+    {
+        string schema = NewTool(new RecordingSource()).InputSchemaJson;
+
+        using JsonDocument doc = JsonDocument.Parse(schema);
+        JsonElement properties = doc.RootElement.GetProperty("properties");
+
+        // The column is an enum, not a free-text field name. A model cannot invent a column, and a
+        // wrong guess is a schema violation rather than a query that silently matches nothing.
+        JsonElement columnEnum = properties
+            .GetProperty("filters").GetProperty("items")
+            .GetProperty("properties").GetProperty("column").GetProperty("enum");
+
+        string[] columns = [.. columnEnum.EnumerateArray().Select(e => e.GetString()!)];
+        Assert.Equal(["Name", "Quantity"], columns);
+
+        Assert.Equal(4, properties.EnumerateObject().Count());
+        Assert.Equal(50, properties.GetProperty("take").GetProperty("maximum").GetInt32());
+    }
+
+    [Fact]
+    public async Task Filters_and_sorts_are_translated_into_a_grid_request()
+    {
+        RecordingSource source = new();
+
+        await NewTool(source).InvokeAsync(
+            """{"filters":[{"column":"Name","contains":"al"}],"sort":[{"column":"Quantity","descending":true}]}""", CancellationToken.None);
+
+        GridDataRequest request = Assert.IsType<GridDataRequest>(source.Last);
+
+        // Both the index and the header travel: a data source maps whichever it prefers to its own
+        // query, and the index is meaningless without the header agreeing with it.
+        GridColumnFilter filter = Assert.Single(request.Filters);
+        Assert.Equal(0, filter.Column);
+        Assert.Equal("Name", filter.Field);
+        Assert.Equal("al", filter.Text);
+
+        GridSortKey sort = Assert.Single(request.Sort);
+        Assert.Equal(1, sort.Column);
+        Assert.Equal("Quantity", sort.Field);
+        Assert.True(sort.Descending);
+    }
+
+    [Fact]
+    public async Task An_unknown_column_is_an_error_that_names_the_real_ones()
+    {
+        AiToolResult result = await NewTool(new RecordingSource()).InvokeAsync(
+            """{"filters":[{"column":"Colour","contains":"red"}]}""", CancellationToken.None);
+
+        // Answering "unknown column" alone would leave the model guessing again. Listing them lets
+        // it correct itself on the next call.
+        Assert.True(result.IsError);
+        Assert.Contains("Colour", result.Text);
+        Assert.Contains("Name, Quantity", result.Text);
+    }
+
+    [Fact]
+    public async Task Take_is_clamped_rather_than_rejected()
+    {
+        RecordingSource source = new();
+
+        await NewTool(source, maxRows: 5).InvokeAsync(
+            """{"take":1000}""", CancellationToken.None);
+
+        // A model asking for everything wants as much as it can have; the totalCount in the reply
+        // is what tells it the answer is partial.
+        Assert.Equal(5, source.Last!.Take);
+    }
+
+    [Fact]
+    public async Task The_reply_reports_the_full_count_even_when_the_page_is_smaller()
+    {
+        RecordingSource source = new() { TotalCount = 4210 };
+
+        AiToolResult result = await NewTool(source).InvokeAsync(
+            """{"take":2}""", CancellationToken.None);
+
+        using JsonDocument doc = JsonDocument.Parse(result.Text);
+        Assert.Equal(4210, doc.RootElement.GetProperty("totalCount").GetInt32());
+        Assert.Equal(2, doc.RootElement.GetProperty("rows").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task Numeric_columns_come_back_as_numbers_and_text_columns_as_strings()
+    {
+        AiToolResult result = await NewTool(new RecordingSource()).InvokeAsync(
+            "{}", CancellationToken.None);
+
+        using JsonDocument doc = JsonDocument.Parse(result.Text);
+        JsonElement first = doc.RootElement.GetProperty("rows")[0];
+
+        // So a model can total or compare a column without re-parsing text it was just handed.
+        Assert.Equal(JsonValueKind.String, first.GetProperty("Name").ValueKind);
+        Assert.Equal(JsonValueKind.Number, first.GetProperty("Quantity").ValueKind);
+        Assert.Equal(10, first.GetProperty("Quantity").GetInt32());
+    }
+
+    [Fact]
+    public async Task Absent_and_empty_arguments_both_mean_the_default_page()
+    {
+        RecordingSource source = new();
+
+        await NewTool(source).InvokeAsync("{}", CancellationToken.None);
+        Assert.Equal(0, source.Last!.Skip);
+        Assert.Empty(source.Last.Filters);
+
+        // An assistant that sends nothing at all should not be an error either.
+        await NewTool(source).InvokeAsync(string.Empty, CancellationToken.None);
+        Assert.Equal(0, source.Last!.Skip);
+    }
+
+    [Fact]
+    public async Task Malformed_arguments_are_reported_rather_than_thrown()
+    {
+        // The model is the caller here, so a parse failure has to come back as something it can
+        // read and retry from — an exception would surface as a transport error instead.
+        AiToolResult result = await NewTool(new RecordingSource()).InvokeAsync(
+            "{not json", CancellationToken.None);
+
+        Assert.True(result.IsError);
+        Assert.Contains("not valid JSON", result.Text);
+    }
+
+    [Fact]
+    public async Task Cell_text_is_escaped_so_the_reply_stays_parseable()
+    {
+        RecordingSource source = new()
+        {
+            Rows = [new WidgetRow { Name = "He said \"hi\"\n\tand left", Quantity = 1 }],
+            TotalCount = 1,
+        };
+
+        AiToolResult result = await NewTool(source).InvokeAsync("{}", CancellationToken.None);
+
+        using JsonDocument doc = JsonDocument.Parse(result.Text);
+        Assert.Equal("He said \"hi\"\n\tand left", doc.RootElement.GetProperty("rows")[0].GetProperty("Name").GetString());
+    }
+}


### PR DESCRIPTION
## The gap

The MCP surface could only be *written* to. `FormAiTool` lets a model act, but nothing let it look
anything up first — so an assistant either guessed at its arguments or narrated instead of acting.

`GridAiTool<TRow>` is the other half: it exposes an `IGridDataSource<TRow>` — the same server-side
source `DxDataGrid` binds to for paging, sorting and filtering — as a read tool. The pair closes
the loop, and neither half is a bespoke AI endpoint: both are declarations the UI already uses.

## The columns are the contract

Schema, filters, sort keys and output all come from the generated `IGridRowAccessor<TRow>`, so the
tool reaches exactly the properties marked `[GridColumn]` and nothing else — with no reflection to
route around it (ADR 0002). **Narrowing what an assistant may read is the same edit as narrowing
what the grid shows**, rather than a second permission model kept in sync by hand. The sample makes
this concrete: `StockRow.Cost` carries no attribute and is unreachable from the tool.

Because the column set is known at compile time, the schema names columns as a JSON-Schema `enum`
rather than a free-text field name. A model cannot invent a column, and a wrong guess is a schema
violation the host rejects rather than a query that quietly matches nothing. One that arrives
anyway is answered with an error naming the real columns, so the model can correct itself instead
of retrying blind.

## Honest partial answers

`take` is **clamped rather than rejected** — a model asking for 1000 rows wants as many as it can
have. What stops a page being reported as the whole answer is that the reply always carries the
unclamped `totalCount`:

```json
{"totalCount":4210,"skip":0,"take":25,"rows":[…]}
```

Numeric columns are emitted as JSON numbers rather than display text, so a model can total or
compare a column without re-parsing what it was just handed.

`IsReadOnly` is hard-coded rather than a constructor flag: `IGridDataSource` has no write path, so
it cannot be set wrongly, and it reaches clients as `annotations.readOnlyHint` (already emitted by
`McpToolServer`). A writable grid tool is something a host has to write deliberately.

## Tests

The schema and the reply are hand-built strings, so the tests **parse them with `JsonDocument`**
rather than matching substrings — a stray comma or an unbalanced brace is exactly this component's
failure mode, and one a substring assertion sails straight past. Ten tests cover schema validity,
request translation (both the column index *and* the header travel), unknown columns, clamping,
`totalCount` vs. page size, numeric vs. text typing, empty/absent/malformed arguments, and
escaping.

Since `BlazorDX.Primitives` cannot be built locally (SDK Roslyn 5.3.0.0 vs the repo's pinned
5.9.0 → `CS9057`), I additionally mirrored `InputSchemaJson`'s append sequence out of the source
and JSON-parsed the result locally as a pre-CI check on brace balance. **CI is the real gate.**

## Samples & docs

`samples/BlazorDX.McpServer` now registers both tools and its README is rebuilt around the
read/write pair. `docs/ai-integration.md` gains a "Reading: the grid as a tool" section, which
notes the corollary belonging with the security model: the data source is reached with the
*server's* permissions, so a read tool makes `IAiToolAuthorizer` load-bearing rather than merely
advisable. Roadmap updated — this was one of the three named "AI access depth" items; HTTP+SSE
with sessions and the wider MCP surface (resources/prompts) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
