### PR TITLE
Complete the MCP surface with resources and prompts

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -141,12 +141,15 @@ enhancements. None of this should be read as "ready"; it is a beta with work ahe
 
 ### Depth & breadth enhancements
 
-- **AI access** — the secured tool core, both transports, and both directions of the tool surface
-  are done: an assistant writes through a `[DxFormModel]` (`FormAiTool`) and reads through a
-  grid's `IGridDataSource` (`GridAiTool`, read-only, columns as a JSON-Schema `enum`, honest
-  `totalCount`), over stdio or over HTTP+SSE with sessions (`McpHttpHost` — `POST`/`GET`/`DELETE`,
-  cryptographically random session ids, bounded outbound queues, idle sweep). Next is the wider
-  MCP surface (resources / prompts). See [docs/ai-integration.md](ai-integration.md).
+- **AI access** — **done**. The secured core; both transports (stdio, and HTTP+SSE with sessions
+  via `McpHttpHost` — `POST`/`GET`/`DELETE`, cryptographically random session ids, bounded
+  outbound queues, idle sweep); tools in both directions (an assistant writes through a
+  `[DxFormModel]` with `FormAiTool`, and reads through a grid's `IGridDataSource` with
+  `GridAiTool` — read-only, columns as a JSON-Schema `enum`, honest `totalCount`); and the rest of
+  the surface, `resources/*` and `prompts/*`, with `FormAiPrompt` making one form declaration a
+  third surface and `IAiContentAuthorizer` gating both. Sampling and roots are **declined, not
+  pending**: they are client responsibilities, and a component library has no business initiating
+  model calls on its host's account. See [docs/ai-integration.md](ai-integration.md).
 - **Chart interactivity** — shipped in full. Point selection, hover, and legend toggling
   (title-tag tooltips only, not a rich hover card). Zoom/pan for `DxLineChart`/`DxAreaChart`
   (X-only, opt-in via `Zoomable`): see [ADR 0017](adr/0017-chart-zoom-pan-strategy.md).

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -60,8 +60,9 @@ properties the model exposes, never an arbitrary field.
 ## Serving tools over MCP
 
 `McpToolServer` is a transport-agnostic [Model Context Protocol](https://modelcontextprotocol.io)
-server. Register `IAiTool`s and feed it JSON-RPC; it answers `initialize`, `tools/list`, and
-`tools/call`.
+server. Register `IAiTool`s, `IAiResource`s and `IAiPrompt`s and feed it JSON-RPC; it answers
+`initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list` and
+`prompts/get`.
 
 ```csharp
 var server = new McpToolServer { ServerName = "My app" }
@@ -238,6 +239,72 @@ The corollary belongs with the security model below: the data source is reached 
 could not have seen in the grid. A read tool is what makes that gate load-bearing rather than
 merely advisable.
 
+## Resources and prompts — the other two surfaces
+
+A tool is chosen by the *model*. The rest of MCP is about the other two directions, and the
+difference is who decides:
+
+| | Chosen by | Runs anything? | BlazorDX type |
+|---|---|---|---|
+| **Tool** | the model, mid-task | yes | `FormAiTool<T>`, `GridAiTool<T>` |
+| **Resource** | the user, or on request | no — it is fetched | `TextAiResource`, or your `IAiResource` |
+| **Prompt** | the **user**, before the task | no — it expands into the chat | `FormAiPrompt<T>`, `TextAiPrompt` |
+
+Both are registered the same fluent way, and both are advertised in `initialize` **only when
+something is actually registered** — telling a client this server has resources buys a wasted
+`resources/list` on every connection, and makes a genuinely empty surface look identical to one
+whose registration was forgotten.
+
+```csharp
+server
+    .Add(new TextAiResource(
+        "stock://low", "Low stock report",
+        "Every SKU at or below its reorder point.",
+        StockDataSource.LowStockReportAsync, "text/markdown"))
+    .Add(new FormAiPrompt<MeetingRequest>(new MeetingRequestFormModel()));
+```
+
+### Resources
+
+`IAiResource` is a URI, a name, a description and a body. There is no argument schema, because
+there is nothing to parameterise — only something to fetch. `AiResourceContent.FromText` and
+`FromBytes` are the two shapes; binary is base64-encoded on the wire, and exactly one of `text` or
+`blob` is ever sent.
+
+The `Uri` is an **identifier, not a path**. Nothing in BlazorDX dereferences it, so a host that
+maps URIs onto files owns the traversal check — which is why `TextAiResource` takes a delegate
+rather than a directory: the safe shape is a fixed set of URIs you chose.
+
+### Prompts, and why a form makes a good one
+
+`FormAiPrompt<T>` turns the same `[DxFormModel]` descriptor into a user-invokable template — the
+third surface on one declaration. In a client it appears as a slash-command; it states the task,
+lists the fields **with the constraints read off the descriptor**, and names the tool that
+submits. Without it, a user has to know the tool exists and describe its fields themselves.
+
+Reading the constraints off the descriptor rather than restating them in prose is the point: a
+rule changed on the model cannot drift out of sync with what the prompt claims.
+
+Every argument is optional, deliberately. A prompt that demanded each required field up front
+would just be the form again in a worse renderer; whatever the user does not supply, the assistant
+asks for.
+
+**Sensitive fields are omitted**, exactly as they are from the tool schema — see
+[Sensitive-field redaction](#sensitive-field-redaction--what-the-ai-must-never-see) below. A
+prompt that helpfully listed `SSN` among the fields to collect would reintroduce the very leak the
+schema avoids, while looking like a convenience feature. There is a test asserting the negative.
+
+### Authorization applies here too
+
+`IAiContentAuthorizer` gates resources and prompts, and a disallowed item is answered **exactly**
+as a non-existent one — same error code, same message — so the surface never reveals that a
+privileged resource exists. It is separate from `IAiToolAuthorizer` because adding methods to that
+interface would break every host already implementing it, and "may you read this" is a different
+question from "may you run this".
+
+This matters more for resources than for tools: a resource *is* raw data, with no validation layer
+or handler between the caller and the bytes.
+
 ## Security model
 
 Opening a system to AI is the highest-risk surface, so it inherits BlazorDX's security
@@ -370,6 +437,12 @@ malicious tool calls — and the errors are returned to the AI so it can self-co
 
 ## What's next
 
-The secured core, both transports (stdio and HTTP+SSE with sessions), and both directions of the
-tool surface — writing through a form, reading through a grid — are in place. Planned: the broader
-MCP surface (resources, prompts). See [ROADMAP.md](ROADMAP.md).
+The MCP surface is complete for a server of this kind: the secured core, both transports (stdio
+and HTTP+SSE with sessions), tools in both directions (writing through a form, reading through a
+grid), and resources and prompts.
+
+What is deliberately *not* here, because it belongs to the client rather than the server:
+**sampling** (the server asking the client's model for a completion) and **roots** (the client
+telling the server which directories it may work in). Neither has a BlazorDX-shaped answer — a
+component library has no business initiating model calls on its host's account — so they are
+declined rather than pending. See [ROADMAP.md](ROADMAP.md).

--- a/samples/BlazorDX.McpServer/Inventory.cs
+++ b/samples/BlazorDX.McpServer/Inventory.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text;
 using BlazorDX.Primitives.Grid;
 
 namespace BlazorDX.McpServer;
@@ -44,6 +46,8 @@ public sealed class StockRow
 /// </remarks>
 internal sealed class StockDataSource : IGridDataSource<StockRow>
 {
+    private const int ReorderPoint = 100;
+
     private static readonly StockRow[] All =
     [
         new() { Sku = "AX-1001", Product = "Hex bolt M6", Warehouse = "Leeds", OnHand = 4820, Cost = 0.04m },
@@ -57,6 +61,24 @@ internal sealed class StockDataSource : IGridDataSource<StockRow>
         new() { Sku = "SL-4406", Product = "Slide rail 450mm", Warehouse = "Gdansk", OnHand = 6, Cost = 9.40m },
         new() { Sku = "WS-5000", Product = "Washer M6", Warehouse = "Gdansk", OnHand = 22400, Cost = 0.01m },
     ];
+
+    /// <summary>
+    /// The same rows the grid tool queries, rendered as a document an assistant can be handed
+    /// whole. Built from <see cref="All"/> rather than from a second copy of the data, so the
+    /// report and the tool cannot disagree about what is low.
+    /// </summary>
+    public static Task<string> LowStockReportAsync(CancellationToken cancellationToken)
+    {
+        StringBuilder sb = new();
+        sb.Append("# Low stock\n\n| SKU | Product | Warehouse | On hand |\n|---|---|---|---|\n");
+
+        foreach (StockRow row in All.Where(r => r.OnHand <= ReorderPoint).OrderBy(r => r.OnHand))
+        {
+            sb.Append(CultureInfo.InvariantCulture, $"| {row.Sku} | {row.Product} | {row.Warehouse} | {row.OnHand} |\n");
+        }
+
+        return Task.FromResult(sb.ToString());
+    }
 
     public Task<GridDataPage<StockRow>> GetRowsAsync(GridDataRequest request, CancellationToken cancellationToken)
     {

--- a/samples/BlazorDX.McpServer/Program.cs
+++ b/samples/BlazorDX.McpServer/Program.cs
@@ -20,7 +20,22 @@ var server = new McpToolServer { ServerName = "BlazorDX MCP sample" }
             + "Consult this before answering questions about what is in stock or running low.",
         new StockRowGridAccessor(),
         new StockDataSource(),
-        maxRows: 25));
+        maxRows: 25))
+
+    // A prompt is the third surface on the same declaration, and the only one the *user* drives:
+    // it shows up as a slash-command, states the task, lists the real field rules, and names the
+    // tool that submits. Without it someone has to know schedule_meeting exists and describe its
+    // fields themselves.
+    .Add(new FormAiPrompt<MeetingRequest>(new MeetingRequestFormModel()))
+
+    // A resource is read, not called — attached by the user rather than chosen by the model.
+    // Built here from the same data the grid tool queries, so the two cannot disagree.
+    .Add(new TextAiResource(
+        "stock://low",
+        "Low stock report",
+        "Every SKU at or below its reorder point, newest count first.",
+        StockDataSource.LowStockReportAsync,
+        "text/markdown"));
 
 // Stop cleanly on Ctrl+C.
 using var cts = new CancellationTokenSource();

--- a/samples/BlazorDX.McpServer/README.md
+++ b/samples/BlazorDX.McpServer/README.md
@@ -7,15 +7,24 @@ BlazorDX declarations as AI tools over **stdio**: a `[DxFormModel]` and a `[Grid
 and read.
 
 ```
-                                        ┌─► query_stock       (read)  ← [GridRow] + IGridDataSource
+                                        ┌─► query_stock       tool     ← [GridRow] + IGridDataSource
+                                        ├─► schedule_meeting  tool     ← [DxFormModel]
 assistant ──spawns──► dotnet run ──MCP──┤
-                                        └─► schedule_meeting  (write) ← [DxFormModel]
+                                        ├─► stock://low       resource ← the same IGridDataSource
+                                        └─► schedule_meeting  prompt   ← the same [DxFormModel]
 ```
 
-The pair is deliberate. A tool that only writes makes an assistant guess at its arguments; a tool
-that only reads leaves it narrating instead of acting. Together they are the whole loop: look
+Two tools, one resource, one prompt — and only two declarations behind them.
+
+The tool pair is deliberate. A tool that only writes makes an assistant guess at its arguments; a
+tool that only reads leaves it narrating instead of acting. Together they are the whole loop: look
 something up in the same data source the grid binds to, then act on it through the same validation
 the form enforces.
+
+The resource and the prompt are the other two directions. A **resource** is read, not called —
+attached by the user rather than chosen by the model; here it renders the same stock rows as a
+report. A **prompt** is invoked by the *user* as a slash-command: it states the task, lists the
+form's real field rules, and names the tool that submits.
 
 ## Run it
 
@@ -36,6 +45,11 @@ printf '%s\n%s\n%s\n' \
 
 You'll get the `initialize` result, a `tools/list` containing both tools with their JSON-Schemas,
 and a page of stock rows carrying the full `totalCount` alongside the three returned.
+
+Swap the last line for `resources/list`, `resources/read` (`{"uri":"stock://low"}`), `prompts/list`
+or `prompts/get` to see the other two surfaces. Note that `initialize` advertises `resources` and
+`prompts` capabilities **only** because this server registers some — a server with none says so,
+rather than making every client ask and get an empty list.
 
 ## What the model can and cannot see
 
@@ -86,7 +100,12 @@ var server = new McpToolServer { ServerName = "BlazorDX MCP sample" }
         "Warehouse stock levels. Filter by SKU, product name or warehouse…",
         new StockRowGridAccessor(),             // source-generated accessor
         new StockDataSource(),                  // the same IGridDataSource a grid would bind to
-        maxRows: 25));
+        maxRows: 25))
+    .Add(new FormAiPrompt<MeetingRequest>(new MeetingRequestFormModel()))   // the form, again
+    .Add(new TextAiResource(                                                // the stock, again
+        "stock://low", "Low stock report",
+        "Every SKU at or below its reorder point.",
+        StockDataSource.LowStockReportAsync, "text/markdown"));
 
 await McpStdioHost.RunAsync(server, Console.In, Console.Out, cts.Token);
 ```

--- a/src/BlazorDX.Primitives/Forms/AiPrompt.cs
+++ b/src/BlazorDX.Primitives/Forms/AiPrompt.cs
@@ -1,0 +1,193 @@
+using System.Globalization;
+using System.Text;
+
+namespace BlazorDX.Primitives.Forms;
+
+/// <summary>One argument a prompt accepts.</summary>
+/// <param name="Name">Argument name, as the client sends it.</param>
+/// <param name="Description">What it is for.</param>
+/// <param name="Required">Whether the client must supply it.</param>
+public sealed record AiPromptArgument(string Name, string? Description, bool Required = false);
+
+/// <summary>One message in an expanded prompt.</summary>
+/// <param name="Role">Either <c>user</c> or <c>assistant</c>.</param>
+/// <param name="Text">The message text.</param>
+public sealed record AiPromptMessage(string Role, string Text)
+{
+    /// <summary>A message from the user — what nearly every prompt expands to.</summary>
+    public static AiPromptMessage User(string text) => new("user", text);
+
+    /// <summary>A message attributed to the assistant, for priming a a multi-turn exchange.</summary>
+    public static AiPromptMessage Assistant(string text) => new("assistant", text);
+}
+
+/// <summary>An expanded prompt: what the client inserts into the conversation.</summary>
+/// <param name="Description">Shown to the user alongside the expansion.</param>
+/// <param name="Messages">The messages, in order.</param>
+public sealed record AiPromptResult(string? Description, IReadOnlyList<AiPromptMessage> Messages);
+
+/// <summary>
+/// A named, user-invoked template — what a client surfaces as a slash-command or a "prompts" menu.
+/// </summary>
+/// <remarks>
+/// The direction of control is what separates this from <see cref="IAiTool"/>. A tool is chosen by
+/// the model; a prompt is chosen by the <em>person</em>, and expands into the conversation before
+/// the model does anything. So a prompt's job is to set a task up well — including pointing at the
+/// tools that should do the work.
+/// </remarks>
+public interface IAiPrompt
+{
+    /// <summary>The name the client shows and sends, e.g. <c>schedule_meeting</c>.</summary>
+    string Name { get; }
+
+    /// <summary>What invoking it does.</summary>
+    string? Description { get; }
+
+    /// <summary>Arguments the client may collect from the user first.</summary>
+    IReadOnlyList<AiPromptArgument> Arguments { get; }
+
+    /// <summary>Expands the prompt. Missing optional arguments are absent from the dictionary.</summary>
+    Task<AiPromptResult> GetAsync(IReadOnlyDictionary<string, string> arguments, CancellationToken cancellationToken);
+}
+
+/// <summary>A prompt built by a delegate.</summary>
+/// <param name="name">The prompt name.</param>
+/// <param name="description">What invoking it does.</param>
+/// <param name="arguments">Arguments the client may collect.</param>
+/// <param name="expand">Builds the messages from the supplied arguments.</param>
+public sealed class TextAiPrompt(
+    string name,
+    string? description,
+    IReadOnlyList<AiPromptArgument> arguments,
+    Func<IReadOnlyDictionary<string, string>, CancellationToken, Task<IReadOnlyList<AiPromptMessage>>> expand)
+    : IAiPrompt
+{
+    /// <inheritdoc />
+    public string Name { get; } = !string.IsNullOrWhiteSpace(name)
+        ? name
+        : throw new ArgumentException("A prompt name is required.", nameof(name));
+
+    /// <inheritdoc />
+    public string? Description { get; } = description;
+
+    /// <inheritdoc />
+    public IReadOnlyList<AiPromptArgument> Arguments { get; } = arguments ?? [];
+
+    /// <inheritdoc />
+    public async Task<AiPromptResult> GetAsync(
+        IReadOnlyDictionary<string, string> arguments,
+        CancellationToken cancellationToken) =>
+        new(Description, await expand(arguments, cancellationToken).ConfigureAwait(false));
+}
+
+/// <summary>
+/// Turns a <c>[DxFormModel]</c> into a user-invokable prompt that sets up filling that form —
+/// the same descriptor that renders the form and projects the tool, on a third surface.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Pair it with the matching <see cref="FormAiTool{TModel}"/>. The prompt is what a person reaches
+/// for ("/schedule a meeting"); it states the task, lists the fields with their real constraints,
+/// and names the tool that submits. Without it a user has to know the tool exists and describe the
+/// fields themselves.
+/// </para>
+/// <para>
+/// <b>Sensitive fields are omitted</b>, exactly as they are from the tool schema. A field marked
+/// <c>[DxField(Sensitive = true)]</c> is one the model must never see or ask for, and a prompt
+/// that helpfully listed it would reintroduce the leak the tool surface was careful to avoid.
+/// </para>
+/// </remarks>
+/// <typeparam name="TModel">The annotated model type.</typeparam>
+/// <param name="model">The source-generated descriptor.</param>
+/// <param name="name">Prompt name; defaults to the model's tool name.</param>
+public sealed class FormAiPrompt<TModel>(IFormModel<TModel> model, string? name = null) : IAiPrompt
+{
+    /// <inheritdoc />
+    public string Name { get; } = name ?? model.ToolName;
+
+    /// <inheritdoc />
+    public string? Description { get; } = model.ToolDescription;
+
+    /// <inheritdoc />
+    public IReadOnlyList<AiPromptArgument> Arguments { get; } =
+    [
+        .. model.Fields
+            .Where(field => !field.Sensitive)
+            // Every argument is optional: the prompt's purpose is to start the task, and a client
+            // that demanded each required field up front would just be the form again, in a worse
+            // renderer. Whatever the user does not supply, the assistant asks for.
+            .Select(field => new AiPromptArgument(field.Name, field.Description ?? field.Label)),
+    ];
+
+    /// <inheritdoc />
+    public Task<AiPromptResult> GetAsync(
+        IReadOnlyDictionary<string, string> arguments,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        StringBuilder sb = new();
+        sb.Append("Help me complete ").Append(Description ?? Name).Append('.').Append('\n');
+        sb.Append("Call the \"").Append(model.ToolName).Append("\" tool once every required value is known.\n\n");
+        sb.Append("Fields:\n");
+
+        foreach (FormFieldInfo field in model.Fields)
+        {
+            if (field.Sensitive)
+            {
+                continue;
+            }
+
+            sb.Append("- ").Append(field.Label);
+            if (field.Required)
+            {
+                sb.Append(" (required)");
+            }
+
+            AppendConstraints(sb, field);
+
+            if (arguments.TryGetValue(field.Name, out string? supplied) && !string.IsNullOrWhiteSpace(supplied))
+            {
+                sb.Append(" — already given: ").Append(supplied);
+            }
+
+            sb.Append('\n');
+        }
+
+        return Task.FromResult(new AiPromptResult(Description, [AiPromptMessage.User(sb.ToString())]));
+    }
+
+    // The constraints come from the descriptor rather than being restated in prose, so a rule
+    // changed on the model cannot drift out of sync with what the prompt claims.
+    private static void AppendConstraints(StringBuilder sb, FormFieldInfo field)
+    {
+        List<string> parts = [];
+
+        if (field.Choices is { Count: > 0 })
+        {
+            parts.Add("one of: " + string.Join(", ", field.Choices));
+        }
+
+        if (field.Min is not null || field.Max is not null)
+        {
+            parts.Add(string.Create(
+                CultureInfo.InvariantCulture,
+                $"range {field.Min?.ToString(CultureInfo.InvariantCulture) ?? "any"}–{field.Max?.ToString(CultureInfo.InvariantCulture) ?? "any"}"));
+        }
+
+        if (field.MaxLength is not null)
+        {
+            parts.Add(string.Create(CultureInfo.InvariantCulture, $"at most {field.MaxLength} characters"));
+        }
+
+        if (!string.IsNullOrWhiteSpace(field.Description))
+        {
+            parts.Add(field.Description);
+        }
+
+        if (parts.Count > 0)
+        {
+            sb.Append(": ").Append(string.Join("; ", parts));
+        }
+    }
+}

--- a/src/BlazorDX.Primitives/Forms/AiResource.cs
+++ b/src/BlazorDX.Primitives/Forms/AiResource.cs
@@ -1,0 +1,143 @@
+namespace BlazorDX.Primitives.Forms;
+
+/// <summary>
+/// The body of a resource: either text or bytes, never both, with the MIME type that says which
+/// to expect.
+/// </summary>
+/// <remarks>
+/// A record with two nullable payloads would let a caller construct a content that is neither or
+/// both, so the constructor is private and the two factories are the only way in.
+/// </remarks>
+public sealed record AiResourceContent
+{
+    private AiResourceContent(string mimeType, string? text, ReadOnlyMemory<byte>? bytes)
+    {
+        MimeType = mimeType;
+        Text = text;
+        Bytes = bytes;
+    }
+
+    /// <summary>The MIME type, e.g. <c>text/markdown</c> or <c>image/png</c>.</summary>
+    public string MimeType { get; }
+
+    /// <summary>The text body, or <see langword="null"/> for a binary resource.</summary>
+    public string? Text { get; }
+
+    /// <summary>The binary body, or <see langword="null"/> for a text resource.</summary>
+    public ReadOnlyMemory<byte>? Bytes { get; }
+
+    /// <summary>A text resource.</summary>
+    public static AiResourceContent FromText(string text, string mimeType = "text/plain")
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentException.ThrowIfNullOrWhiteSpace(mimeType);
+        return new AiResourceContent(mimeType, text, null);
+    }
+
+    /// <summary>A binary resource. Sent to the client base64-encoded, as the protocol requires.</summary>
+    public static AiResourceContent FromBytes(ReadOnlyMemory<byte> bytes, string mimeType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(mimeType);
+        return new AiResourceContent(mimeType, null, bytes);
+    }
+}
+
+/// <summary>
+/// Something an assistant can <em>read</em> by URI — a document, a spec, a config, a report.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The distinction from <see cref="IAiTool"/> is who decides to use it. A tool is called by the
+/// model when it judges the moment right; a resource is attached by the <em>user</em>, or read on
+/// request, and never runs anything. That is why a resource has no argument schema: there is
+/// nothing to parameterise, only something to fetch.
+/// </para>
+/// <para>
+/// The <see cref="Uri"/> is an identifier, not a path. Nothing here dereferences it, so a host
+/// that maps URIs onto files owns the traversal check — the safe shape is a fixed dictionary of
+/// URIs it chose, which is what <see cref="TextAiResource"/> encourages by taking a delegate
+/// rather than a directory.
+/// </para>
+/// </remarks>
+public interface IAiResource
+{
+    /// <summary>Stable identifier the client uses to read this resource, e.g. <c>docs://pricing</c>.</summary>
+    string Uri { get; }
+
+    /// <summary>Human-readable name, shown when a user picks a resource to attach.</summary>
+    string Name { get; }
+
+    /// <summary>What it contains. This is what tells a user, or a model, whether it is relevant.</summary>
+    string? Description { get; }
+
+    /// <summary>Declared MIME type for listings. The read may still answer a different one.</summary>
+    string? MimeType { get; }
+
+    /// <summary>Fetches the body.</summary>
+    Task<AiResourceContent> ReadAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// A resource backed by a delegate — the common case, where the body is produced on demand from
+/// something the app already has.
+/// </summary>
+/// <param name="uri">Stable identifier, e.g. <c>docs://onboarding</c>.</param>
+/// <param name="name">Human-readable name.</param>
+/// <param name="description">What it contains.</param>
+/// <param name="read">Produces the body. Called on every read, so it sees current data.</param>
+/// <param name="mimeType">Declared MIME type.</param>
+public sealed class TextAiResource(
+    string uri,
+    string name,
+    string? description,
+    Func<CancellationToken, Task<string>> read,
+    string mimeType = "text/plain") : IAiResource
+{
+    /// <inheritdoc />
+    public string Uri { get; } = !string.IsNullOrWhiteSpace(uri)
+        ? uri
+        : throw new ArgumentException("A resource URI is required.", nameof(uri));
+
+    /// <inheritdoc />
+    public string Name { get; } = !string.IsNullOrWhiteSpace(name)
+        ? name
+        : throw new ArgumentException("A resource name is required.", nameof(name));
+
+    /// <inheritdoc />
+    public string? Description { get; } = description;
+
+    // Held as a field rather than read back off the property: MimeType is nullable on the
+    // interface, and ReadAsync needs the non-null value it was constructed with.
+    private readonly string mime = mimeType;
+
+    /// <inheritdoc />
+    public string? MimeType => mime;
+
+    /// <inheritdoc />
+    public async Task<AiResourceContent> ReadAsync(CancellationToken cancellationToken) =>
+        AiResourceContent.FromText(await read(cancellationToken).ConfigureAwait(false), mime);
+}
+
+/// <summary>
+/// Decides whether the current caller may see and read a given resource or prompt.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Separate from <see cref="IAiToolAuthorizer"/> deliberately. Adding these to that interface
+/// would break every host already implementing it, and the two decisions are not the same
+/// question anyway: one is "may you run this", the other "may you read this".
+/// </para>
+/// <para>
+/// <see cref="McpToolServer"/> consults it on every list and every fetch, and a disallowed item is
+/// answered exactly as a non-existent one — so the surface never reveals that a privileged
+/// resource exists, matching how tools already behave.
+/// </para>
+/// </remarks>
+public interface IAiContentAuthorizer
+{
+    /// <summary>Whether the caller may list and read <paramref name="resource"/>.</summary>
+    ValueTask<bool> IsAllowedAsync(IAiResource resource, CancellationToken cancellationToken);
+
+    /// <summary>Whether the caller may list and fetch <paramref name="prompt"/>.</summary>
+    ValueTask<bool> IsAllowedAsync(IAiPrompt prompt, CancellationToken cancellationToken);
+}

--- a/src/BlazorDX.Primitives/Forms/McpToolServer.cs
+++ b/src/BlazorDX.Primitives/Forms/McpToolServer.cs
@@ -15,6 +15,8 @@ namespace BlazorDX.Primitives.Forms;
 public sealed class McpToolServer
 {
     private readonly Dictionary<string, IAiTool> tools = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, IAiResource> resources = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, IAiPrompt> prompts = new(StringComparer.Ordinal);
 
     /// <summary>Server name advertised during <c>initialize</c>.</summary>
     public string ServerName { get; init; } = "BlazorDX";
@@ -51,12 +53,40 @@ public sealed class McpToolServer
     public static string ToolListChangedNotification =>
         "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/tools/list_changed\"}";
 
+    /// <summary>
+    /// Optional gate for resources and prompts. Separate from <see cref="Authorizer"/> because
+    /// adding these to <see cref="IAiToolAuthorizer"/> would break every host implementing it, and
+    /// "may you read this" is a different question from "may you run this". When null, all
+    /// registered resources and prompts are allowed.
+    /// </summary>
+    public IAiContentAuthorizer? ContentAuthorizer { get; init; }
+
     /// <summary>Registers a tool (replacing any with the same name). Fluent.</summary>
     public McpToolServer Add(IAiTool tool)
     {
         tools[tool.Name] = tool;
         return this;
     }
+
+    /// <summary>Registers a resource (replacing any with the same URI). Fluent.</summary>
+    public McpToolServer Add(IAiResource resource)
+    {
+        resources[resource.Uri] = resource;
+        return this;
+    }
+
+    /// <summary>Registers a prompt (replacing any with the same name). Fluent.</summary>
+    public McpToolServer Add(IAiPrompt prompt)
+    {
+        prompts[prompt.Name] = prompt;
+        return this;
+    }
+
+    /// <summary>The registered resources, by URI.</summary>
+    public IReadOnlyDictionary<string, IAiResource> Resources => resources;
+
+    /// <summary>The registered prompts, by name.</summary>
+    public IReadOnlyDictionary<string, IAiPrompt> Prompts => prompts;
 
     /// <summary>The registered tools, by name.</summary>
     public IReadOnlyDictionary<string, IAiTool> Tools => tools;
@@ -94,6 +124,10 @@ public sealed class McpToolServer
                 "initialize" => Response(id, InitializeResult(root)),
                 "tools/list" => Response(id, await ToolsListResult(cancellationToken)),
                 "tools/call" => Response(id, await ToolsCallResult(root, cancellationToken)),
+                "resources/list" => Response(id, await ResourcesListResult(cancellationToken)),
+                "resources/read" => await ResourcesReadResponse(id, root, cancellationToken),
+                "prompts/list" => Response(id, await PromptsListResult(cancellationToken)),
+                "prompts/get" => await PromptsGetResponse(id, root, cancellationToken),
                 _ => Error(id, -32601, $"Method not found: {method}"),
             };
         }
@@ -202,10 +236,246 @@ public sealed class McpToolServer
             sb.Append("\"listChanged\":true");
         }
 
-        sb.Append("}},\"serverInfo\":{\"name\":");
+        sb.Append("}");
+
+        // Only advertise what is actually registered. A client that is told this server has
+        // resources will call resources/list; answering an empty list is a wasted round trip on
+        // every single connection, and it makes a genuinely empty surface indistinguishable from
+        // one whose registration was forgotten.
+        if (resources.Count > 0)
+        {
+            sb.Append(",\"resources\":{}");
+        }
+
+        if (prompts.Count > 0)
+        {
+            sb.Append(",\"prompts\":{}");
+        }
+
+        sb.Append("},\"serverInfo\":{\"name\":");
         AppendString(sb, ServerName);
         sb.Append(",\"version\":\"1.0.0\"}}");
         return sb.ToString();
+    }
+
+    private async ValueTask<bool> IsAllowedAsync(IAiResource resource, CancellationToken cancellationToken) =>
+        ContentAuthorizer is null || await ContentAuthorizer.IsAllowedAsync(resource, cancellationToken);
+
+    private async ValueTask<bool> IsAllowedAsync(IAiPrompt prompt, CancellationToken cancellationToken) =>
+        ContentAuthorizer is null || await ContentAuthorizer.IsAllowedAsync(prompt, cancellationToken);
+
+    private async Task<string> ResourcesListResult(CancellationToken cancellationToken)
+    {
+        StringBuilder sb = new();
+        sb.Append("{\"resources\":[");
+        bool first = true;
+        foreach (IAiResource resource in resources.Values)
+        {
+            if (!await IsAllowedAsync(resource, cancellationToken))
+            {
+                continue;   // never advertise a resource the caller may not read
+            }
+
+            if (!first)
+            {
+                sb.Append(',');
+            }
+
+            first = false;
+            sb.Append("{\"uri\":");
+            AppendString(sb, resource.Uri);
+            sb.Append(",\"name\":");
+            AppendString(sb, resource.Name);
+            sb.Append(",\"description\":");
+            AppendString(sb, resource.Description ?? string.Empty);
+            if (resource.MimeType is not null)
+            {
+                sb.Append(",\"mimeType\":");
+                AppendString(sb, resource.MimeType);
+            }
+
+            sb.Append('}');
+        }
+
+        sb.Append("]}");
+        return sb.ToString();
+    }
+
+    private async Task<string> ResourcesReadResponse(string id, JsonElement root, CancellationToken cancellationToken)
+    {
+        string uri = string.Empty;
+        if (root.TryGetProperty("params", out JsonElement p)
+            && p.ValueKind == JsonValueKind.Object
+            && p.TryGetProperty("uri", out JsonElement u)
+            && u.ValueKind == JsonValueKind.String)
+        {
+            uri = u.GetString() ?? string.Empty;
+        }
+
+        // Unknown and unauthorized are answered identically, so the surface never reveals that a
+        // privileged resource exists — the same rule tools already follow.
+        if (!resources.TryGetValue(uri, out IAiResource? resource)
+            || !await IsAllowedAsync(resource, cancellationToken))
+        {
+            Diagnostics.TryReportWarning("BlazorDX.Mcp", $"resources/read denied or unknown: '{uri}'");
+            return Error(id, -32002, $"Resource not found: {uri}");
+        }
+
+        try
+        {
+            AiResourceContent content = await resource.ReadAsync(cancellationToken);
+            Diagnostics.TryReportInfo("BlazorDX.Mcp", $"resources/read '{uri}' -> ok");
+
+            StringBuilder sb = new();
+            sb.Append("{\"contents\":[{\"uri\":");
+            AppendString(sb, uri);
+            sb.Append(",\"mimeType\":");
+            AppendString(sb, content.MimeType);
+
+            if (content.Bytes is { } bytes)
+            {
+                sb.Append(",\"blob\":");
+                AppendString(sb, Convert.ToBase64String(bytes.Span));
+            }
+            else
+            {
+                sb.Append(",\"text\":");
+                AppendString(sb, content.Text ?? string.Empty);
+            }
+
+            sb.Append("}]}");
+            return Response(id, sb.ToString());
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A reader threw: report it and answer a protocol error rather than crashing the
+            // transport, matching how a failing tool is handled.
+            Diagnostics.TryReportError("BlazorDX.Mcp", $"resources/read '{uri}' threw: {ex.Message}", ex);
+            return Error(id, -32603, $"Resource '{uri}' could not be read.");
+        }
+    }
+
+    private async Task<string> PromptsListResult(CancellationToken cancellationToken)
+    {
+        StringBuilder sb = new();
+        sb.Append("{\"prompts\":[");
+        bool first = true;
+        foreach (IAiPrompt prompt in prompts.Values)
+        {
+            if (!await IsAllowedAsync(prompt, cancellationToken))
+            {
+                continue;
+            }
+
+            if (!first)
+            {
+                sb.Append(',');
+            }
+
+            first = false;
+            sb.Append("{\"name\":");
+            AppendString(sb, prompt.Name);
+            sb.Append(",\"description\":");
+            AppendString(sb, prompt.Description ?? string.Empty);
+            sb.Append(",\"arguments\":[");
+
+            for (int i = 0; i < prompt.Arguments.Count; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(',');
+                }
+
+                AiPromptArgument argument = prompt.Arguments[i];
+                sb.Append("{\"name\":");
+                AppendString(sb, argument.Name);
+                sb.Append(",\"description\":");
+                AppendString(sb, argument.Description ?? string.Empty);
+                sb.Append(",\"required\":").Append(argument.Required ? "true" : "false").Append('}');
+            }
+
+            sb.Append("]}");
+        }
+
+        sb.Append("]}");
+        return sb.ToString();
+    }
+
+    private async Task<string> PromptsGetResponse(string id, JsonElement root, CancellationToken cancellationToken)
+    {
+        string name = string.Empty;
+        Dictionary<string, string> arguments = new(StringComparer.Ordinal);
+
+        if (root.TryGetProperty("params", out JsonElement p) && p.ValueKind == JsonValueKind.Object)
+        {
+            if (p.TryGetProperty("name", out JsonElement n) && n.ValueKind == JsonValueKind.String)
+            {
+                name = n.GetString() ?? string.Empty;
+            }
+
+            if (p.TryGetProperty("arguments", out JsonElement a) && a.ValueKind == JsonValueKind.Object)
+            {
+                foreach (JsonProperty argument in a.EnumerateObject())
+                {
+                    // A client may send a number for a numeric-looking argument; take its raw
+                    // text rather than dropping it, as the tool surface does.
+                    arguments[argument.Name] = argument.Value.ValueKind switch
+                    {
+                        JsonValueKind.String => argument.Value.GetString() ?? string.Empty,
+                        JsonValueKind.Number => argument.Value.GetRawText(),
+                        _ => string.Empty,
+                    };
+                }
+            }
+        }
+
+        if (!prompts.TryGetValue(name, out IAiPrompt? prompt)
+            || !await IsAllowedAsync(prompt, cancellationToken))
+        {
+            Diagnostics.TryReportWarning("BlazorDX.Mcp", $"prompts/get denied or unknown: '{name}'");
+            return Error(id, -32602, $"Prompt not found: {name}");
+        }
+
+        try
+        {
+            AiPromptResult result = await prompt.GetAsync(arguments, cancellationToken);
+            Diagnostics.TryReportInfo("BlazorDX.Mcp", $"prompts/get '{name}' -> ok");
+
+            StringBuilder sb = new();
+            sb.Append("{\"description\":");
+            AppendString(sb, result.Description ?? string.Empty);
+            sb.Append(",\"messages\":[");
+
+            for (int i = 0; i < result.Messages.Count; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(',');
+                }
+
+                sb.Append("{\"role\":");
+                AppendString(sb, result.Messages[i].Role);
+                sb.Append(",\"content\":{\"type\":\"text\",\"text\":");
+                AppendString(sb, result.Messages[i].Text);
+                sb.Append("}}");
+            }
+
+            sb.Append("]}");
+            return Response(id, sb.ToString());
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Diagnostics.TryReportError("BlazorDX.Mcp", $"prompts/get '{name}' threw: {ex.Message}", ex);
+            return Error(id, -32603, $"Prompt '{name}' could not be expanded.");
+        }
     }
 
     private async Task<string> ToolsListResult(CancellationToken cancellationToken)

--- a/tests/BlazorDX.Components.Tests/AiSecurityTests.cs
+++ b/tests/BlazorDX.Components.Tests/AiSecurityTests.cs
@@ -87,8 +87,11 @@ public sealed class AiSecurityTests
 
         Assert.Equal(["Name"], prompt.Arguments.Select(a => a.Name));
 
+        // Concatenated, not an interpolated raw string: this JSON ends in "}} , which a $$"""
+        // literal reads as an interpolation hole rather than as content.
         string res = await new McpToolServer().Add(prompt).HandleAsync(
-            $$"""{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"{{prompt.Name}}"}}""");
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"prompts/get\",\"params\":{\"name\":\""
+            + prompt.Name + "\"}}");
 
         using JsonDocument doc = JsonDocument.Parse(res);
         string text = doc.RootElement.GetProperty("result").GetProperty("messages")[0]

--- a/tests/BlazorDX.Components.Tests/AiSecurityTests.cs
+++ b/tests/BlazorDX.Components.Tests/AiSecurityTests.cs
@@ -76,6 +76,31 @@ public sealed class AiSecurityTests
         Assert.Equal(string.Empty, target.ApiKey);
     }
 
+    [Fact]
+    public async Task A_form_derived_prompt_leaks_no_sensitive_field()
+    {
+        // The tests above cover the tool surface. A prompt is a third surface built from the same
+        // descriptor, and one that helpfully listed "SSN" among the fields to collect would
+        // reintroduce exactly the leak the schema was careful to avoid — while looking like a
+        // convenience feature.
+        FormAiPrompt<ProfileUpdate> prompt = new(Profile);
+
+        Assert.Equal(["Name"], prompt.Arguments.Select(a => a.Name));
+
+        string res = await new McpToolServer().Add(prompt).HandleAsync(
+            $$"""{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"{{prompt.Name}}"}}""");
+
+        using JsonDocument doc = JsonDocument.Parse(res);
+        string text = doc.RootElement.GetProperty("result").GetProperty("messages")[0]
+            .GetProperty("content").GetProperty("text").GetString()!;
+
+        // Asserted on the label a human sees, not the property name: the prompt prints labels, so
+        // checking for "Ssn" alone would pass while the text said "SSN".
+        Assert.DoesNotContain("SSN", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("API key", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Display name", text, StringComparison.Ordinal);
+    }
+
     // ---- Authorization ----
 
     [Fact]

--- a/tests/BlazorDX.Components.Tests/McpResourcesPromptsTests.cs
+++ b/tests/BlazorDX.Components.Tests/McpResourcesPromptsTests.cs
@@ -1,0 +1,226 @@
+using System.Text.Json;
+using BlazorDX.Primitives.Forms;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// The rest of the MCP surface: <c>resources/*</c> (things an assistant reads) and
+/// <c>prompts/*</c> (templates a <em>person</em> invokes).
+/// </summary>
+/// <remarks>
+/// Every response here is hand-built JSON, so these parse rather than substring-match. The
+/// authorization cases matter most: a resource is raw data, so a surface that leaked which
+/// resources exist would be a worse failure than the equivalent for tools.
+/// </remarks>
+public sealed class McpResourcesPromptsTests
+{
+    private static McpToolServer Bare() => new() { ServerName = "BlazorDX Test" };
+
+    private static TextAiResource Pricing() => new(
+        "docs://pricing",
+        "Pricing",
+        "Current price list",
+        _ => Task.FromResult("Widgets cost 4."),
+        "text/markdown");
+
+    private sealed class DenyAll : IAiContentAuthorizer
+    {
+        public ValueTask<bool> IsAllowedAsync(IAiResource resource, CancellationToken ct) => new(false);
+
+        public ValueTask<bool> IsAllowedAsync(IAiPrompt prompt, CancellationToken ct) => new(false);
+    }
+
+    private sealed class PngResource : IAiResource
+    {
+        public string Uri => "img://logo";
+
+        public string Name => "Logo";
+
+        public string? Description => null;
+
+        public string? MimeType => "image/png";
+
+        public Task<AiResourceContent> ReadAsync(CancellationToken ct) =>
+            Task.FromResult(AiResourceContent.FromBytes(new byte[] { 1, 2, 3 }, "image/png"));
+    }
+
+    private static async Task<JsonElement> ResultOf(McpToolServer server, string request)
+    {
+        using JsonDocument doc = JsonDocument.Parse(await server.HandleAsync(request));
+        return doc.RootElement.Clone();
+    }
+
+    // ---- capabilities ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task Capabilities_name_only_what_is_actually_registered()
+    {
+        JsonElement bare = await ResultOf(Bare(), """{"jsonrpc":"2.0","id":1,"method":"initialize"}""");
+        JsonElement none = bare.GetProperty("result").GetProperty("capabilities");
+
+        // Advertising resources this server does not have costs a wasted resources/list on every
+        // connection, and makes a genuinely empty surface look identical to one whose
+        // registration was forgotten.
+        Assert.False(none.TryGetProperty("resources", out _));
+        Assert.False(none.TryGetProperty("prompts", out _));
+
+        JsonElement withResource = await ResultOf(
+            Bare().Add(Pricing()), """{"jsonrpc":"2.0","id":1,"method":"initialize"}""");
+        JsonElement some = withResource.GetProperty("result").GetProperty("capabilities");
+
+        Assert.True(some.TryGetProperty("resources", out _));
+        Assert.False(some.TryGetProperty("prompts", out _));
+    }
+
+    // ---- resources ------------------------------------------------------------------------
+
+    [Fact]
+    public async Task A_resource_is_listed_and_read_by_uri()
+    {
+        McpToolServer server = Bare().Add(Pricing());
+
+        JsonElement listed = await ResultOf(server, """{"jsonrpc":"2.0","id":1,"method":"resources/list"}""");
+        JsonElement one = listed.GetProperty("result").GetProperty("resources")[0];
+        Assert.Equal("docs://pricing", one.GetProperty("uri").GetString());
+        Assert.Equal("Pricing", one.GetProperty("name").GetString());
+        Assert.Equal("text/markdown", one.GetProperty("mimeType").GetString());
+
+        JsonElement read = await ResultOf(server,
+            """{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"docs://pricing"}}""");
+        JsonElement content = read.GetProperty("result").GetProperty("contents")[0];
+        Assert.Equal("Widgets cost 4.", content.GetProperty("text").GetString());
+        Assert.Equal("text/markdown", content.GetProperty("mimeType").GetString());
+    }
+
+    [Fact]
+    public async Task A_binary_resource_is_base64_and_carries_no_text_member()
+    {
+        JsonElement read = await ResultOf(Bare().Add(new PngResource()),
+            """{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"img://logo"}}""");
+
+        JsonElement content = read.GetProperty("result").GetProperty("contents")[0];
+        Assert.Equal(Convert.ToBase64String([1, 2, 3]), content.GetProperty("blob").GetString());
+
+        // Sending both would let a client pick the wrong one; the protocol expects exactly one.
+        Assert.False(content.TryGetProperty("text", out _));
+    }
+
+    [Fact]
+    public async Task An_unknown_resource_is_a_protocol_error()
+    {
+        JsonElement read = await ResultOf(Bare().Add(Pricing()),
+            """{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"docs://nope"}}""");
+
+        Assert.Equal(-32002, read.GetProperty("error").GetProperty("code").GetInt32());
+    }
+
+    [Fact]
+    public async Task A_reader_that_throws_does_not_take_the_transport_down()
+    {
+        McpToolServer server = Bare().Add(new TextAiResource(
+            "x://boom", "Boom", null, _ => throw new InvalidOperationException("disk gone")));
+
+        JsonElement read = await ResultOf(server,
+            """{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"x://boom"}}""");
+
+        Assert.Equal(-32603, read.GetProperty("error").GetProperty("code").GetInt32());
+
+        // The exception's own text is not echoed: "disk gone" is the kind of internal detail an
+        // error message hands to whoever is on the other end of the connection.
+        Assert.DoesNotContain("disk gone", read.GetProperty("error").GetProperty("message").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_denied_resource_is_indistinguishable_from_a_missing_one()
+    {
+        McpToolServer gated = new McpToolServer { ServerName = "T", ContentAuthorizer = new DenyAll() }.Add(Pricing());
+
+        JsonElement listed = await ResultOf(gated, """{"jsonrpc":"2.0","id":1,"method":"resources/list"}""");
+        Assert.Empty(listed.GetProperty("result").GetProperty("resources").EnumerateArray());
+
+        JsonElement read = await ResultOf(gated,
+            """{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"docs://pricing"}}""");
+
+        // Byte-identical to the unknown-resource answer above. A different message, or a
+        // different code, would confirm the resource exists to a caller not allowed to read it.
+        Assert.Equal(-32002, read.GetProperty("error").GetProperty("code").GetInt32());
+        Assert.Equal("Resource not found: docs://pricing", read.GetProperty("error").GetProperty("message").GetString());
+    }
+
+    // ---- prompts --------------------------------------------------------------------------
+
+    [Fact]
+    public async Task A_form_becomes_a_prompt_that_points_at_its_own_tool()
+    {
+        FormAiPrompt<MeetingRequest> prompt = new(new MeetingRequestFormModel());
+        McpToolServer server = Bare().Add(prompt);
+
+        JsonElement listed = await ResultOf(server, """{"jsonrpc":"2.0","id":1,"method":"prompts/list"}""");
+        JsonElement one = listed.GetProperty("result").GetProperty("prompts")[0];
+        Assert.Equal(prompt.Name, one.GetProperty("name").GetString());
+        Assert.Equal(prompt.Arguments.Count, one.GetProperty("arguments").GetArrayLength());
+
+        JsonElement got = await ResultOf(server,
+            $$"""{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"{{prompt.Name}}"}}""");
+        JsonElement message = got.GetProperty("result").GetProperty("messages")[0];
+
+        Assert.Equal("user", message.GetProperty("role").GetString());
+        string text = message.GetProperty("content").GetProperty("text").GetString()!;
+
+        // The point of the prompt: a person invokes it, and the assistant is told which tool
+        // finishes the job. Without that it would gather the values and then guess.
+        Assert.Contains(new MeetingRequestFormModel().ToolName, text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Prompt_text_states_the_model_s_real_constraints()
+    {
+        FormAiPrompt<MeetingRequest> prompt = new(new MeetingRequestFormModel());
+
+        JsonElement got = await ResultOf(Bare().Add(prompt),
+            $$"""{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"{{prompt.Name}}"}}""");
+        string text = got.GetProperty("result").GetProperty("messages")[0]
+            .GetProperty("content").GetProperty("text").GetString()!;
+
+        // Read off the descriptor rather than restated in prose, so a rule changed on the model
+        // cannot drift from what the prompt claims. Attendees is Min = 1, Max = 50.
+        Assert.Contains("range 1\u201350", text, StringComparison.Ordinal);
+        Assert.Contains("(required)", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_numeric_argument_is_kept_rather_than_dropped()
+    {
+        FormAiPrompt<MeetingRequest> prompt = new(new MeetingRequestFormModel());
+
+        // A client collecting a number sends a number. Ignoring it would silently lose what the
+        // user already typed and make the assistant ask again.
+        JsonElement got = await ResultOf(Bare().Add(prompt),
+            $$"""{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"{{prompt.Name}}","arguments":{"Attendees":4}}}""");
+
+        string text = got.GetProperty("result").GetProperty("messages")[0]
+            .GetProperty("content").GetProperty("text").GetString()!;
+
+        Assert.Contains("already given: 4", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task An_unknown_prompt_is_a_protocol_error()
+    {
+        JsonElement got = await ResultOf(Bare(),
+            """{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"nope"}}""");
+
+        Assert.Equal(-32602, got.GetProperty("error").GetProperty("code").GetInt32());
+    }
+
+    [Fact]
+    public async Task A_denied_prompt_is_neither_listed_nor_fetchable()
+    {
+        McpToolServer gated = new McpToolServer { ServerName = "T", ContentAuthorizer = new DenyAll() }
+            .Add(new FormAiPrompt<MeetingRequest>(new MeetingRequestFormModel()));
+
+        JsonElement listed = await ResultOf(gated, """{"jsonrpc":"2.0","id":1,"method":"prompts/list"}""");
+        Assert.Empty(listed.GetProperty("result").GetProperty("prompts").EnumerateArray());
+    }
+}

--- a/tests/BlazorDX.Components.Tests/McpResourcesPromptsTests.cs
+++ b/tests/BlazorDX.Components.Tests/McpResourcesPromptsTests.cs
@@ -51,6 +51,14 @@ public sealed class McpResourcesPromptsTests
         return doc.RootElement.Clone();
     }
 
+    // Built by concatenation rather than an interpolated raw string: the JSON ends in "}} , which
+    // a $$""" literal reads as an interpolation hole rather than as content.
+    private static string PromptGet(string name, string? argumentsJson = null) =>
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"prompts/get\",\"params\":{\"name\":\""
+        + name + "\""
+        + (argumentsJson is null ? string.Empty : ",\"arguments\":" + argumentsJson)
+        + "}}";
+
     // ---- capabilities ---------------------------------------------------------------------
 
     [Fact]
@@ -161,8 +169,7 @@ public sealed class McpResourcesPromptsTests
         Assert.Equal(prompt.Name, one.GetProperty("name").GetString());
         Assert.Equal(prompt.Arguments.Count, one.GetProperty("arguments").GetArrayLength());
 
-        JsonElement got = await ResultOf(server,
-            $$"""{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"{{prompt.Name}}"}}""");
+        JsonElement got = await ResultOf(server, PromptGet(prompt.Name));
         JsonElement message = got.GetProperty("result").GetProperty("messages")[0];
 
         Assert.Equal("user", message.GetProperty("role").GetString());
@@ -178,8 +185,7 @@ public sealed class McpResourcesPromptsTests
     {
         FormAiPrompt<MeetingRequest> prompt = new(new MeetingRequestFormModel());
 
-        JsonElement got = await ResultOf(Bare().Add(prompt),
-            $$"""{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"{{prompt.Name}}"}}""");
+        JsonElement got = await ResultOf(Bare().Add(prompt), PromptGet(prompt.Name));
         string text = got.GetProperty("result").GetProperty("messages")[0]
             .GetProperty("content").GetProperty("text").GetString()!;
 
@@ -196,8 +202,7 @@ public sealed class McpResourcesPromptsTests
 
         // A client collecting a number sends a number. Ignoring it would silently lose what the
         // user already typed and make the assistant ask again.
-        JsonElement got = await ResultOf(Bare().Add(prompt),
-            $$"""{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"{{prompt.Name}}","arguments":{"Attendees":4}}}""");
+        JsonElement got = await ResultOf(Bare().Add(prompt), PromptGet(prompt.Name, """{"Attendees":4}"""));
 
         string text = got.GetProperty("result").GetProperty("messages")[0]
             .GetProperty("content").GetProperty("text").GetString()!;


### PR DESCRIPTION
> **Stacked on #60.** Because CI only triggers for PRs based on `main`, this PR gets no automatic
> run — I dispatch it manually and report the result. When #60 merges, **retarget this PR before
> deleting `feature/mcp-http-sse`**: deleting a base branch closes the child PR irrecoverably,
> which is what happened to #59.

## The gap

Tools cover the direction the *model* drives. The other two directions are the user's — a
**resource** is something a person attaches, a **prompt** is something a person invokes before the
model does anything. Without them a BlazorDX server can only be talked to mid-task, never set up.

| | Chosen by | Runs anything? | Type |
|---|---|---|---|
| Tool | the model, mid-task | yes | `FormAiTool<T>`, `GridAiTool<T>` |
| Resource | the user, or on request | no — it is fetched | `TextAiResource` / your `IAiResource` |
| Prompt | the **user**, before the task | no — it expands into the chat | `FormAiPrompt<T>`, `TextAiPrompt` |

`resources/list`, `resources/read`, `prompts/list` and `prompts/get` now round out `initialize`,
`tools/list` and `tools/call`.

## `FormAiPrompt<T>` — one declaration, a third surface

This is the piece that belongs in *this* library rather than in generic MCP plumbing. It turns the
same `[DxFormModel]` descriptor into a slash-command that states the task, lists the fields **with
the constraints read off the descriptor**, and names the tool that submits.

Reading constraints off the descriptor rather than restating them in prose is the point: a rule
changed on the model cannot drift from what the prompt claims. Every argument is optional on
purpose — a prompt demanding each required field up front would just be the form again in a worse
renderer.

## Security

- **Sensitive fields are omitted** from both the prompt's arguments and its text, exactly as from
  the tool schema. A prompt that helpfully listed `SSN` among the fields to collect would
  reintroduce the very leak the schema avoids *while looking like a convenience feature*. The
  assertion lives in `AiSecurityTests` beside the other redaction tests, not off in the new file,
  so anyone auditing redaction sees all three surfaces in one place.
- **`IAiContentAuthorizer`** gates resources and prompts. A disallowed item is answered **exactly**
  as a non-existent one — same code, same message — so the surface never reveals that a privileged
  resource exists. Separate from `IAiToolAuthorizer` because adding methods there would break every
  host implementing it, and "may you read this" isn't "may you run this". It matters more here:
  a resource *is* raw data, with no validation layer between caller and bytes.
- A reader that throws becomes `-32603` and **its exception text is not echoed** — asserted, since
  that is how internal detail leaks to whoever is on the other end of the connection.
- The resource `Uri` is an identifier, not a path; nothing dereferences it. `TextAiResource` takes
  a delegate rather than a directory precisely so the safe shape is a fixed set of URIs you chose.

## Capabilities are honest

`resources` and `prompts` appear in `initialize` **only when something is registered** — otherwise
every client pays a wasted `resources/list` per connection, and a genuinely empty surface looks
identical to one whose registration was forgotten.

## Scope declined, not deferred

**Sampling** (server asks the client's model for a completion) and **roots** (client tells the
server which directories it may use) are client responsibilities. A component library has no
business initiating model calls on its host's account, so the docs mark them declined rather than
leaving them looking pending forever.

## Verification

Compiled and ran the real Forms/MCP sources standalone before pushing — 24 checks, including the
sensitive-field one. That caught a genuine compile error CI would otherwise have surfaced a full
round-trip later: **CS9124**, a primary-constructor parameter both captured into `ReadAsync` and
used to initialize `MimeType`.

13 new tests (`McpResourcesPromptsTests` + one in `AiSecurityTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
