### PR TITLE
Add /audit, a guided harness for the manual screen-reader pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,29 @@ All notable changes to BlazorDX are documented here. The format is loosely based
 
 ## [0.5.0] — 2026-09-02
 
+> **Note added 2026-09-05: this release raised the minimum .NET SDK for consumers, and the
+> release notes did not say so.**
+>
+> `Microsoft.CodeAnalysis.CSharp` went from **4.8.0 to 5.9.0** in this version, and both
+> `BlazorDX.SourceGen` and `BlazorDX.Analyzers` are built against it. A source generator only
+> runs on a compiler at least as new as the one it references, so **from 0.5.0 onward a consumer
+> needs an SDK whose Roslyn is ≥ 5.9.0.** SDK 10.0.204 carries 5.3.0 and is not enough.
+>
+> **The failure is much worse for consumers than for this repo, and the reason is a setting.**
+> `Directory.Build.props` here sets `TreatWarningsAsErrors`, so CS9057 stops the build and names
+> the cause outright. A consumer without that setting gets CS9057 as a *warning* — the generator
+> is silently skipped and the build fails instead with `CS0246: the type or namespace name
+> '<Model>FormModel' could not be found`, pointing at their own Razor pages. Found that way:
+> HolosThought's upgrade from 0.4.4 produced three such errors and no obvious cause.
+>
+> CI is unaffected because `actions/setup-dotnet` requests `10.0.x` and gets the latest, so this
+> gap only shows on a workstation that has not updated. **It also means this repository cannot be
+> built on such a machine at all** — `dotnet build src/BlazorDX.Components` fails with the same
+> CS9057 against `BlazorDX.Analyzers`.
+>
+> Nothing here is wrong except the omission: consumers should be told a version bump moved their
+> toolchain floor.
+
 ### Removed
 
 - **The Zero-Trust, Ephemeral AI Chat Conduit moved to its own repository, [AIEphemeral](https://github.com/logixrcorp/AIEphemeral).**

--- a/docs/accessibility-screen-reader-checklist.md
+++ b/docs/accessibility-screen-reader-checklist.md
@@ -9,6 +9,12 @@ green in CI for every route; this checklist is the human verification that remai
 
 Mark each: ✅ pass / ⚠ issue (link) / ⬜ not yet run.
 
+> **Running the pass?** Use the guided version at **[blazordx.com/audit](https://blazordx.com/audit)**
+> rather than this file. It renders these same checks next to a link to the route each one tests,
+> saves answers in your browser as you go, and generates a Markdown report to paste back here or
+> onto the PR. `AuditChecklistDriftTests` fails the build if that page and this list diverge, so
+> the two cannot quietly fall out of step — it caught a missing item the first time it ran.
+
 ## All components (baseline)
 - [ ] First-tab reveals a skip link; landmarks (`nav`/`main`) let the user jump blocks (2.4.1).
 - [ ] Every interactive control announces **name, role, value/state** (4.1.2).

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/Components/App.razor
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/Components/App.razor
@@ -99,6 +99,11 @@
     {
         <script src="powerbi-stub.js"></script>
     }
+    @* Progressive enhancement for /audit, and a no-op on every other route. Loaded globally
+       rather than from the page itself because enhanced navigation does not execute scripts a
+       page transition introduces — a tester arriving there from a link would otherwise get the
+       checklist with none of its tooling, and no sign anything was missing. *@
+    <script src="audit.js" defer></script>
     <script src="https://unpkg.com/htmx.org@2.0.3" integrity="sha384-0895/pl2MU10Hqc6jd4RvrthNlDiE9U1tWmX7WRESftEDRosgxNsQG/Ze9YMRzHq" crossorigin="anonymous"></script>
     <ImportMap />
     @* Any <script type="module"> must come after <ImportMap /> — the browser locks

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/Components/Pages/Audit.razor
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/Components/Pages/Audit.razor
@@ -1,0 +1,158 @@
+@page "/audit"
+
+@* Static-SSR: every check is in the server-rendered HTML. This page is a tool FOR screen-reader
+   users, so content that only exists after JavaScript runs would be the exact failure the
+   library's own no-JS checks exist to catch. audit.js adds progress, saving and export on top,
+   and the page is fully readable and answerable without it. *@
+
+<PageTitle>Screen reader audit — BlazorDX</PageTitle>
+
+<section class="dx-audit" data-audit-root>
+
+    <header class="dx-audit-top">
+        <p class="dx-audit-eyebrow">Manual accessibility pass</p>
+        <h1>Screen reader audit</h1>
+        <p class="dx-audit-lede">
+            Every BlazorDX route is checked automatically by axe-core on three browser engines, and
+            passes. This is the half automation cannot do: whether someone using a screen reader can
+            actually operate the components. That pass has never been run.
+        </p>
+    </header>
+
+    <div class="dx-audit-card">
+        <h2>How this works</h2>
+        <p>
+            Open a section's link in a second tab, work through its checks with your screen reader
+            running, and mark what you find. Your answers are saved in this browser as you go, so you
+            can stop and come back. Nothing is sent anywhere.
+        </p>
+        <p class="dx-audit-emphasis">
+            <strong>&ldquo;Issue&rdquo; is the most useful answer here.</strong> This exists to find
+            problems, not to collect ticks — one specific note about something that read wrongly is
+            worth more than a clean sweep.
+        </p>
+    </div>
+
+    <div class="dx-audit-card">
+        <h2>Your setup</h2>
+        <p class="dx-audit-hint">Included in the report, because a finding is only reproducible if
+            we know what produced it.</p>
+        <div class="dx-audit-grid">
+            <p class="dx-audit-field">
+                <label for="audit-who">Your name</label>
+                <input id="audit-who" data-audit-meta="who" autocomplete="name" />
+            </p>
+            <p class="dx-audit-field">
+                <label for="audit-at">Screen reader and version</label>
+                <input id="audit-at" data-audit-meta="at" placeholder="NVDA 2026.1" />
+            </p>
+            <p class="dx-audit-field">
+                <label for="audit-browser">Browser and version</label>
+                <input id="audit-browser" data-audit-meta="browser" placeholder="Firefox 140" />
+            </p>
+            <p class="dx-audit-field">
+                <label for="audit-os">Operating system</label>
+                <input id="audit-os" data-audit-meta="os" placeholder="Windows 11" />
+            </p>
+        </div>
+    </div>
+
+    <div class="dx-audit-card" data-audit-progress hidden>
+        <h2>Progress</h2>
+        <p class="dx-audit-progress-row">
+            <span class="dx-audit-num" data-audit-done>0</span>
+            <span>of @AuditChecklist.TotalChecks checks answered</span>
+        </p>
+        <p class="dx-audit-tallies">
+            <span class="dx-audit-tally dx-audit-pass">Pass: <span data-audit-t-pass>0</span></span>
+            <span class="dx-audit-tally dx-audit-issue">Issue: <span data-audit-t-issue>0</span></span>
+            <span class="dx-audit-tally dx-audit-na">Not applicable: <span data-audit-t-na>0</span></span>
+        </p>
+        <p class="dx-audit-status" role="status" data-audit-save-status></p>
+    </div>
+
+@foreach (AuditArea area in AuditChecklist.Areas)
+{
+    <section class="dx-audit-area" id="@area.Id" aria-labelledby="@($"{area.Id}-h")">
+        <div class="dx-audit-area-head">
+            <h2 id="@($"{area.Id}-h")">@area.Title</h2>
+            @if (area.Route is not null)
+            {
+                <a class="dx-audit-route" href="@area.Route" target="_blank" rel="noopener">
+                    Open <code>@area.Route</code><span class="dx-audit-vh"> in a new tab</span>
+                </a>
+            }
+        </div>
+        <p class="dx-audit-note">@area.Note</p>
+
+        <ol class="dx-audit-checks">
+            @foreach (string check in area.Checks)
+            {
+                int index = Next();
+                string name = $"c{index}";
+                <li>
+                    <fieldset>
+                        <legend><span class="dx-audit-cnum">@index</span> @check</legend>
+                        <span class="dx-audit-opts">
+                            @foreach ((string value, string label) in Options)
+                            {
+                                <span class="dx-audit-opt dx-audit-opt-@value">
+                                    <input type="radio" name="@name" id="@($"{name}-{value}")"
+                                           value="@value" checked="@(value == "todo")" />
+                                    <label for="@($"{name}-{value}")">@label</label>
+                                </span>
+                            }
+                        </span>
+                        <span class="dx-audit-notes">
+                            <label for="@($"{name}-n")">Notes<span class="dx-audit-vh"> for check @index</span></label>
+                            <input type="text" id="@($"{name}-n")" data-audit-note="@name"
+                                   placeholder="What did you hear?" />
+                        </span>
+                    </fieldset>
+                </li>
+            }
+        </ol>
+    </section>
+}
+
+    <section class="dx-audit-card" aria-labelledby="audit-report-h" data-audit-report-card hidden>
+        <h2 id="audit-report-h">Generate the report</h2>
+        <p>Produces Markdown covering your setup, the tallies, and every check you marked, with your
+            notes. Select it and copy, or use the copy button.</p>
+        <p class="dx-audit-actions">
+            <button type="button" data-audit-generate>Generate report</button>
+            <button type="button" class="dx-audit-secondary" data-audit-copy>Copy to clipboard</button>
+            <button type="button" class="dx-audit-secondary" data-audit-reset>Clear my answers</button>
+        </p>
+        <label class="dx-audit-vh" for="audit-report">Generated Markdown report</label>
+        <textarea id="audit-report" data-audit-output readonly
+                  placeholder="The report appears here once you generate it."></textarea>
+        <p class="dx-audit-status" role="status" data-audit-report-status></p>
+    </section>
+
+    <footer class="dx-audit-foot">
+        <p>
+            Checks are transcribed from <code>docs/accessibility-screen-reader-checklist.md</code>.
+            Send the generated report back on the pull request, or open an issue.
+        </p>
+        <p>
+            This page stores your answers in your own browser only, and sends nothing anywhere. The
+            progress and report tools need JavaScript; the checklist itself does not.
+        </p>
+    </footer>
+</section>
+
+@code {
+    private static readonly (string Value, string Label)[] Options =
+    [
+        ("pass", "Pass"),
+        ("issue", "Issue"),
+        ("na", "Not applicable"),
+        ("todo", "Not run"),
+    ];
+
+    // Numbers the checks across every area so a tester and a report can refer to "check 24".
+    private int counter;
+
+    private int Next() => ++counter;
+}

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/Components/Pages/Audit.razor.css
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/Components/Pages/Audit.razor.css
@@ -1,0 +1,306 @@
+/* Screen-reader audit page.
+
+   Built on the demo's own theme tokens so it inherits light/dark with the rest of the site.
+   Two rules are load-bearing rather than decorative, because this page is a tool for the people
+   most affected if they are wrong: state is never carried by colour alone (each option has a
+   visible text label and a checked radio), and focus is always visible. */
+
+.dx-audit {
+    max-width: 62rem;
+    margin: 0 auto;
+    padding: 1.5rem 0 4rem;
+}
+
+.dx-audit-vh {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.dx-audit-top {
+    margin-bottom: 1.75rem;
+}
+
+.dx-audit-eyebrow {
+    font-family: var(--dx-font-mono, ui-monospace, monospace);
+    font-size: 0.78rem;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: var(--dx-color-accent, #2b4c9b);
+    margin: 0 0 0.4rem;
+}
+
+.dx-audit h1 {
+    margin: 0 0 0.6rem;
+    line-height: 1.15;
+}
+
+.dx-audit-lede {
+    margin: 0;
+    max-width: 62ch;
+    color: var(--dx-color-text-muted, #4a4a4a);
+}
+
+.dx-audit-card {
+    background: var(--dx-color-surface, #fff);
+    border: 1px solid var(--dx-color-border, #d8d8d8);
+    border-radius: var(--dx-radius-md, 8px);
+    padding: 1.15rem 1.35rem;
+    margin: 1.4rem 0;
+}
+
+.dx-audit-card h2 {
+    margin: 0 0 0.6rem;
+    font-size: 1.1rem;
+}
+
+.dx-audit-card p {
+    color: var(--dx-color-text-muted, #4a4a4a);
+    max-width: 68ch;
+}
+
+.dx-audit-emphasis strong {
+    color: var(--dx-color-text, #1a1a1a);
+}
+
+.dx-audit-hint {
+    font-size: 0.9rem;
+}
+
+.dx-audit-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+    gap: 0.75rem 1.1rem;
+}
+
+.dx-audit-field {
+    margin: 0;
+}
+
+.dx-audit-field label {
+    display: block;
+    font-size: 0.86rem;
+    color: var(--dx-color-text-muted, #4a4a4a);
+    margin-bottom: 0.25rem;
+}
+
+.dx-audit-field input,
+.dx-audit-notes input {
+    width: 100%;
+    padding: 0.45rem 0.6rem;
+    font: inherit;
+    font-size: 0.92rem;
+    color: var(--dx-color-text, #1a1a1a);
+    background: var(--dx-color-bg, #fff);
+    border: 1px solid var(--dx-color-border-strong, #b4b4b4);
+    border-radius: 6px;
+}
+
+.dx-audit-progress-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.7rem;
+    flex-wrap: wrap;
+    margin: 0;
+}
+
+.dx-audit-num {
+    font-family: var(--dx-font-mono, ui-monospace, monospace);
+    font-size: 1.5rem;
+    font-weight: 600;
+}
+
+.dx-audit-tallies {
+    display: flex;
+    gap: 0.5rem 0.85rem;
+    flex-wrap: wrap;
+    margin: 0.6rem 0 0;
+    font-size: 0.88rem;
+}
+
+.dx-audit-tally {
+    padding: 0.1rem 0.65rem;
+    border-radius: 99px;
+    border: 1px solid var(--dx-color-border, #d8d8d8);
+}
+
+.dx-audit-pass {
+    background: var(--dx-color-success-bg, #e2f2e7);
+    color: var(--dx-color-success, #1b6b3a);
+    border-color: currentColor;
+}
+
+.dx-audit-issue {
+    background: var(--dx-color-danger-bg, #fbe7e4);
+    color: var(--dx-color-danger, #9a2b20);
+    border-color: currentColor;
+}
+
+.dx-audit-status {
+    margin: 0.6rem 0 0;
+    font-size: 0.9rem;
+    color: var(--dx-color-text-muted, #4a4a4a);
+    min-height: 1.4em;
+}
+
+.dx-audit-area {
+    margin: 2.4rem 0;
+}
+
+.dx-audit-area-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.9rem;
+    flex-wrap: wrap;
+    border-bottom: 2px solid var(--dx-color-border-strong, #b4b4b4);
+    padding-bottom: 0.4rem;
+}
+
+.dx-audit-area-head h2 {
+    margin: 0;
+    font-size: 1.3rem;
+}
+
+.dx-audit-route {
+    font-size: 0.92rem;
+    white-space: nowrap;
+}
+
+.dx-audit-note {
+    color: var(--dx-color-text-muted, #4a4a4a);
+    font-size: 0.92rem;
+    margin: 0.6rem 0 0.9rem;
+}
+
+.dx-audit-checks {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.dx-audit-checks > li {
+    margin-bottom: 0.8rem;
+}
+
+.dx-audit-checks fieldset {
+    margin: 0;
+    border: 1px solid var(--dx-color-border, #d8d8d8);
+    border-radius: var(--dx-radius-md, 8px);
+    background: var(--dx-color-surface, #fff);
+    padding: 0.8rem 0.95rem 0.7rem;
+}
+
+.dx-audit-checks legend {
+    padding: 0 0.35rem;
+    font-weight: 700;
+    max-width: 68ch;
+}
+
+.dx-audit-cnum {
+    font-family: var(--dx-font-mono, ui-monospace, monospace);
+    color: var(--dx-color-text-muted, #4a4a4a);
+    font-weight: 400;
+    margin-right: 0.25rem;
+}
+
+.dx-audit-opts {
+    display: flex;
+    gap: 0.45rem 0.55rem;
+    flex-wrap: wrap;
+    margin: 0.6rem 0 0.7rem;
+}
+
+.dx-audit-opt {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.28rem 0.7rem 0.28rem 0.45rem;
+    border-radius: 99px;
+    border: 1px solid var(--dx-color-border-strong, #b4b4b4);
+}
+
+.dx-audit-opt label {
+    font-size: 0.9rem;
+    cursor: pointer;
+}
+
+.dx-audit-opt input {
+    width: 1.1rem;
+    height: 1.1rem;
+    cursor: pointer;
+}
+
+/* Selected state is reinforced, never conveyed, by colour: the radio itself and its text
+   label are what say which option is chosen. */
+.dx-audit-opt-pass:has(input:checked) {
+    background: var(--dx-color-success-bg, #e2f2e7);
+    border-color: var(--dx-color-success, #1b6b3a);
+}
+
+.dx-audit-opt-issue:has(input:checked) {
+    background: var(--dx-color-danger-bg, #fbe7e4);
+    border-color: var(--dx-color-danger, #9a2b20);
+}
+
+.dx-audit-notes label {
+    font-size: 0.82rem;
+    color: var(--dx-color-text-muted, #4a4a4a);
+    display: block;
+    margin-bottom: 0.15rem;
+}
+
+.dx-audit-actions {
+    display: flex;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
+.dx-audit-actions button {
+    font: inherit;
+    font-size: 0.93rem;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    border: 1px solid var(--dx-color-accent, #2b4c9b);
+    background: var(--dx-color-accent, #2b4c9b);
+    color: var(--dx-color-accent-contrast, #fff);
+    cursor: pointer;
+}
+
+.dx-audit-actions .dx-audit-secondary {
+    background: transparent;
+    color: var(--dx-color-accent, #2b4c9b);
+}
+
+.dx-audit textarea {
+    width: 100%;
+    min-height: 14rem;
+    margin-top: 0.7rem;
+    padding: 0.7rem;
+    font-family: var(--dx-font-mono, ui-monospace, monospace);
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: var(--dx-color-text, #1a1a1a);
+    background: var(--dx-color-bg, #fff);
+    border: 1px solid var(--dx-color-border-strong, #b4b4b4);
+    border-radius: 6px;
+}
+
+.dx-audit :is(a, button, input, textarea):focus-visible {
+    outline: 3px solid var(--dx-color-accent, #2b4c9b);
+    outline-offset: 2px;
+}
+
+.dx-audit-foot {
+    margin-top: 3rem;
+    padding-top: 1.1rem;
+    border-top: 1px solid var(--dx-color-border, #d8d8d8);
+    color: var(--dx-color-text-muted, #4a4a4a);
+    font-size: 0.86rem;
+}

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/Components/Pages/AuditChecklist.cs
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/Components/Pages/AuditChecklist.cs
@@ -1,0 +1,102 @@
+namespace BlazorDX.Demo.Components.Pages;
+
+/// <summary>One area of the manual screen-reader pass, and the checks that belong to it.</summary>
+/// <param name="Id">Anchor id for the section.</param>
+/// <param name="Title">Heading shown to the tester.</param>
+/// <param name="Route">Demo route this area is tested on, or null for the baseline pass.</param>
+/// <param name="Note">One line of guidance shown under the heading.</param>
+/// <param name="Checks">The individual checks, in order.</param>
+public sealed record AuditArea(string Id, string Title, string? Route, string Note, string[] Checks);
+
+/// <summary>
+/// The manual screen-reader checklist, rendered by <c>/audit</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Transcribed from <c>docs/accessibility-screen-reader-checklist.md</c>. The two are kept in step
+/// by <c>AuditChecklistDriftTests</c>, which parses both and fails if the counts diverge — the
+/// same shape of guard the localization resources use, and for the same reason: a checklist that
+/// has quietly drifted from the document it claims to implement is worse than no checklist,
+/// because it still looks authoritative.
+/// </para>
+/// <para>
+/// The data lives in C# rather than being read from the markdown at runtime because the document
+/// is not shipped with the app, and because rendering it server-side is what lets the page work
+/// with no JavaScript at all.
+/// </para>
+/// </remarks>
+public static class AuditChecklist
+{
+    /// <summary>Every area, in the order a tester should work through them.</summary>
+    public static readonly AuditArea[] Areas =
+    [
+        new("baseline", "Every page (baseline)", null, "Run these once on any route before starting the component sections.",
+        [
+            "First Tab reveals a skip link, and landmarks (nav / main) let you jump blocks. (2.4.1)",
+            "Every interactive control announces name, role, and value or state. (4.1.2)",
+            "A visible focus indicator is present and follows a logical order. (2.4.7 / 2.4.3)",
+            "Async results are announced through the live region. (4.1.3)",
+            "No keyboard trap; Escape dismisses overlays. (2.1.2)",
+            "With reduced motion enabled in your OS, transitions are suppressed.",
+        ]),
+        new("files", "File manager", "/files", "The move alternative is the important one: drag-and-drop is enhancement-only.",
+        [
+            "The tree announces treeitem, its level, and expanded or collapsed state; arrow keys navigate it.",
+            "The move alternative works with no mouse: arm \"Move\", choose a \"Move here\" target, confirm, and hear the result. (2.5.7)",
+            "Upload through the standard file input works without dragging anything.",
+            "After a move or upload, focus lands somewhere sensible - the moved row, or the status. (2.4.3)",
+            "A name collision is announced clearly rather than silently dropped.",
+        ]),
+        new("scheduler", "Scheduler", "/scheduler", "Category must not be conveyed by colour alone.",
+        [
+            "The view switch (Week / Month / Day) is a tablist, and arrow keys move between tabs.",
+            "The month grid announces as a grid with rows and cells; arrows, Home/End and PageUp/PageDown move the active cell, and aria-current reads on today.",
+            "In the day or week time view, the active slot is announced with its date and hour.",
+            "Each event announces title, date, time and category - with category not colour-only.",
+            "Changing the view or the date is announced. (4.1.3)",
+        ]),
+        new("docviewer", "Document and PDF viewer", "/docviewer", "An untagged PDF is a content limitation, not a viewer bug - note which you hit.",
+        [
+            "The embed or iframe announces a meaningful title. (4.1.2)",
+            "The toolbar (Download / Print / Open) is reachable and labelled, with targets at least 24 by 24.",
+            "The accessible download link is reachable even when the toolbar is hidden.",
+            "An unsafe or empty source gives a spoken \"unavailable\" placeholder rather than a broken control.",
+            "Note whether the source PDF is PDF/UA-tagged.",
+        ]),
+        new("reporting", "Reporting and Power BI", "/reports", "Also visit /powerbi. Results were recorded for this area once; this re-checks them.",
+        [
+            "The iframe has a title, and the toolbar plus parameter form conform. (3.3.1 / 3.3.2)",
+            "An accessible export is offered - tagged PDF, data, or \"show as table\".",
+            "The accessibility statement names what BlazorDX guarantees versus the renderer or report author.",
+        ]),
+        new("excel", "Excel viewer and editor", "/excel", "Also visit /excel-edit. No manual pass has ever been recorded here.",
+        [
+            "The formula bar, cell reference and active cell value are announced as you navigate.",
+            "Arrow-key cell navigation reads as a grid and gridcell pattern, not as a plain table.",
+            "Recalculated cells are announced, or the update is otherwise discoverable rather than silent.",
+        ]),
+        new("word", "Word viewer and editor", "/word", "Also visit /word-edit. No manual pass has ever been recorded here.",
+        [
+            "Document structure - headings, lists, tables - reads correctly through the OOXML to HTML round trip, with no semantic loss versus the source file.",
+            "The formatting toolbar announces pressed or active state for the current selection.",
+        ]),
+        new("htmx", "HTMX static-SSR viewer", "/htmx/doc", "This route deliberately skips Blazor enhanced navigation.",
+        [
+            "With JavaScript disabled entirely, the fallback is independently operable.",
+            "After a full-page navigation, focus lands somewhere sensible rather than being stranded.",
+        ]),
+        new("editorial", "Editorial components", "/docs", "Open a real article from the docs, not just the component gallery.",
+        [
+            "Scrollytelling stages neither trap nor steal focus, and the reveal respects reduced motion for a keyboard or AT user - not only visually.",
+            "Without the scrollytelling script, stage content is still reachable and readable in document order.",
+            "Heading hierarchy in a real article is correct and skips no levels.",
+            "Figure and spread images have meaningful alt text in practice, not only in the flagship article.",
+            "Table-of-contents links move focus to the target section on activation, not just scroll to it.",
+            "The reading-progress indicator is aria-hidden, and is never the only way information is conveyed.",
+            "The drop cap's enlarged first letter is not read twice or oddly - some screen readers mishandle a styled ::first-letter.",
+        ]),
+    ];
+
+    /// <summary>Total number of individual checks across every area.</summary>
+    public static int TotalChecks => Areas.Sum(area => area.Checks.Length);
+}

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/wwwroot/audit.js
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/wwwroot/audit.js
@@ -1,0 +1,245 @@
+// Progressive enhancement for /audit. The checklist itself is server-rendered and fully
+// answerable without this file; everything here is additive — progress, saving, and the report.
+//
+// Loaded globally from App.razor and a no-op on every other route. It re-initialises on Blazor's
+// `enhancedload` because enhanced navigation swaps the DOM without re-running page scripts, so a
+// tester who reaches /audit from a link would otherwise get the static page with none of the
+// tooling and no indication anything was missing.
+(function () {
+    "use strict";
+
+    var KEY = "blazordx-sr-audit-v1";
+
+    function readState() {
+        try {
+            return JSON.parse(localStorage.getItem(KEY) || "{}");
+        } catch (e) {
+            return {};
+        }
+    }
+
+    function init() {
+        var root = document.querySelector("[data-audit-root]");
+        if (!root || root.dataset.auditReady === "1") {
+            return;
+        }
+
+        root.dataset.auditReady = "1";
+
+        var fieldsets = Array.prototype.slice.call(root.querySelectorAll(".dx-audit-checks fieldset"));
+        var total = fieldsets.length;
+        if (total === 0) {
+            return;
+        }
+
+        // Only revealed once the tooling is running, so a no-JS reader is never shown a progress
+        // panel stuck at zero or a report button that does nothing.
+        var progress = root.querySelector("[data-audit-progress]");
+        var reportCard = root.querySelector("[data-audit-report-card]");
+        if (progress) { progress.hidden = false; }
+        if (reportCard) { reportCard.hidden = false; }
+
+        var state = readState();
+        var saveStatus = root.querySelector("[data-audit-save-status]");
+        var reportStatus = root.querySelector("[data-audit-report-status]");
+        var output = root.querySelector("[data-audit-output]");
+
+        function save(message) {
+            var ok = true;
+            try {
+                localStorage.setItem(KEY, JSON.stringify(state));
+            } catch (e) {
+                ok = false;
+            }
+
+            if (saveStatus) {
+                saveStatus.textContent = ok
+                    ? (message || "Saved in this browser.")
+                    : "Could not save — this browser is blocking site storage, so copy your report before leaving.";
+            }
+        }
+
+        // Restore anything from a previous sitting.
+        Object.keys(state.answers || {}).forEach(function (name) {
+            var el = document.getElementById(name + "-" + state.answers[name]);
+            if (el) { el.checked = true; }
+        });
+        Object.keys(state.notes || {}).forEach(function (name) {
+            var el = root.querySelector('[data-audit-note="' + name + '"]');
+            if (el) { el.value = state.notes[name]; }
+        });
+        Object.keys(state.meta || {}).forEach(function (key) {
+            var el = root.querySelector('[data-audit-meta="' + key + '"]');
+            if (el) { el.value = state.meta[key]; }
+        });
+
+        function tally() {
+            var counts = { pass: 0, issue: 0, na: 0, todo: 0 };
+            fieldsets.forEach(function (fs) {
+                var picked = fs.querySelector("input[type=radio]:checked");
+                counts[picked ? picked.value : "todo"]++;
+            });
+
+            var answered = counts.pass + counts.issue + counts.na;
+            var set = function (sel, value) {
+                var el = root.querySelector(sel);
+                if (el) { el.textContent = String(value); }
+            };
+            set("[data-audit-done]", answered);
+            set("[data-audit-t-pass]", counts.pass);
+            set("[data-audit-t-issue]", counts.issue);
+            set("[data-audit-t-na]", counts.na);
+            return counts;
+        }
+
+        root.addEventListener("change", function (e) {
+            var t = e.target;
+            if (t.type === "radio" && t.name.charAt(0) === "c") {
+                state.answers = state.answers || {};
+                state.answers[t.name] = t.value;
+                var counts = tally();
+                save("Saved. " + (counts.pass + counts.issue + counts.na) + " of " + total + " answered.");
+            }
+        });
+
+        root.addEventListener("input", function (e) {
+            var t = e.target;
+            if (!t.dataset) {
+                return;
+            }
+
+            if (t.dataset.auditNote) {
+                state.notes = state.notes || {};
+                state.notes[t.dataset.auditNote] = t.value;
+                save();
+            } else if (t.dataset.auditMeta) {
+                state.meta = state.meta || {};
+                state.meta[t.dataset.auditMeta] = t.value;
+                save();
+            }
+        });
+
+        function buildReport() {
+            var meta = state.meta || {};
+            var counts = tally();
+            var lines = [
+                "# BlazorDX manual screen-reader pass",
+                "",
+                "- Tester: " + (meta.who || "(not given)"),
+                "- Screen reader: " + (meta.at || "(not given)"),
+                "- Browser: " + (meta.browser || "(not given)"),
+                "- OS: " + (meta.os || "(not given)"),
+                "- Date: " + new Date().toISOString().slice(0, 10),
+                "- Result: " + counts.pass + " pass, " + counts.issue + " issue, " +
+                    counts.na + " n/a, " + counts.todo + " not run (of " + total + ")",
+                ""
+            ];
+
+            root.querySelectorAll(".dx-audit-area").forEach(function (area) {
+                var rows = [];
+                area.querySelectorAll("fieldset").forEach(function (fs) {
+                    var picked = fs.querySelector("input[type=radio]:checked");
+                    var value = picked ? picked.value : "todo";
+                    if (value === "todo") {
+                        return;
+                    }
+
+                    var text = fs.querySelector("legend").textContent.trim().replace(/\s+/g, " ");
+                    var noteInput = fs.querySelector('input[type="text"]');
+                    var note = noteInput ? noteInput.value : "";
+                    var mark = value === "pass" ? "PASS " : value === "issue" ? "ISSUE" : "N/A  ";
+                    rows.push("- `" + mark + "` " + text + (note ? "\n      - " + note : ""));
+                });
+
+                if (rows.length) {
+                    lines.push("## " + area.querySelector("h2").textContent.trim());
+                    lines.push("");
+                    lines.push(rows.join("\n"));
+                    lines.push("");
+                }
+            });
+
+            if (counts.pass + counts.issue + counts.na === 0) {
+                lines.push("_No checks answered yet._");
+            }
+
+            return lines.join("\n");
+        }
+
+        var generate = root.querySelector("[data-audit-generate]");
+        if (generate) {
+            generate.addEventListener("click", function () {
+                output.value = buildReport();
+                if (reportStatus) { reportStatus.textContent = "Report generated below."; }
+                output.focus();
+            });
+        }
+
+        var copy = root.querySelector("[data-audit-copy]");
+        if (copy) {
+            copy.addEventListener("click", function () {
+                if (!output.value) {
+                    output.value = buildReport();
+                }
+
+                output.select();
+                // The clipboard API needs a secure context and permission; selecting the text and
+                // saying so is the fallback that always works, including for a keyboard user.
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(output.value).then(function () {
+                        if (reportStatus) { reportStatus.textContent = "Report copied to the clipboard."; }
+                    }, function () {
+                        if (reportStatus) {
+                            reportStatus.textContent =
+                                "Could not copy automatically — the report is selected, so copy it with your keyboard.";
+                        }
+                    });
+                } else if (reportStatus) {
+                    reportStatus.textContent =
+                        "The report is selected — copy it with your keyboard.";
+                }
+            });
+        }
+
+        var reset = root.querySelector("[data-audit-reset]");
+        if (reset) {
+            reset.addEventListener("click", function () {
+                state = {};
+                try {
+                    localStorage.removeItem(KEY);
+                } catch (e) {
+                    // Nothing stored to clear.
+                }
+
+                root.querySelectorAll('input[type=radio][value="todo"]').forEach(function (r) {
+                    r.checked = true;
+                });
+                root.querySelectorAll('input[type="text"]').forEach(function (i) {
+                    i.value = "";
+                });
+                output.value = "";
+                tally();
+                if (saveStatus) { saveStatus.textContent = "Answers cleared."; }
+                if (reportStatus) { reportStatus.textContent = ""; }
+            });
+        }
+
+        tally();
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+
+    window.addEventListener("load", function () {
+        if (window.Blazor && typeof window.Blazor.addEventListener === "function") {
+            try {
+                window.Blazor.addEventListener("enhancedload", init);
+            } catch (e) {
+                // Enhanced navigation unavailable; a full page load still initialises above.
+            }
+        }
+    });
+})();

--- a/tests/BlazorDX.Components.Tests/AuditChecklistDriftTests.cs
+++ b/tests/BlazorDX.Components.Tests/AuditChecklistDriftTests.cs
@@ -1,0 +1,103 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace BlazorDX.Components.Tests;
+
+/// <summary>
+/// Keeps the <c>/audit</c> page in step with the checklist document it claims to implement.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The page renders its checks from a C# array rather than from the markdown, because the document
+/// is not shipped with the app. That leaves two copies, and two copies drift. A checklist that has
+/// quietly fallen behind the document is worse than no checklist at all, because it still looks
+/// authoritative to the volunteer working through it — they would report a complete pass over an
+/// incomplete list.
+/// </para>
+/// <para>
+/// Both files are read as text rather than through a project reference: the test project does not
+/// reference the demo, and the localization consistency tests already establish this shape in this
+/// repo. The assertion is deliberately on the <em>count</em> per section rather than on the exact
+/// wording, since the page rewrites each check into a spoken instruction ("Open a section's link
+/// and…") while the document is written as a terse spec. Pinning the prose would make every
+/// editorial improvement a test failure and teach people to edit the test.
+/// </para>
+/// </remarks>
+public sealed class AuditChecklistDriftTests
+{
+    private static string RepositoryRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "BlazorDX.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    private static string Read(params string[] parts) =>
+        File.ReadAllText(Path.Combine([RepositoryRoot(), .. parts]));
+
+    private static string ChecklistMarkdown() =>
+        Read("docs", "accessibility-screen-reader-checklist.md");
+
+    private static string PageData() =>
+        Read("samples", "BlazorDX.Demo", "BlazorDX.Demo", "Components", "Pages", "AuditChecklist.cs");
+
+    [Fact]
+    public void The_page_carries_every_check_the_document_lists()
+    {
+        // "- [ ] " opens each unchecked item in the document.
+        int documented = Regex.Matches(ChecklistMarkdown(), @"^- \[[ xX]\] ", RegexOptions.Multiline).Count;
+
+        // Each check in the C# data is a quoted string inside an area's collection expression.
+        // Counting the entries between the [ ... ] of each Checks array is fragile; counting the
+        // lines that are nothing but a quoted string is not, because the generator writes one per
+        // line and nothing else in the file has that shape.
+        int rendered = Regex.Matches(PageData(), @"^\s{12}"".*"",\s*$", RegexOptions.Multiline).Count;
+
+        Assert.Equal(documented, rendered);
+    }
+
+    [Fact]
+    public void Every_area_names_a_route_that_the_demo_actually_serves()
+    {
+        // A dead link here sends a volunteer to a 404 and quietly loses that whole section of the
+        // pass. The routes are asserted against the demo's own @page directives rather than a
+        // hand-kept list, so a renamed route fails here rather than in someone's testing session.
+        string[] routes = [.. Regex.Matches(PageData(), @"^\s{8}new\(""[^""]+"", ""[^""]+"", ""([^""]+)""",
+                RegexOptions.Multiline)
+            .Select(m => m.Groups[1].Value)];
+
+        Assert.NotEmpty(routes);
+
+        string demo = Path.Combine(RepositoryRoot(), "samples", "BlazorDX.Demo");
+        HashSet<string> served = [.. Directory
+            .EnumerateFiles(demo, "*.razor", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .SelectMany(path => Regex.Matches(File.ReadAllText(path), @"@page\s+""([^""]+)""")
+                .Select(m => m.Groups[1].Value))];
+
+        foreach (string route in routes)
+        {
+            Assert.Contains(route, served);
+        }
+    }
+
+    [Fact]
+    public void The_audit_route_itself_is_served()
+    {
+        string page = Read("samples", "BlazorDX.Demo", "BlazorDX.Demo", "Components", "Pages", "Audit.razor");
+
+        Assert.Contains("@page \"/audit\"", page, StringComparison.Ordinal);
+
+        // The checklist has to be in the server-rendered markup: this is a tool for screen-reader
+        // users, so content that only appears once JavaScript runs is the exact failure the
+        // library's own no-JS checks exist to catch.
+        Assert.Contains("AuditChecklist.Areas", page, StringComparison.Ordinal);
+        Assert.DoesNotContain("@rendermode", page, StringComparison.Ordinal);
+    }
+}

--- a/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
+++ b/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
@@ -43,6 +43,9 @@ public sealed class AccessibilityE2ETests(PlaywrightFixture fx)
     // the roadmap's "zero serious/critical violations over the showcase" a claim about the listed
     // routes rather than the showcase. Adding a route is cheap; the point is that the claim is now
     // checkable against the whole thing, and stays that way as pages are added.
+    // The screen-reader audit kit itself. A page that recruits people to the manual pass would be
+    // a poor advertisement for it if it were the one route nobody had swept.
+    [InlineData("/audit")]
     [InlineData("/barcodes")]
     [InlineData("/chat")]
     [InlineData("/command")]


### PR DESCRIPTION
The manual screen-reader pass is the project's oldest open item and the one every "done" claim in
the WCAG gate defers to. It was blocked on a person — but it was also blocked on **there being
nothing for that person to do.** The checklist is a markdown file in the repo, which is not
something you hand a volunteer with a screen reader.

`/audit` renders those same checks beside a link to the route each one tests, saves answers in the
tester's own browser as they go, and generates a Markdown report to paste onto the PR — which is
what the checklist already asked for and had no way to produce.

## Three things follow from who this page is for

**It is static SSR, and every check is in the server-rendered HTML.** A tool for screen-reader users
whose content only exists after JavaScript runs would be the exact failure this library's own no-JS
checks exist to catch. `audit.js` adds progress, saving and export on top, and reveals those panels
*only once it is running* — so a reader without it never sees a progress meter stuck at zero or a
button that does nothing.

**State is never carried by colour alone.** Each option is a radio with a visible text label;
colour only reinforces it.

**`audit.js` is loaded globally rather than from the page.** Enhanced navigation doesn't execute
scripts a page transition introduces, so a tester arriving from a link would otherwise get the
checklist with none of the tooling and no sign anything was missing.

## The drift guard earned its place immediately

The checks live in C# rather than being read from the markdown at runtime, since the document isn't
shipped with the app. That leaves two copies, so `AuditChecklistDriftTests` parses both and fails if
they diverge — the same shape of guard the localization resources use.

**It caught that I had transcribed 37 of the document's 38 checks**, having dropped the
`DxEditorialDropCap` one. I'd have shipped a checklist that looked complete and quietly wasn't,
which is worse than no checklist because a volunteer would report a full pass over a short list.

It also asserts every route the page names is one the demo actually serves, so a rename fails the
build rather than sending a tester to a 404 and losing that section of the pass.

## Also

`/audit` is added to the axe sweep — a page recruiting people to the manual pass would be a poor
advertisement for it if it were the one route nobody had swept. The checklist document now links to
the page, and the page cites the document.

## What I could not verify

I have not run a screen reader or axe against this page myself. The structural properties are
checked (no duplicate ids, every control labelled, one `h1`, no heading jumps, skip link, reduced
motion), and CI will axe it — but the first tester's most useful opening task is the audit kit
itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
