### PR TITLE
Serve MCP over HTTP with sessions and a server-to-client SSE stream

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -141,12 +141,12 @@ enhancements. None of this should be read as "ready"; it is a beta with work ahe
 
 ### Depth & breadth enhancements
 
-- **AI access** — the secured tool core, the stdio transport, an HTTP (request/response) endpoint,
-  and both directions of the tool surface are done: an assistant writes through a `[DxFormModel]`
-  (`FormAiTool`) and reads through a grid's `IGridDataSource` (`GridAiTool`, read-only, columns as
-  a JSON-Schema `enum`, honest `totalCount`). Next are HTTP+SSE/sessions for server-initiated
-  streaming and the wider MCP surface (resources / prompts). See
-  [docs/ai-integration.md](ai-integration.md).
+- **AI access** — the secured tool core, both transports, and both directions of the tool surface
+  are done: an assistant writes through a `[DxFormModel]` (`FormAiTool`) and reads through a
+  grid's `IGridDataSource` (`GridAiTool`, read-only, columns as a JSON-Schema `enum`, honest
+  `totalCount`), over stdio or over HTTP+SSE with sessions (`McpHttpHost` — `POST`/`GET`/`DELETE`,
+  cryptographically random session ids, bounded outbound queues, idle sweep). Next is the wider
+  MCP surface (resources / prompts). See [docs/ai-integration.md](ai-integration.md).
 - **Chart interactivity** — shipped in full. Point selection, hover, and legend toggling
   (title-tag tooltips only, not a rich hover card). Zoom/pan for `DxLineChart`/`DxAreaChart`
   (X-only, opt-in via `Zoomable`): see [ADR 0017](adr/0017-chart-zoom-pan-strategy.md).

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -78,18 +78,34 @@ string response = await server.HandleAsync(jsonRpcRequest, cancellationToken);
 | Transport | How | Status |
 |---|---|---|
 | **stdio** | `McpStdioHost.RunAsync(server, Console.In, Console.Out, ct)` — newline-delimited JSON-RPC. How local assistants (e.g. Claude Desktop) connect. | ✅ Built — see [`samples/BlazorDX.McpServer`](../samples/BlazorDX.McpServer) |
-| **HTTP** | A web agent POSTs a JSON-RPC message and gets the JSON-RPC response — the request/response subset of MCP Streamable HTTP. Enough for request/response tools. | ✅ Built — `/mcp` in the demo |
-| **HTTP + SSE / sessions** | Server-initiated streaming (progress, sampling) over Server-Sent Events with session ids. | Planned |
+| **HTTP + SSE / sessions** | `McpHttpHost` — `POST` for request/response, `GET` for a Server-Sent Events stream of server-initiated messages, `DELETE` to end a session. | ✅ Built — `/mcp` in the demo |
 
 A complete, runnable stdio server lives in [`samples/BlazorDX.McpServer`](../samples/BlazorDX.McpServer/README.md),
-with the exact Claude Desktop config. The HTTP transport is ~10 lines of standard ASP.NET Core,
-since the server is transport-agnostic — the host owns the transport:
+with the exact Claude Desktop config.
+
+### Why the HTTP transport is not an ASP.NET type
+
+`BlazorDX.Primitives` is browser-WASM safe: it references the Blazor component *packages*, not the
+ASP.NET Core framework. Binding the MCP transport to `HttpContext` would cost the whole library
+that guarantee for one feature. So `McpHttpHost` speaks in strings and status codes, and the host
+writes a short endpoint that moves bytes across.
+
+That trade pays twice. The transport rules — which status code an expired session gets, whether a
+notification may be answered, what `GET` returns when a server cannot stream — are **decided in a
+plain class and unit-tested without a web server**, which matters in a repo where the browser
+tests are the slowest thing in CI.
 
 ```csharp
-app.MapPost("/mcp", async (HttpContext http) =>
+McpSessionStore sessions = new();   // singleton; stdio needs none, its connection is the session
+
+app.MapMethods("/mcp", ["POST", "GET", "DELETE"], async (HttpContext http) =>
 {
-    using StreamReader reader = new(http.Request.Body);
-    string body = await reader.ReadToEndAsync(http.RequestAborted);
+    string? body = null;
+    if (HttpMethods.IsPost(http.Request.Method))
+    {
+        using StreamReader reader = new(http.Request.Body);
+        body = await reader.ReadToEndAsync(http.RequestAborted);
+    }
 
     McpToolServer mcp = new McpToolServer
     {
@@ -97,10 +113,71 @@ app.MapPost("/mcp", async (HttpContext http) =>
         Diagnostics = http.RequestServices.GetService<IDxDiagnostics>(),
     }.Add(/* your tools */);
 
-    string response = await mcp.HandleAsync(body, http.RequestAborted);
-    return Results.Content(response, "application/json");
+    McpHttpResponse result = await new McpHttpHost(mcp, sessions).HandleAsync(
+        new McpHttpRequest(http.Request.Method, body, http.Request.Headers["Mcp-Session-Id"]),
+        http.RequestAborted);
+
+    http.Response.StatusCode = result.StatusCode;
+    if (result.SessionId is not null)
+    {
+        http.Response.Headers["Mcp-Session-Id"] = result.SessionId;
+    }
+
+    if (result.Stream is not null)
+    {
+        http.Response.ContentType = result.ContentType!;
+        http.Response.Headers.CacheControl = "no-cache";
+        await http.Response.Body.FlushAsync(http.RequestAborted);
+
+        await foreach (string message in result.Stream.ReadAllAsync(http.RequestAborted))
+        {
+            await http.Response.WriteAsync(McpSse.Frame(message), http.RequestAborted);
+            await http.Response.Body.FlushAsync(http.RequestAborted);
+        }
+
+        return Results.Empty;
+    }
+
+    return result.Body is null
+        ? Results.Empty
+        : Results.Content(result.Body, result.ContentType, null, result.StatusCode);
 }).RequireAuthorization();   // HTTPS + auth in production
 ```
+
+### Sessions, and what they're for
+
+Sessions exist for the **server-to-client** direction. A tool call is a request the client already
+has an open response for; a progress update or a "the tool list changed" notice has no such
+response to ride on, so the client opens a long-lived `GET` that streams the session's queue.
+
+- `initialize` mints the session id and returns it as `Mcp-Session-Id`; every later request must
+  carry it.
+- An unknown id gets **404, not 401** — the caller is not unauthorized, its session is gone (swept,
+  deleted, or the server restarted). 404's meaning here is "initialize again", which is what the
+  client should do; 401 would send it to fetch credentials it already has.
+- The id comes from `RandomNumberGenerator`, not `Guid`. It is the only thing separating one
+  caller's session from another's, so it is a credential and has to be unguessable, not merely
+  unique.
+- Each session's outbound queue is **bounded and lossy on purpose**. A client that opens a session
+  and never drains it would otherwise grow the server's memory without limit, and a disconnected
+  client is the case that actually happens. `TryPost` returns `false` rather than blocking or
+  growing, and `Broadcast` returns how many sessions *accepted* the message rather than how many
+  exist — a broadcast that quietly reached fewer clients than it claims is worse than one that
+  says so.
+- Call `Sweep(idleTimeout)` on a timer. A client can vanish without a `DELETE`, so without a sweep
+  the store only grows.
+
+Server-initiated notifications are opt-in:
+
+```csharp
+McpToolServer mcp = new() { NotifiesToolListChanged = true };   // a promise
+sessions.Broadcast(McpToolServer.ToolListChangedNotification);  // that you then keep
+```
+
+`NotifiesToolListChanged` is off by default and should stay off unless something actually
+broadcasts. Advertising the capability without delivering is worse than not advertising it: the
+client stops re-listing, waits for a notice that never comes, and works from a stale tool list
+forever with no error anywhere to explain why.
 
 ## Reading: the grid as a tool
 
@@ -293,7 +370,6 @@ malicious tool calls — and the errors are returned to the AI so it can self-co
 
 ## What's next
 
-The secured core, the stdio and HTTP transports, and both directions of the tool surface — writing
-through a form, reading through a grid — are in place. Planned: HTTP+SSE with sessions for
-server-initiated streaming, and the broader MCP surface (resources, prompts). See
-[ROADMAP.md](ROADMAP.md).
+The secured core, both transports (stdio and HTTP+SSE with sessions), and both directions of the
+tool surface — writing through a form, reading through a grid — are in place. Planned: the broader
+MCP surface (resources, prompts). See [ROADMAP.md](ROADMAP.md).

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/Program.cs
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/Program.cs
@@ -277,10 +277,18 @@ app.MapMethods("/mcp", ["POST", "GET", "DELETE"], async (HttpContext http) =>
         http.Response.Headers.CacheControl = "no-cache";
         await http.Response.Body.FlushAsync(http.RequestAborted);
 
-        await foreach (string message in result.Stream.ReadAllAsync(http.RequestAborted))
+        try
         {
-            await http.Response.WriteAsync(McpSse.Frame(message), http.RequestAborted);
-            await http.Response.Body.FlushAsync(http.RequestAborted);
+            await foreach (string message in result.Stream.ReadAllAsync(http.RequestAborted))
+            {
+                await http.Response.WriteAsync(McpSse.Frame(message), http.RequestAborted);
+                await http.Response.Body.FlushAsync(http.RequestAborted);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The client hung up. That is how a listening stream normally ends — letting the
+            // cancellation escape would log every ordinary disconnect as a server error.
         }
 
         return Results.Empty;

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/Program.cs
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/Program.cs
@@ -218,19 +218,37 @@ app.MapPost("/htmx/echo", (HttpContext http) =>
     return Results.Content(fragment, "text/html");
 }).DisableAntiforgery();
 
-// MCP over HTTP — the JSON request/response subset of the Streamable HTTP transport, which is
-// enough for request/response tools (server-initiated SSE/sessions are a follow-up). A web
-// agent POSTs a JSON-RPC message and gets the JSON-RPC response. The same McpToolServer that
-// runs over stdio (samples/BlazorDX.McpServer) is the engine.
+// MCP over HTTP — the full Streamable HTTP shape: POST for request/response, GET for the
+// Server-Sent Events stream carrying server-initiated messages, DELETE to end a session. The
+// same McpToolServer that runs over stdio (samples/BlazorDX.McpServer) is the engine.
+//
+// McpHttpHost decides every status code and header; this endpoint only moves bytes. That split
+// is deliberate: BlazorDX.Primitives is browser-WASM safe and references the Blazor component
+// packages rather than the ASP.NET Core framework, so the transport rules cannot mention
+// HttpContext. What it costs is the ~30 lines below; what it buys is a transport whose rules are
+// unit-tested without a web server.
 //
 // PRODUCTION: protect this endpoint with `.RequireAuthorization()` and pass an
 // `IAiToolAuthorizer` to the McpToolServer so tools are gated per caller. This demo exposes a
 // single harmless echo tool anonymously, and audits every call to the diagnostics sink.
-app.MapPost("/mcp", async (HttpContext http) =>
-{
-    using StreamReader reader = new(http.Request.Body);
-    string body = await reader.ReadToEndAsync(http.RequestAborted);
+McpSessionStore mcpSessions = new();
 
+app.MapMethods("/mcp", ["POST", "GET", "DELETE"], async (HttpContext http) =>
+{
+    string? body = null;
+    if (HttpMethods.IsPost(http.Request.Method))
+    {
+        using StreamReader reader = new(http.Request.Body);
+        body = await reader.ReadToEndAsync(http.RequestAborted);
+    }
+
+    // Opportunistic expiry. A client can vanish without a DELETE — a closed tab, a crash, a
+    // partition — so something has to reclaim sessions or the store only ever grows. Doing it per
+    // request keeps the sample free of a background service; a real server would use one.
+    mcpSessions.Sweep(TimeSpan.FromMinutes(30));
+
+    // NotifiesToolListChanged stays off: this server's tool set is fixed, so promising
+    // notifications/tools/list_changed would leave a client waiting for a notice never sent.
     McpToolServer mcp = new McpToolServer
     {
         ServerName = "BlazorDX demo",
@@ -240,8 +258,40 @@ app.MapPost("/mcp", async (HttpContext http) =>
         () => new MeetingRequest(),
         (meeting, ct) => Task.FromResult($"Scheduled \"{meeting.Title}\" for {meeting.Attendees} attendee(s).")));
 
-    string response = await mcp.HandleAsync(body, http.RequestAborted);
-    return Results.Content(response, "application/json");
+    McpHttpResponse result = await new McpHttpHost(mcp, mcpSessions).HandleAsync(
+        new McpHttpRequest(http.Request.Method, body, http.Request.Headers["Mcp-Session-Id"]),
+        http.RequestAborted);
+
+    http.Response.StatusCode = result.StatusCode;
+    if (result.SessionId is not null)
+    {
+        http.Response.Headers["Mcp-Session-Id"] = result.SessionId;
+    }
+
+    if (result.Stream is not null)
+    {
+        // A long-lived response. no-cache and an immediate flush matter: a proxy that buffers
+        // this turns "server pushes a message" into "server pushes a message some minutes later",
+        // which looks exactly like the feature not working.
+        http.Response.ContentType = result.ContentType!;
+        http.Response.Headers.CacheControl = "no-cache";
+        await http.Response.Body.FlushAsync(http.RequestAborted);
+
+        await foreach (string message in result.Stream.ReadAllAsync(http.RequestAborted))
+        {
+            await http.Response.WriteAsync(McpSse.Frame(message), http.RequestAborted);
+            await http.Response.Body.FlushAsync(http.RequestAborted);
+        }
+
+        return Results.Empty;
+    }
+
+    // The status code goes through Results.Content explicitly — it would otherwise write 200 over
+    // the 400/404 already set on the response, turning a protocol error into an apparent success
+    // carrying an error body.
+    return result.Body is null
+        ? Results.Empty
+        : Results.Content(result.Body, result.ContentType, contentEncoding: null, statusCode: result.StatusCode);
 }).DisableAntiforgery();
 
 app.Run();

--- a/src/BlazorDX.Primitives/Forms/McpHttpHost.cs
+++ b/src/BlazorDX.Primitives/Forms/McpHttpHost.cs
@@ -1,0 +1,180 @@
+using System.Text;
+
+namespace BlazorDX.Primitives.Forms;
+
+/// <summary>One inbound HTTP request, reduced to the parts the MCP transport actually reads.</summary>
+/// <param name="Method">The HTTP method, e.g. <c>POST</c>. Case-insensitive.</param>
+/// <param name="Body">The request body, for <c>POST</c>.</param>
+/// <param name="SessionId">The <c>Mcp-Session-Id</c> request header, if the client sent one.</param>
+public sealed record McpHttpRequest(string Method, string? Body = null, string? SessionId = null);
+
+/// <summary>
+/// What the endpoint should send back. Either <see cref="Body"/> (a complete response) or
+/// <see cref="Stream"/> (an open server-to-client stream) is set, never both.
+/// </summary>
+/// <param name="StatusCode">The HTTP status to return.</param>
+/// <param name="ContentType">The <c>Content-Type</c>, when there is a body or a stream.</param>
+/// <param name="Body">The complete response body, if any.</param>
+/// <param name="SessionId">Set the <c>Mcp-Session-Id</c> response header to this, if non-null.</param>
+/// <param name="Stream">When set, write <see cref="McpSse.Frame"/> of each message from
+/// <see cref="McpSession.ReadAllAsync"/> until it ends.</param>
+public sealed record McpHttpResponse(
+    int StatusCode,
+    string? ContentType = null,
+    string? Body = null,
+    string? SessionId = null,
+    McpSession? Stream = null);
+
+/// <summary>
+/// Server-Sent Events framing. Kept separate from the host because the framing is the only part
+/// an endpoint has to get byte-exact, and it is worth being able to test on its own.
+/// </summary>
+public static class McpSse
+{
+    /// <summary>
+    /// Frames one message as an SSE <c>data:</c> event.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every line needs its own <c>data:</c> prefix. A JSON-RPC message containing a newline —
+    /// which any tool returning multi-line text produces — would otherwise be cut in half by the
+    /// first bare newline, and the client would see a truncated event followed by garbage.
+    /// </para>
+    /// <para>
+    /// The framing round-trips: a client joins the <c>data:</c> lines with <c>\n</c> and strips
+    /// one trailing <c>\n</c>, recovering the message exactly — including leading spaces, empty
+    /// lines, and a trailing newline. The one exception is <c>\r\n</c> inside the payload, which
+    /// normalises to <c>\n</c>. That is harmless for JSON-RPC, where a real carriage return inside
+    /// a string is escaped as <c>\\r</c> and a literal CRLF can only be insignificant whitespace.
+    /// </para>
+    /// </remarks>
+    public static string Frame(string message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        StringBuilder sb = new();
+        foreach (ReadOnlySpan<char> line in message.AsSpan().EnumerateLines())
+        {
+            sb.Append("data: ").Append(line).Append('\n');
+        }
+
+        // The blank line is what dispatches the event; without it the client buffers forever.
+        sb.Append('\n');
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Serves an <see cref="McpToolServer"/> over MCP's HTTP transport: <c>POST</c> for
+/// request/response, <c>GET</c> for a Server-Sent Events stream carrying server-initiated
+/// messages, and <c>DELETE</c> to end a session.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type speaks in strings and status codes rather than <c>HttpContext</c>, deliberately.
+/// <c>BlazorDX.Primitives</c> is browser-WASM safe and references the Blazor component packages
+/// rather than the ASP.NET Core framework, so binding the transport to a web framework would cost
+/// the whole library that guarantee for one feature. The trade is that a host writes a short
+/// endpoint to move headers and the body across — see <c>samples/BlazorDX.McpServer</c> — and gets
+/// a transport that is unit-testable without a web server in exchange.
+/// </para>
+/// <para>
+/// <b>Sessions are optional.</b> Without an <see cref="McpSessionStore"/> this is a plain
+/// request/response endpoint and <c>GET</c> answers <c>405</c>, which is what the protocol
+/// prescribes for a server that cannot stream. With a store, <c>initialize</c> mints a session id,
+/// every later request must carry it, and an unknown id answers <c>404</c> so the client knows to
+/// initialize again rather than retrying forever.
+/// </para>
+/// </remarks>
+/// <param name="server">The tool server handling JSON-RPC.</param>
+/// <param name="sessions">Session store; omit for a request/response-only endpoint.</param>
+public sealed class McpHttpHost(McpToolServer server, McpSessionStore? sessions = null)
+{
+    private const string Json = "application/json";
+    private const string EventStream = "text/event-stream";
+
+    /// <summary>The session store, or null when this host is request/response only.</summary>
+    public McpSessionStore? Sessions => sessions;
+
+    /// <summary>Applies the transport rules to one request.</summary>
+    public async Task<McpHttpResponse> HandleAsync(
+        McpHttpRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return request.Method.ToUpperInvariant() switch
+        {
+            "POST" => await PostAsync(request, cancellationToken),
+            "GET" => Get(request),
+            "DELETE" => Delete(request),
+            _ => new McpHttpResponse(405),
+        };
+    }
+
+    private async Task<McpHttpResponse> PostAsync(McpHttpRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Body))
+        {
+            return new McpHttpResponse(400, Json, McpToolServer.ErrorJson("null", -32600, "Empty request body."));
+        }
+
+        bool initializing = McpToolServer.IsInitialize(request.Body);
+        McpSession? session = null;
+
+        if (sessions is not null)
+        {
+            if (initializing)
+            {
+                session = sessions.Create();
+            }
+            else if (!sessions.TryGet(request.SessionId, out session))
+            {
+                // 404, not 401: the client is not unauthorized, its session is gone (swept,
+                // deleted, or the server restarted). The protocol's meaning of 404 here is
+                // "initialize again", which is exactly what it should do.
+                return new McpHttpResponse(404, Json, McpToolServer.ErrorJson("null", -32001, "Unknown or expired session."));
+            }
+        }
+
+        // A notification carries no id and JSON-RPC forbids answering it, so there is nothing to
+        // return but an acknowledgement that it was accepted.
+        if (!McpToolServer.ExpectsResponse(request.Body))
+        {
+            await server.HandleAsync(request.Body, cancellationToken);
+            return new McpHttpResponse(202, SessionId: session?.Id);
+        }
+
+        string body = await server.HandleAsync(request.Body, cancellationToken);
+        return new McpHttpResponse(200, Json, body, session?.Id);
+    }
+
+    private McpHttpResponse Get(McpHttpRequest request)
+    {
+        if (sessions is null)
+        {
+            // The protocol's way of saying "this server never initiates messages". A client that
+            // gets this simply does not open a listening stream.
+            return new McpHttpResponse(405);
+        }
+
+        if (!sessions.TryGet(request.SessionId, out McpSession? session))
+        {
+            return new McpHttpResponse(404, Json, McpToolServer.ErrorJson("null", -32001, "Unknown or expired session."));
+        }
+
+        return new McpHttpResponse(200, EventStream, Stream: session);
+    }
+
+    private McpHttpResponse Delete(McpHttpRequest request)
+    {
+        if (sessions is null)
+        {
+            return new McpHttpResponse(405);
+        }
+
+        // Terminating an already-terminated session is a client retrying, not an error.
+        sessions.Terminate(request.SessionId);
+        return new McpHttpResponse(204);
+    }
+}

--- a/src/BlazorDX.Primitives/Forms/McpSession.cs
+++ b/src/BlazorDX.Primitives/Forms/McpSession.cs
@@ -1,0 +1,240 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Threading.Channels;
+
+namespace BlazorDX.Primitives.Forms;
+
+/// <summary>
+/// One client's connection to an <see cref="McpToolServer"/> over a transport that has no
+/// connection of its own — HTTP. It holds the queue of messages the <em>server</em> wants to send
+/// the client, which is the thing a request/response endpoint cannot express.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Sessions exist for the server-to-client direction. A tool call is a request the client already
+/// has an open response for; a progress update, a "the tool list changed" notice, or anything the
+/// app decides to volunteer has no such response to ride on. The client opens a long-lived
+/// <c>GET</c> that streams this queue instead.
+/// </para>
+/// <para>
+/// The queue is <b>bounded and lossy by design</b>. A client that opened a session and never
+/// drained it would otherwise grow the server's memory without limit, and a disconnected client is
+/// exactly the case that happens in production. <see cref="TryPost"/> returns
+/// <see langword="false"/> rather than blocking or growing, so a caller learns its notification
+/// was dropped instead of discovering the leak later.
+/// </para>
+/// </remarks>
+public sealed class McpSession
+{
+    private readonly Channel<string> outbound;
+    private long lastSeenTicks;
+
+    internal McpSession(string id, int capacity, DateTimeOffset now)
+    {
+        Id = id;
+        Created = now;
+        lastSeenTicks = now.UtcTicks;
+
+        // Wait, not one of the Drop modes, precisely because we only ever TryWrite: under Wait a
+        // full queue makes TryWrite return false, whereas every Drop* mode returns true and
+        // discards the item — which would make TryPost claim a delivery it did not make. Nothing
+        // ever actually waits here, because TryWrite does not block.
+        //
+        // SingleReader stays false: the protocol says a client should not open two streams on one
+        // session, but "should not" is not "cannot", and two readers on a single-reader channel is
+        // undefined behaviour rather than a handled error.
+        outbound = Channel.CreateBounded<string>(new BoundedChannelOptions(capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = false,
+        });
+    }
+
+    /// <summary>The session id, sent to the client as <c>Mcp-Session-Id</c>.</summary>
+    public string Id { get; }
+
+    /// <summary>When the session was created.</summary>
+    public DateTimeOffset Created { get; }
+
+    /// <summary>When the client was last seen, used by <see cref="McpSessionStore.Sweep"/>.</summary>
+    public DateTimeOffset LastSeen => new(Interlocked.Read(ref lastSeenTicks), TimeSpan.Zero);
+
+    internal void Touch(DateTimeOffset now) => Interlocked.Exchange(ref lastSeenTicks, now.UtcTicks);
+
+    /// <summary>
+    /// Queues a JSON-RPC message for delivery to the client. Returns <see langword="false"/> if
+    /// the queue is full (a client that is not draining it) or the session has been terminated —
+    /// in both cases the message is dropped, and the caller is told so rather than left to assume
+    /// it arrived.
+    /// </summary>
+    public bool TryPost(string message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        return outbound.Writer.TryWrite(message);
+    }
+
+    /// <summary>
+    /// Streams queued messages until the session is terminated or the token is cancelled. This is
+    /// what an SSE endpoint iterates.
+    /// </summary>
+    public IAsyncEnumerable<string> ReadAllAsync(CancellationToken cancellationToken = default) =>
+        outbound.Reader.ReadAllAsync(cancellationToken);
+
+    // Completing the writer ends every in-flight ReadAllAsync, so terminating a session also ends
+    // the streaming response holding it open.
+    internal void Close() => outbound.Writer.TryComplete();
+}
+
+/// <summary>
+/// The live <see cref="McpSession"/>s, keyed by id. Attach one to <see cref="McpHttpHost"/> to
+/// serve MCP over HTTP; stdio needs none, because its connection <em>is</em> the session.
+/// </summary>
+/// <remarks>
+/// Session ids are generated with <see cref="RandomNumberGenerator"/>, not <see cref="Guid"/>:
+/// the id is the only thing separating one caller's session from another's, so it is a credential
+/// and has to be unguessable rather than merely unique.
+/// </remarks>
+public sealed class McpSessionStore
+{
+    private readonly Dictionary<string, McpSession> sessions = new(StringComparer.Ordinal);
+    private readonly Lock gate = new();
+
+    /// <summary>Clock source. Override in tests so expiry does not depend on wall time.</summary>
+    public TimeProvider TimeProvider { get; init; } = TimeProvider.System;
+
+    /// <summary>How many server-to-client messages one session may buffer before dropping.</summary>
+    public int QueueCapacity { get; init; } = 256;
+
+    /// <summary>The number of live sessions.</summary>
+    public int Count
+    {
+        get
+        {
+            lock (gate)
+            {
+                return sessions.Count;
+            }
+        }
+    }
+
+    /// <summary>Mints a new session with a cryptographically random id.</summary>
+    public McpSession Create()
+    {
+        // 32 hex characters = 128 bits. Visible ASCII only, as the transport puts it in a header.
+        string id = Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
+        McpSession session = new(id, QueueCapacity, TimeProvider.GetUtcNow());
+
+        lock (gate)
+        {
+            sessions[id] = session;
+        }
+
+        return session;
+    }
+
+    /// <summary>Looks up a live session and marks it seen. Returns false for unknown or terminated ids.</summary>
+    public bool TryGet(string? id, [NotNullWhen(true)] out McpSession? session)
+    {
+        session = null;
+        if (string.IsNullOrEmpty(id))
+        {
+            return false;
+        }
+
+        lock (gate)
+        {
+            if (!sessions.TryGetValue(id, out session))
+            {
+                return false;
+            }
+        }
+
+        session.Touch(TimeProvider.GetUtcNow());
+        return true;
+    }
+
+    /// <summary>
+    /// Ends a session and closes any stream holding it open. Returns whether it existed — a
+    /// second <c>DELETE</c> is not an error, it is a client retrying.
+    /// </summary>
+    public bool Terminate(string? id)
+    {
+        if (string.IsNullOrEmpty(id))
+        {
+            return false;
+        }
+
+        McpSession? session;
+        lock (gate)
+        {
+            if (!sessions.Remove(id, out session))
+            {
+                return false;
+            }
+        }
+
+        session.Close();
+        return true;
+    }
+
+    /// <summary>
+    /// Drops sessions unseen for longer than <paramref name="idleTimeout"/> and returns how many
+    /// went. A client can vanish without a <c>DELETE</c> — a browser tab closing, a crash, a
+    /// network partition — so without a sweep the store only ever grows.
+    /// </summary>
+    public int Sweep(TimeSpan idleTimeout)
+    {
+        DateTimeOffset cutoff = TimeProvider.GetUtcNow() - idleTimeout;
+        List<McpSession> expired = [];
+
+        lock (gate)
+        {
+            foreach (KeyValuePair<string, McpSession> entry in sessions)
+            {
+                if (entry.Value.LastSeen <= cutoff)
+                {
+                    expired.Add(entry.Value);
+                }
+            }
+
+            foreach (McpSession session in expired)
+            {
+                sessions.Remove(session.Id);
+            }
+        }
+
+        foreach (McpSession session in expired)
+        {
+            session.Close();
+        }
+
+        return expired.Count;
+    }
+
+    /// <summary>
+    /// Queues a message to every live session, returning how many accepted it. The count is
+    /// deliberately not the session count: a session whose queue is full drops the message, and a
+    /// broadcast that quietly reached fewer clients than it claims is worse than one that says so.
+    /// </summary>
+    public int Broadcast(string message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        McpSession[] snapshot;
+        lock (gate)
+        {
+            snapshot = [.. sessions.Values];
+        }
+
+        int delivered = 0;
+        foreach (McpSession session in snapshot)
+        {
+            if (session.TryPost(message))
+            {
+                delivered++;
+            }
+        }
+
+        return delivered;
+    }
+}

--- a/src/BlazorDX.Primitives/Forms/McpStdioHost.cs
+++ b/src/BlazorDX.Primitives/Forms/McpStdioHost.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-
 namespace BlazorDX.Primitives.Forms;
 
 /// <summary>
@@ -39,28 +37,13 @@ public static class McpStdioHost
 
             string response = await server.HandleAsync(line, cancellationToken);
 
-            // JSON-RPC forbids replying to a notification (a request carrying no "id").
-            if (ExpectsResponse(line))
+            // JSON-RPC forbids replying to a notification (a request carrying no "id"). The rule
+            // lives on McpToolServer so stdio and HTTP cannot drift apart on it.
+            if (McpToolServer.ExpectsResponse(line))
             {
                 await output.WriteLineAsync(response.AsMemory(), cancellationToken);
                 await output.FlushAsync(cancellationToken);
             }
-        }
-    }
-
-    // A message warrants a response unless it is a notification (a JSON object with no "id").
-    // Malformed JSON still warrants the JSON-RPC parse-error response, so it counts as needing one.
-    private static bool ExpectsResponse(string line)
-    {
-        try
-        {
-            using JsonDocument document = JsonDocument.Parse(line);
-            return document.RootElement.ValueKind != JsonValueKind.Object
-                || document.RootElement.TryGetProperty("id", out _);
-        }
-        catch (JsonException)
-        {
-            return true;
         }
     }
 }

--- a/src/BlazorDX.Primitives/Forms/McpToolServer.cs
+++ b/src/BlazorDX.Primitives/Forms/McpToolServer.cs
@@ -32,6 +32,25 @@ public sealed class McpToolServer
     /// </summary>
     public IDxDiagnostics? Diagnostics { get; init; }
 
+    /// <summary>
+    /// Whether <c>initialize</c> advertises <c>tools.listChanged</c> — a promise that the server
+    /// sends <c>notifications/tools/list_changed</c> when its tool set changes.
+    /// </summary>
+    /// <remarks>
+    /// Off by default, and it should stay off unless something actually broadcasts
+    /// <see cref="ToolListChangedNotification"/> over a session store. A client that is told the
+    /// list can change stops re-listing and waits for a notice; if none ever arrives it simply
+    /// works from a stale tool list forever, with no error anywhere to explain why.
+    /// </remarks>
+    public bool NotifiesToolListChanged { get; init; }
+
+    /// <summary>
+    /// The JSON-RPC notification announcing that the tool list changed. Pass it to
+    /// <see cref="McpSessionStore.Broadcast"/> after adding or removing tools.
+    /// </summary>
+    public static string ToolListChangedNotification =>
+        "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/tools/list_changed\"}";
+
     /// <summary>Registers a tool (replacing any with the same name). Fluent.</summary>
     public McpToolServer Add(IAiTool tool)
     {
@@ -53,6 +72,16 @@ public sealed class McpToolServer
             using JsonDocument document = JsonDocument.Parse(requestJson);
             JsonElement root = document.RootElement;
 
+            // A JSON-RPC batch is a valid JSON array, and TryGetProperty on a non-object throws
+            // InvalidOperationException — not JsonException — so without this a batched body
+            // escaped the catch below and took the transport down. Batching was removed from the
+            // protocol in 2025-06-18; refusing it as an Invalid Request is both correct and the
+            // answer a client can act on.
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return Error(id, -32600, "Invalid Request: expected a single JSON-RPC object.");
+            }
+
             if (root.TryGetProperty("id", out JsonElement idElement))
             {
                 id = idElement.GetRawText();
@@ -62,7 +91,7 @@ public sealed class McpToolServer
 
             return method switch
             {
-                "initialize" => Response(id, InitializeResult()),
+                "initialize" => Response(id, InitializeResult(root)),
                 "tools/list" => Response(id, await ToolsListResult(cancellationToken)),
                 "tools/call" => Response(id, await ToolsCallResult(root, cancellationToken)),
                 _ => Error(id, -32601, $"Method not found: {method}"),
@@ -74,14 +103,106 @@ public sealed class McpToolServer
         }
     }
 
+    /// <summary>
+    /// Whether a message warrants a reply. JSON-RPC forbids answering a notification (a message
+    /// carrying no <c>id</c>), and every transport has to honour that, so the rule lives here
+    /// rather than being re-derived — and re-derived differently — in each host.
+    /// </summary>
+    /// <remarks>
+    /// Malformed JSON counts as warranting a response: the caller gets the parse error rather
+    /// than silence, which is the difference between a client that reports a bad request and one
+    /// that hangs waiting.
+    /// </remarks>
+    public static bool ExpectsResponse(string message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(message);
+            return document.RootElement.ValueKind != JsonValueKind.Object
+                || document.RootElement.TryGetProperty("id", out _);
+        }
+        catch (JsonException)
+        {
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Whether a message is an <c>initialize</c> request — the point at which a session-based
+    /// transport mints a session, since it is the one request that arrives without one.
+    /// </summary>
+    public static bool IsInitialize(string message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(message);
+            return document.RootElement.ValueKind == JsonValueKind.Object
+                && document.RootElement.TryGetProperty("method", out JsonElement method)
+                && method.ValueKind == JsonValueKind.String
+                && method.ValueEquals("initialize");
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Builds a JSON-RPC error object, so a transport can answer with a protocol-shaped body for
+    /// failures the tool server never sees — an expired session, an unreadable request.
+    /// </summary>
+    /// <param name="id">The request id as raw JSON, or <c>"null"</c> when it could not be read.</param>
+    /// <param name="code">The JSON-RPC error code.</param>
+    /// <param name="message">Human-readable message, returned to the caller.</param>
+    public static string ErrorJson(string id, int code, string message) => Error(id, code, message);
+
     // Whether the (optional) authorizer permits this tool for the current caller.
     private async ValueTask<bool> IsAllowedAsync(IAiTool tool, CancellationToken cancellationToken) =>
         Authorizer is null || await Authorizer.IsAllowedAsync(tool, cancellationToken);
 
-    private string InitializeResult()
+    /// <summary>
+    /// Protocol revisions this server speaks, newest last. <c>2025-03-26</c> is the revision that
+    /// introduced the HTTP + Server-Sent Events transport (<see cref="McpHttpHost"/>).
+    /// </summary>
+    private static readonly string[] SupportedProtocolVersions = ["2024-11-05", "2025-03-26"];
+
+    private string InitializeResult(JsonElement root)
     {
+        // Echo the client's revision when it is one we speak, otherwise name our newest and let
+        // the client decide whether it can proceed. Answering with a fixed version regardless of
+        // what was asked is how a server ends up claiming a revision whose rules it does not
+        // follow — which is what the previous hard-coded string did.
+        string version = SupportedProtocolVersions[^1];
+        if (root.TryGetProperty("params", out JsonElement p)
+            && p.ValueKind == JsonValueKind.Object
+            && p.TryGetProperty("protocolVersion", out JsonElement requested)
+            && requested.ValueKind == JsonValueKind.String)
+        {
+            string? asked = requested.GetString();
+            if (asked is not null && Array.IndexOf(SupportedProtocolVersions, asked) >= 0)
+            {
+                version = asked;
+            }
+        }
+
         StringBuilder sb = new();
-        sb.Append("{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{\"tools\":{}},\"serverInfo\":{\"name\":");
+        sb.Append("{\"protocolVersion\":");
+        AppendString(sb, version);
+
+        // listChanged is a promise to send notifications/tools/list_changed. It is opt-in because
+        // only a host with a session store can deliver one, and advertising a capability the
+        // server cannot honour makes a client wait for a message that never comes.
+        sb.Append(",\"capabilities\":{\"tools\":{");
+        if (NotifiesToolListChanged)
+        {
+            sb.Append("\"listChanged\":true");
+        }
+
+        sb.Append("}},\"serverInfo\":{\"name\":");
         AppendString(sb, ServerName);
         sb.Append(",\"version\":\"1.0.0\"}}");
         return sb.ToString();

--- a/tests/BlazorDX.Components.Tests/McpHttpHostTests.cs
+++ b/tests/BlazorDX.Components.Tests/McpHttpHostTests.cs
@@ -1,0 +1,306 @@
+using System.Text.Json;
+using BlazorDX.Primitives.Forms;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// The MCP HTTP transport: <c>POST</c> for request/response, <c>GET</c> for the server-to-client
+/// SSE stream, <c>DELETE</c> to end a session.
+/// </summary>
+/// <remarks>
+/// <see cref="McpHttpHost"/> speaks in strings and status codes rather than <c>HttpContext</c>,
+/// because <c>BlazorDX.Primitives</c> is browser-WASM safe and cannot take an ASP.NET dependency.
+/// The compensation is here: the transport rules are testable without a web server, so every
+/// status code below is asserted rather than hoped for.
+/// </remarks>
+public sealed class McpHttpHostTests
+{
+    // A settable clock, so session expiry is a property of the test rather than of how long the
+    // test happened to take. The suite already has two wall-clock flakes; this is the pattern
+    // that avoids adding a third.
+    private sealed class TestClock(DateTimeOffset start) : TimeProvider
+    {
+        public DateTimeOffset Now { get; set; } = start;
+
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
+    private static McpToolServer NewServer() => new() { ServerName = "BlazorDX Test" };
+
+    private const string Initialize = """{"jsonrpc":"2.0","id":1,"method":"initialize"}""";
+    private const string ToolsList = """{"jsonrpc":"2.0","id":2,"method":"tools/list"}""";
+    private const string Initialized = """{"jsonrpc":"2.0","method":"notifications/initialized"}""";
+
+    // ---- SSE framing -------------------------------------------------------------------------
+
+    [Fact]
+    public void A_single_line_message_is_one_data_frame()
+    {
+        Assert.Equal("data: {\"a\":1}\n\n", McpSse.Frame("""{"a":1}"""));
+    }
+
+    [Fact]
+    public void Every_line_of_a_multi_line_message_gets_its_own_data_prefix()
+    {
+        // The failure this prevents: a bare newline inside the payload ends the frame early, so
+        // the client sees a truncated event and then treats the remainder as garbage. Any tool
+        // returning multi-line text produces exactly that payload.
+        Assert.Equal("data: one\ndata: two\n\n", McpSse.Frame("one\ntwo"));
+    }
+
+    [Fact]
+    public void A_frame_ends_with_the_blank_line_that_dispatches_it()
+    {
+        // Without the terminating blank line the client buffers the event forever and the stream
+        // looks alive while delivering nothing.
+        Assert.EndsWith("\n\n", McpSse.Frame("x"), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("""{"jsonrpc":"2.0","method":"x"}""")]
+    [InlineData("one\ntwo")]
+    [InlineData("trailing\n")]
+    [InlineData("")]
+    [InlineData("  leading spaces")]
+    [InlineData("blank\n\nline")]
+    public void A_framed_message_is_recovered_exactly_by_a_client(string payload)
+    {
+        // The property that matters, rather than the bytes: leading spaces survive (the "data: "
+        // prefix strips exactly one space and Frame adds exactly one), as do empty lines and a
+        // trailing newline. Byte-pinning the frame would pass while any of those quietly broke.
+        Assert.Equal(payload, ParseSseData(McpSse.Frame(payload)));
+    }
+
+    // What a conforming client does: join the data lines with "\n", strip one trailing "\n".
+    private static string ParseSseData(string frame)
+    {
+        System.Text.StringBuilder buffer = new();
+        foreach (string line in frame.Split('\n'))
+        {
+            if (line.StartsWith("data:", StringComparison.Ordinal))
+            {
+                string value = line[5..];
+                buffer.Append(value.StartsWith(' ') ? value[1..] : value).Append('\n');
+            }
+        }
+
+        return buffer.Length > 0 ? buffer.ToString()[..^1] : string.Empty;
+    }
+
+    // ---- Sessions ----------------------------------------------------------------------------
+
+    [Fact]
+    public void Session_ids_are_unique_and_long_enough_to_be_unguessable()
+    {
+        McpSessionStore store = new();
+
+        HashSet<string> ids = [.. Enumerable.Range(0, 50).Select(_ => store.Create().Id)];
+
+        // The id is the only thing separating one caller's session from another's, so it is a
+        // credential: 128 bits of RandomNumberGenerator, not a counter and not a Guid.
+        Assert.Equal(50, ids.Count);
+        Assert.All(ids, id => Assert.Equal(32, id.Length));
+    }
+
+    [Fact]
+    public void A_terminated_session_is_no_longer_found()
+    {
+        McpSessionStore store = new();
+        McpSession session = store.Create();
+
+        Assert.True(store.Terminate(session.Id));
+        Assert.False(store.TryGet(session.Id, out _));
+
+        // A second DELETE is a client retrying, not an error.
+        Assert.False(store.Terminate(session.Id));
+    }
+
+    [Fact]
+    public async Task Terminating_a_session_ends_the_stream_holding_it_open()
+    {
+        McpSessionStore store = new();
+        McpSession session = store.Create();
+
+        store.Terminate(session.Id);
+
+        // Without this the streaming response never completes and the request leaks a connection.
+        IAsyncEnumerator<string> stream = session.ReadAllAsync().GetAsyncEnumerator();
+        Assert.False(await stream.MoveNextAsync());
+    }
+
+    [Fact]
+    public void An_idle_session_is_swept_and_an_active_one_is_not()
+    {
+        TestClock clock = new(DateTimeOffset.UnixEpoch);
+        McpSessionStore store = new() { TimeProvider = clock };
+
+        McpSession stale = store.Create();
+        clock.Now = clock.Now.AddMinutes(10);
+        McpSession fresh = store.Create();
+
+        // A client can vanish without a DELETE — a closed tab, a crash, a partition — so without
+        // a sweep the store only ever grows.
+        clock.Now = clock.Now.AddMinutes(1);
+        Assert.Equal(1, store.Sweep(TimeSpan.FromMinutes(5)));
+
+        Assert.False(store.TryGet(stale.Id, out _));
+        Assert.True(store.TryGet(fresh.Id, out _));
+    }
+
+    [Fact]
+    public void A_request_keeps_its_session_alive()
+    {
+        TestClock clock = new(DateTimeOffset.UnixEpoch);
+        McpSessionStore store = new() { TimeProvider = clock };
+        McpSession session = store.Create();
+
+        clock.Now = clock.Now.AddMinutes(4);
+        Assert.True(store.TryGet(session.Id, out _));   // touches LastSeen
+
+        clock.Now = clock.Now.AddMinutes(4);
+        Assert.Equal(0, store.Sweep(TimeSpan.FromMinutes(5)));
+    }
+
+    [Fact]
+    public void A_full_queue_drops_the_message_and_says_so()
+    {
+        McpSessionStore store = new() { QueueCapacity = 2 };
+        McpSession session = store.Create();
+
+        Assert.True(session.TryPost("one"));
+        Assert.True(session.TryPost("two"));
+
+        // A client that opened a session and never drained it would otherwise grow the server's
+        // memory without limit, and a disconnected client is the case that actually happens.
+        Assert.False(session.TryPost("three"));
+    }
+
+    [Fact]
+    public void Broadcast_counts_what_was_delivered_not_what_was_attempted()
+    {
+        McpSessionStore store = new() { QueueCapacity = 1 };
+        store.Create();
+        McpSession full = store.Create();
+        full.TryPost("already here");
+
+        // Reporting 2 here would claim a delivery that did not happen.
+        Assert.Equal(1, store.Broadcast(McpToolServer.ToolListChangedNotification));
+    }
+
+    // ---- Transport rules ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task Initialize_mints_a_session_and_later_requests_must_carry_it()
+    {
+        McpSessionStore store = new();
+        McpHttpHost host = new(NewServer(), store);
+
+        McpHttpResponse init = await host.HandleAsync(new McpHttpRequest("POST", Initialize));
+
+        Assert.Equal(200, init.StatusCode);
+        Assert.NotNull(init.SessionId);
+
+        McpHttpResponse listed = await host.HandleAsync(new McpHttpRequest("POST", ToolsList, init.SessionId));
+        Assert.Equal(200, listed.StatusCode);
+    }
+
+    [Fact]
+    public async Task An_expired_session_gets_404_so_the_client_initializes_again()
+    {
+        McpHttpHost host = new(NewServer(), new McpSessionStore());
+
+        McpHttpResponse response = await host.HandleAsync(new McpHttpRequest("POST", ToolsList, "deadbeef"));
+
+        // 404, not 401: the caller is not unauthorized, its session is gone. The protocol's
+        // meaning of 404 here is "initialize again", which is what it should do — 401 would send
+        // it to fetch credentials it already has.
+        Assert.Equal(404, response.StatusCode);
+        using JsonDocument doc = JsonDocument.Parse(response.Body!);
+        Assert.Equal(-32001, doc.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+    }
+
+    [Fact]
+    public async Task Without_a_session_store_the_endpoint_is_plain_request_response()
+    {
+        McpHttpHost host = new(NewServer());
+
+        McpHttpResponse init = await host.HandleAsync(new McpHttpRequest("POST", Initialize));
+        Assert.Equal(200, init.StatusCode);
+        Assert.Null(init.SessionId);
+
+        // 405 is the protocol's way of saying "this server never initiates messages", and a
+        // client that sees it simply does not open a listening stream.
+        Assert.Equal(405, (await host.HandleAsync(new McpHttpRequest("GET"))).StatusCode);
+    }
+
+    [Fact]
+    public async Task A_notification_is_accepted_with_no_body()
+    {
+        McpHttpHost host = new(NewServer());
+
+        McpHttpResponse response = await host.HandleAsync(new McpHttpRequest("POST", Initialized));
+
+        // JSON-RPC forbids answering a notification, so there is nothing to return but an
+        // acknowledgement. Returning a response body here is a protocol violation the stdio host
+        // already avoided; this is the same rule, shared rather than re-derived.
+        Assert.Equal(202, response.StatusCode);
+        Assert.Null(response.Body);
+    }
+
+    [Fact]
+    public async Task An_empty_body_is_a_protocol_error_not_a_crash()
+    {
+        McpHttpHost host = new(NewServer());
+
+        McpHttpResponse response = await host.HandleAsync(new McpHttpRequest("POST", "   "));
+
+        Assert.Equal(400, response.StatusCode);
+        Assert.Contains("-32600", response.Body!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task An_unsupported_method_is_405()
+    {
+        McpHttpHost host = new(NewServer(), new McpSessionStore());
+
+        Assert.Equal(405, (await host.HandleAsync(new McpHttpRequest("PUT", "{}"))).StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_ends_the_session()
+    {
+        McpSessionStore store = new();
+        McpHttpHost host = new(NewServer(), store);
+        McpHttpResponse init = await host.HandleAsync(new McpHttpRequest("POST", Initialize));
+
+        McpHttpResponse deleted = await host.HandleAsync(new McpHttpRequest("DELETE", SessionId: init.SessionId));
+
+        Assert.Equal(204, deleted.StatusCode);
+        Assert.Equal(0, store.Count);
+    }
+
+    [Fact]
+    public async Task A_get_opens_the_stream_that_carries_server_initiated_messages()
+    {
+        McpSessionStore store = new();
+        McpHttpHost host = new(NewServer(), store);
+        McpHttpResponse init = await host.HandleAsync(new McpHttpRequest("POST", Initialize));
+
+        McpHttpResponse stream = await host.HandleAsync(new McpHttpRequest("GET", SessionId: init.SessionId));
+
+        Assert.Equal(200, stream.StatusCode);
+        Assert.Equal("text/event-stream", stream.ContentType);
+        McpSession opened = Assert.IsType<McpSession>(stream.Stream);
+
+        // The whole point of the session: a message with no request to ride back on.
+        store.Broadcast(McpToolServer.ToolListChangedNotification);
+
+        IAsyncEnumerator<string> messages = opened.ReadAllAsync().GetAsyncEnumerator();
+        Assert.True(await messages.MoveNextAsync());
+        Assert.Equal(McpToolServer.ToolListChangedNotification, messages.Current);
+        Assert.Equal(
+            "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/tools/list_changed\"}\n\n",
+            McpSse.Frame(messages.Current));
+    }
+}

--- a/tests/BlazorDX.Components.Tests/McpToolServerTests.cs
+++ b/tests/BlazorDX.Components.Tests/McpToolServerTests.cs
@@ -34,6 +34,76 @@ public sealed class McpToolServerTests
     }
 
     [Fact]
+    public async Task Initialize_echoes_a_protocol_revision_it_actually_speaks()
+    {
+        string res = await NewServer().HandleAsync(
+            """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}""");
+
+        using JsonDocument doc = JsonDocument.Parse(res);
+        Assert.Equal("2024-11-05", doc.RootElement.GetProperty("result").GetProperty("protocolVersion").GetString());
+    }
+
+    [Fact]
+    public async Task An_unknown_client_revision_is_answered_with_our_newest()
+    {
+        // Not an error: naming what we speak lets the client decide whether it can proceed.
+        string res = await NewServer().HandleAsync(
+            """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"1999-01-01"}}""");
+
+        using JsonDocument doc = JsonDocument.Parse(res);
+        Assert.Equal("2025-03-26", doc.RootElement.GetProperty("result").GetProperty("protocolVersion").GetString());
+    }
+
+    [Fact]
+    public async Task The_tool_list_changed_capability_is_off_unless_something_can_send_it()
+    {
+        string res = await NewServer().HandleAsync("""{"jsonrpc":"2.0","id":1,"method":"initialize"}""");
+        using JsonDocument doc = JsonDocument.Parse(res);
+        JsonElement tools = doc.RootElement.GetProperty("result").GetProperty("capabilities").GetProperty("tools");
+
+        // Advertising it without delivering is worse than not advertising: the client stops
+        // re-listing, waits for a notice that never comes, and works from a stale tool list with
+        // no error anywhere to explain why.
+        Assert.False(tools.TryGetProperty("listChanged", out _));
+
+        McpToolServer promising = new() { ServerName = "x", NotifiesToolListChanged = true };
+        using JsonDocument opted = JsonDocument.Parse(
+            await promising.HandleAsync("""{"jsonrpc":"2.0","id":1,"method":"initialize"}"""));
+        Assert.True(opted.RootElement.GetProperty("result").GetProperty("capabilities")
+            .GetProperty("tools").GetProperty("listChanged").GetBoolean());
+    }
+
+    [Fact]
+    public async Task A_batched_request_is_refused_rather_than_taking_the_transport_down()
+    {
+        // TryGetProperty on a JSON array throws InvalidOperationException, not JsonException, so
+        // a batch body used to escape the parse-error catch entirely. Batching left the protocol
+        // in 2025-06-18; refusing it as an Invalid Request is both correct and actionable.
+        string res = await NewServer().HandleAsync(
+            """[{"jsonrpc":"2.0","id":1,"method":"initialize"}]""");
+
+        using JsonDocument doc = JsonDocument.Parse(res);
+        Assert.Equal(-32600, doc.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+    }
+
+    [Fact]
+    public void Notifications_are_told_apart_from_requests()
+    {
+        // Both hosts route on this, so it is worth asserting directly rather than only through
+        // the transports that consume it.
+        Assert.True(McpToolServer.ExpectsResponse("""{"jsonrpc":"2.0","id":1,"method":"initialize"}"""));
+        Assert.False(McpToolServer.ExpectsResponse("""{"jsonrpc":"2.0","method":"notifications/initialized"}"""));
+
+        // Malformed input still gets the parse error, which is the difference between a client
+        // that reports a bad request and one that hangs waiting.
+        Assert.True(McpToolServer.ExpectsResponse("{not json"));
+
+        Assert.True(McpToolServer.IsInitialize("""{"jsonrpc":"2.0","id":1,"method":"initialize"}"""));
+        Assert.False(McpToolServer.IsInitialize("""{"jsonrpc":"2.0","id":1,"method":"tools/list"}"""));
+        Assert.False(McpToolServer.IsInitialize("{not json"));
+    }
+
+    [Fact]
     public async Task Tools_list_returns_the_generated_schema()
     {
         string res = await NewServer().HandleAsync("""{"jsonrpc":"2.0","id":2,"method":"tools/list"}""");


### PR DESCRIPTION
> Stacked on #58 — based on `feature/mcp-depth`, and will retarget to `main` when that merges.

## The gap

The HTTP endpoint could only answer what it was asked. A tool call rides back on the response its
request already has open; a progress update, a "the tool list changed" notice, or anything the app
volunteers has none — so the server could never speak first.

`McpHttpHost` completes the transport: **POST** for request/response, **GET** for a Server-Sent
Events stream carrying server-initiated messages, **DELETE** to end a session.

## Why it isn't an ASP.NET type

It speaks in strings and status codes rather than `HttpContext`. `BlazorDX.Primitives` is
browser-WASM safe — it references the Blazor component *packages*, not the ASP.NET Core framework —
so binding the transport to a web framework would cost the whole library that guarantee for one
feature. A host writes ~30 lines to move bytes across (the demo's `/mcp` is exactly that), and in
exchange the transport rules are unit-tested with no web server, which in this repo is the
difference between a fast check and the slowest job in CI.

## Sessions

- `initialize` mints a **cryptographically random** id (`RandomNumberGenerator`, not `Guid`) — it
  is the only thing separating one caller's session from another's, so it is a credential, not just
  an identifier.
- An unknown id gets **404, not 401**. The caller is not unauthorized, its session is gone. 404's
  meaning here is "initialize again"; 401 would send it to fetch credentials it already has.
- Outbound queues are **bounded and honest**. A client that opens a session and never drains it
  would otherwise grow memory without limit, and a disconnected client is the case that actually
  happens. `Broadcast` returns how many sessions *accepted* a message rather than how many exist.
- Expiry runs off an injected `TimeProvider`, so the tests don't race the wall clock — the pattern
  the two known flaky tests in this suite need.

`tools.listChanged` is **opt-in and off by default**. Advertising it without delivering is worse
than not advertising: the client stops re-listing, waits for a notice that never comes, and works
from a stale tool list forever with nothing to explain why.

## Three fixes from the same area

1. **A batched request took the transport down.** A JSON-RPC batch is a valid JSON array, and
   `TryGetProperty` on a non-object throws `InvalidOperationException` — not `JsonException` — so it
   escaped the parse-error catch entirely. Batching left the protocol in 2025-06-18; it's now
   refused as an Invalid Request.
2. **`initialize` answered a hard-coded revision** whatever the client asked. It now echoes one it
   actually speaks — which matters more now that `2025-03-26`, the revision defining this transport,
   is one of them.
3. **The notification rule was private to the stdio host.** It now lives on `McpToolServer`, so two
   transports can't drift apart on whether a message with no `id` may be answered.

## Verification — unusually strong for this repo

The Forms/MCP sources have **no source-generator dependency**, so unlike the rest of
`BlazorDX.Primitives` they compile standalone. I built them under `TreatWarningsAsErrors` and ran
every transport rule in this PR locally before pushing.

That caught two errors of my own that green CI would not have:

- `BoundedChannelFullMode.DropWrite` makes `TryWrite` return **true** while discarding the item —
  `TryPost` would have claimed deliveries it never made. Corrected to `Wait`, where `TryWrite`
  returns `false` when full without ever blocking.
- `EnumerateLines` **does** yield the trailing empty segment, contrary to what I'd assumed. The SSE
  framing is now asserted on **round-trip through a client-shaped parser** rather than on bytes I
  guessed at — which also proves leading spaces, empty lines and trailing newlines survive. The one
  case that doesn't round-trip byte-for-byte is `\r\n`, which normalises to `\n`; harmless for
  JSON-RPC, and documented rather than left to be discovered.

29 new tests across `McpHttpHostTests` and `McpToolServerTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
