### PR TITLE
Format the last two user-visible dates in the reader's culture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,29 @@ All notable changes to BlazorDX are documented here. The format is loosely based
 
 ## [0.5.0] — 2026-09-02
 
+> **Note added 2026-09-05: this release raised the minimum .NET SDK for consumers, and the
+> release notes did not say so.**
+>
+> `Microsoft.CodeAnalysis.CSharp` went from **4.8.0 to 5.9.0** in this version, and both
+> `BlazorDX.SourceGen` and `BlazorDX.Analyzers` are built against it. A source generator only
+> runs on a compiler at least as new as the one it references, so **from 0.5.0 onward a consumer
+> needs an SDK whose Roslyn is ≥ 5.9.0.** SDK 10.0.204 carries 5.3.0 and is not enough.
+>
+> **The failure is much worse for consumers than for this repo, and the reason is a setting.**
+> `Directory.Build.props` here sets `TreatWarningsAsErrors`, so CS9057 stops the build and names
+> the cause outright. A consumer without that setting gets CS9057 as a *warning* — the generator
+> is silently skipped and the build fails instead with `CS0246: the type or namespace name
+> '<Model>FormModel' could not be found`, pointing at their own Razor pages. Found that way:
+> HolosThought's upgrade from 0.4.4 produced three such errors and no obvious cause.
+>
+> CI is unaffected because `actions/setup-dotnet` requests `10.0.x` and gets the latest, so this
+> gap only shows on a workstation that has not updated. **It also means this repository cannot be
+> built on such a machine at all** — `dotnet build src/BlazorDX.Components` fails with the same
+> CS9057 against `BlazorDX.Analyzers`.
+>
+> Nothing here is wrong except the omission: consumers should be told a version bump moved their
+> toolchain floor.
+
 ### Removed
 
 - **The Zero-Trust, Ephemeral AI Chat Conduit moved to its own repository, [AIEphemeral](https://github.com/logixrcorp/AIEphemeral).**

--- a/src/BlazorDX.Components/DxDatePicker.cs
+++ b/src/BlazorDX.Components/DxDatePicker.cs
@@ -163,7 +163,13 @@ public sealed class DxDatePicker : DatePickerPrimitive
             builder.AddAttribute(39, "role", "gridcell");
             builder.AddAttribute(40, "class", css);
             builder.AddAttribute(41, "aria-selected", IsSelected(day) ? "true" : "false");
-            builder.AddAttribute(42, "aria-label", day.ToString("D", CultureInfo.InvariantCulture));
+            // Fmt, not InvariantCulture: this label is the whole of what a screen reader announces
+            // for a day cell, so an invariant long date read out in English under a French UI.
+            // Using the same Fmt the month header and trigger use — rather than CurrentCulture —
+            // is what keeps an explicit Culture="fr-FR" from producing a French header above cells
+            // announced in English. The day number below stays invariant on purpose: it is a bare
+            // integer, and .NET renders Latin digits for it either way.
+            builder.AddAttribute(42, "aria-label", day.ToString("D", Fmt));
             builder.AddAttribute(43, "onclick", EventCallback.Factory.Create(this, () => SelectAsync(captured)));
             builder.AddContent(44, day.Day.ToString(CultureInfo.InvariantCulture));
             builder.CloseElement();

--- a/src/BlazorDX.Components/DxFileManager.cs
+++ b/src/BlazorDX.Components/DxFileManager.cs
@@ -331,7 +331,12 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
             builder.OpenElement(106, "span");
             builder.AddAttribute(107, "class", "dx-fm-cell dx-fm-modified");
             builder.AddAttribute(1071, "role", "cell");
-            builder.AddContent(108, entry.Modified.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+            // The culture alone was not the bug here: "yyyy-MM-dd" is a fixed pattern, so swapping
+            // the culture on it would still render ISO to every user. The short-date pattern is
+            // what follows the reader's culture, which is what every file manager they already use
+            // shows them. Sorting is done on the value, not this string, so nothing depended on
+            // the ISO shape.
+            builder.AddContent(108, entry.Modified.ToString("d", CultureInfo.CurrentCulture));
             builder.CloseElement();
 
             // Per-row "Move" toggle: arms the keyboard/single-pointer move (2.5.7).

--- a/src/BlazorDX.Primitives/Inputs/DatePickerPrimitive.cs
+++ b/src/BlazorDX.Primitives/Inputs/DatePickerPrimitive.cs
@@ -66,7 +66,13 @@ public class DatePickerPrimitive : ComponentBase, IAsyncDisposable
 
     protected bool HasValue => Value is not null;
 
-    private CultureInfo Fmt => Culture ?? CultureInfo.CurrentCulture;
+    /// <summary>
+    /// The culture every date string in this component is formatted with. Protected rather than
+    /// private because the styled layer renders the day cells and their labels, and a second copy
+    /// of this expression there is a second thing to keep in step — the failure mode being a
+    /// French month header above day cells a screen reader announces in English.
+    /// </summary>
+    protected CultureInfo Fmt => Culture ?? CultureInfo.CurrentCulture;
 
     protected string DisplayText => Value?.ToString("d", Fmt) ?? ResolvedPlaceholder;
 

--- a/tests/BlazorDX.Components.Tests/DxDatePickerTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDatePickerTests.cs
@@ -17,6 +17,46 @@ public sealed class DxDatePickerTests : TestContext
     }
 
     [Fact]
+    public void A_day_cell_announces_its_date_in_the_ambient_culture()
+    {
+        // The aria-label is the whole of what a screen reader says for a day cell, and it was
+        // built with InvariantCulture — so a user on a French UI heard every date read out in
+        // English. Nothing visual changes when this is wrong, which is why nothing caught it.
+        using CultureScope _ = CultureScope.For("fr-FR");
+
+        IRenderedComponent<DxDatePicker> picker = RenderComponent<DxDatePicker>(parameters => parameters
+            .Add(p => p.Value, new DateOnly(2026, 6, 16)));
+        picker.Find(".dx-date-trigger").Click();
+
+        string labels = string.Join(" | ", picker.FindAll("[role='gridcell']")
+            .Select(cell => cell.GetAttribute("aria-label") ?? string.Empty));
+
+        Assert.Contains("juin", labels, StringComparison.Ordinal);
+        Assert.DoesNotContain("June", labels, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void An_explicit_Culture_reaches_the_day_labels_too_not_just_the_visible_text()
+    {
+        // The subtler half. Formatting the label from CurrentCulture would look correct in the
+        // test above and still be wrong here: an explicit Culture would render a French month
+        // header over day cells announced in English — visible text and announced text
+        // disagreeing, which no real user is ever in.
+        using CultureScope _ = CultureScope.For("en-US");
+
+        IRenderedComponent<DxDatePicker> picker = RenderComponent<DxDatePicker>(parameters => parameters
+            .Add(p => p.Value, new DateOnly(2026, 6, 16))
+            .Add(p => p.Culture, new System.Globalization.CultureInfo("fr-FR")));
+        picker.Find(".dx-date-trigger").Click();
+
+        string labels = string.Join(" | ", picker.FindAll("[role='gridcell']")
+            .Select(cell => cell.GetAttribute("aria-label") ?? string.Empty));
+
+        Assert.Equal("juin 2026", picker.Find(".dx-date-month").TextContent);
+        Assert.Contains("juin", labels, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Shows_placeholder_until_a_date_is_set()
     {
         IRenderedComponent<DxDatePicker> picker = RenderComponent<DxDatePicker>(parameters => parameters

--- a/tests/BlazorDX.Components.Tests/DxFileManagerTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxFileManagerTests.cs
@@ -51,6 +51,23 @@ public sealed class DxFileManagerTests : TestContext
         });
 
     [Fact]
+    public void The_modified_column_uses_the_reader_s_date_format()
+    {
+        // Not a culture bug but a *format* bug: the column was built from the fixed pattern
+        // "yyyy-MM-dd", so swapping the culture on it would still have shown ISO to every reader.
+        // The short-date pattern is the one that follows their culture — 01/06/2026 in France,
+        // 6/1/2026 in the US, for the same day.
+        using CultureScope _ = CultureScope.For("fr-FR");
+
+        IRenderedComponent<DxFileManager> fm = Render();
+
+        string modified = fm.FindAll(".dx-fm-modified")[0].TextContent;
+
+        Assert.Equal("01/06/2026", modified);
+        Assert.DoesNotContain("2026-06-01", modified, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Tree_shows_only_top_level_folders_until_expanded()
     {
         IRenderedComponent<DxFileManager> fm = Render();


### PR DESCRIPTION
Closes the two date-formatting cases the `0.6.0` changelog named as **found but not fixed** while
auditing the localization rollout. They're the counter-example to that release's headline: a library
that externalizes every string and then prints dates invariantly isn't culture-correct.

They are not the same defect, which is why one is a one-word change and the other isn't.

## `DxDatePicker` — the culture

The day cell's `aria-label` was built with `InvariantCulture`. That label is **the whole of what a
screen reader announces for the cell**, so a user on a French UI heard every date read out in
English while seeing a French month header above it. Nothing visual changes when this is wrong,
which is how it survived both an accessibility sweep and a localization rollout.

The non-obvious part: `CurrentCulture` would have been the wrong fix. `DxDatePicker` already has a
`Culture` parameter that the month header and trigger format through, so `CurrentCulture` would
pass a test that only sets the ambient culture and still be wrong — an explicit `Culture="fr-FR"`
would render a French header over cells announced in English.

It now uses `Fmt`, the same `Culture ?? CurrentCulture` the other two already use. `Fmt` moves from
`private` to `protected` on `DatePickerPrimitive` so there's one definition rather than a second
copy to keep in step. Both paths are tested.

## `DxFileManager` — the format string

Not a culture bug at all. The modified column was built from the fixed pattern `"yyyy-MM-dd"`, so
swapping the culture on it would still have shown ISO to every reader. The **short-date pattern** is
the one that follows them: `01/06/2026` in France, `6/1/2026` in the US, same day.

Sorting works off the value rather than this string, so nothing depended on the ISO shape — checked
before changing it, along with confirming no test or E2E selector pinned the rendered text.

## Verification

The French formats asserted in the tests were checked against real ICU rather than assumed —
`01/06/2026`, `mardi 16 juin 2026`, `juin 2026` — since these assertions run on a Linux CI runner
and I'd otherwise be guessing at ICU's patterns from memory.

Both new tests fail against the old code for the right reason: the date picker's on the announced
text, the file manager's on the format shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
