### PR TITLE
Sweep the dark theme, which nothing has ever checked

### DIFF
--- a/samples/BlazorDX.Demo/BlazorDX.Demo/Components/App.razor
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/Components/App.razor
@@ -1,7 +1,7 @@
 ﻿@inject NavigationManager Nav
 @inject IConfiguration Configuration
 <!DOCTYPE html>
-<html lang="en" dir="@Dir">
+<html lang="en" dir="@Dir" data-dx-theme="@Theme">
 
 <head>
     <meta charset="utf-8" />
@@ -148,4 +148,15 @@
     // cases without any client-side wiring.
     private string Dir =>
         System.Web.HttpUtility.ParseQueryString(new Uri(Nav.Uri).Query)["dir"] == "rtl" ? "rtl" : "ltr";
+
+    // The same idea for the theme: ?theme=dark on any route puts data-dx-theme="dark" on <html>,
+    // which is the attribute dx-theme.css already keys its dark block off. DxThemeProvider does
+    // this for a subtree; doing it at the document root is what lets a whole route be swept.
+    //
+    // This exists because the axe sweep only ever ran in light mode, and that blind spot was not
+    // theoretical: twelve rules sat at 1.93:1 against the dark surfaces indefinitely, and a fix
+    // that broke dark mode passed CI cleanly on its way in. A theme the tests never render is a
+    // theme nothing checks.
+    private string Theme =>
+        System.Web.HttpUtility.ParseQueryString(new Uri(Nav.Uri).Query)["theme"] == "dark" ? "dark" : "light";
 }

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/Components/Layout/MainLayout.razor
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/Components/Layout/MainLayout.razor
@@ -115,7 +115,10 @@
     @Body
 </main>
 
-<footer class="dx-footer" style="padding:24px 16px; border-top:1px solid #e2e8f0; margin-top:48px; display:flex; gap:18px; flex-wrap:wrap; align-items:center; font-size:14px; color:#475569">
+@* Styled in app.css rather than inline, because these colours have to follow the theme and an
+   inline style cannot. The links also needed a colour of their own: they had none, so they took
+   the browser's default #0000ee — which passes on a light page and is 1.89:1 on a dark one. *@
+<footer class="dx-footer">
     <span>© 2026 Logixr Corp · BlazorDX (MIT) · Beta</span>
     <a href="/faq">FAQ</a>
     <a href="/support">Support</a>

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/wwwroot/app.css
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/wwwroot/app.css
@@ -10,6 +10,19 @@ body {
     background: #f1f5f9;
 }
 
+/* The demo's own chrome under ?theme=dark. Scoped to the dark attribute rather than switching
+   the rule above onto tokens, deliberately: the light values stay byte-identical, so adding dark
+   coverage cannot shift the contrast of the sixty routes already swept and passing.
+
+   Without this the page would be a hybrid — component tokens dark, body still light — and every
+   dark route would report a pile of violations that are artifacts of the demo chrome rather than
+   anything wrong in the library. A consumer theming a real app would bind body to the tokens
+   instead, which is what dx-theme.css exists for. */
+[data-dx-theme="dark"] body {
+    color: var(--dx-text, #e2e8f0);
+    background: var(--dx-surface-alt, #0f172a);
+}
+
 .dx-nav {
     display: flex;
     align-items: center;

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/wwwroot/app.css
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/wwwroot/app.css
@@ -148,7 +148,7 @@ body {
 }
 
 .dx-demo-meta {
-    color: #475569;
+    color: var(--dx-text-muted, #475569);
     font-size: 14px;
 }
 
@@ -254,10 +254,10 @@ body {
     font-size: 13px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: #2563eb;
+    color: var(--dx-accent, #2563eb);
     margin: 0 0 4px;
 }
-.dx-section > .dx-section-sub { color: #475569; margin: 0 0 18px; font-size: 14px; }
+.dx-section > .dx-section-sub { color: var(--dx-text-muted, #475569); margin: 0 0 18px; font-size: 14px; }
 
 /* Pillars */
 .dx-pillars {
@@ -266,14 +266,14 @@ body {
     gap: 16px;
 }
 .dx-pillar {
-    background: #fff;
-    border: 1px solid #e2e8f0;
+    background: var(--dx-surface, #fff);
+    border: 1px solid var(--dx-border, #e2e8f0);
     border-radius: 12px;
     padding: 18px;
 }
 .dx-pillar .dx-pillar-icon { font-size: 22px; }
 .dx-pillar h3 { margin: 10px 0 6px; font-size: 15px; }
-.dx-pillar p { margin: 0; color: #475569; font-size: 13.5px; line-height: 1.5; }
+.dx-pillar p { margin: 0; color: var(--dx-text-muted, #475569); font-size: 13.5px; line-height: 1.5; }
 
 /* Getting started steps */
 .dx-steps { display: flex; flex-direction: column; gap: 18px; }

--- a/samples/BlazorDX.Demo/BlazorDX.Demo/wwwroot/app.css
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo/wwwroot/app.css
@@ -289,7 +289,24 @@ body {
 }
 .dx-step-body { flex: 1 1 auto; min-width: 0; }
 .dx-step-body h3 { margin: 0 0 8px; font-size: 15px; }
-.dx-step-body p { margin: 0 0 8px; color: #475569; font-size: 13.5px; }
+.dx-step-body p { margin: 0 0 8px; color: var(--dx-text-muted, #475569); font-size: 13.5px; }
+
+/* Footer. Moved off an inline style attribute so it can follow the theme, and its links given an
+   explicit colour — unstyled they took the browser default #0000ee, which passes on the light page
+   it was designed against and is 1.89:1 on a dark one. The light values are unchanged. */
+.dx-footer {
+    padding: 24px 16px;
+    margin-top: 48px;
+    border-top: 1px solid var(--dx-border, #e2e8f0);
+    display: flex;
+    gap: 18px;
+    flex-wrap: wrap;
+    align-items: center;
+    font-size: 14px;
+    color: var(--dx-text-muted, #475569);
+}
+
+.dx-footer a { color: var(--dx-accent, #2563eb); }
 
 /* Code block */
 .dx-code {

--- a/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
+++ b/tests/BlazorDX.E2E.Tests/AccessibilityE2ETests.cs
@@ -104,6 +104,21 @@ public sealed class AccessibilityE2ETests(PlaywrightFixture fx)
     [InlineData("/controls?dir=rtl")]    // dx-input: DxPassword's affixed reveal button
     [InlineData("/files?dir=rtl")]       // dx-filemanager, plus dx-layout's toast host
     [InlineData("/excel?dir=rtl")]       // dx-spreadsheet: the sticky row-number gutter
+    // ---- The dark theme ----
+    // Every route above renders in light mode, and until now so did the whole sweep. That gap was
+    // not theoretical: twelve rules pointed at a token no stylesheet defined and sat at 1.93:1
+    // against the dark surfaces indefinitely, and a change that fixed light while breaking dark
+    // passed CI on its way in. A theme the tests never render is a theme nothing checks.
+    //
+    // These six are chosen per stylesheet rather than per feature — the sheets whose muted,
+    // border and surface tokens carry the most weight, since a token that fails to theme shows up
+    // as contrast rather than as layout.
+    [InlineData("/?theme=dark")]              // the demo chrome itself: nav, footer, hero
+    [InlineData("/app/records?theme=dark")]   // dx-datagrid: striping, sticky header, toolbar
+    [InlineData("/forms?theme=dark")]         // dx-form: labels, hints, validation text
+    [InlineData("/overlays?theme=dark")]      // dx-overlay: dialog, sheet, popover surfaces
+    [InlineData("/files?theme=dark")]         // dx-filemanager: tree, breadcrumb, empty states
+    [InlineData("/controls?theme=dark")]      // dx-input: placeholders, disabled and affixed controls
     public async Task Page_has_no_serious_axe_violations(string route)
     {
         Skip.IfNot(fx.Ready, fx.SkipReason);


### PR DESCRIPTION
Every route in the axe sweep renders in **light mode**, and until now so did the entire suite.

That blind spot wasn't theoretical:

- Twelve rules pointed at `--dx-muted`, a token no stylesheet defines, and sat at **1.93:1**
  against the dark surfaces for as long as they've existed.
- Yesterday, in #67, a change that fixed light mode *while breaking dark* passed CI cleanly on its
  way in. Nothing could have noticed. I caught it by continuing to read after the tests went green,
  which is not a control.

## The mechanism

`?theme=dark` on any route puts `data-dx-theme="dark"` on `<html>` — the attribute `dx-theme.css`
already keys its dark block off. It mirrors the existing `?dir=rtl` toggle exactly, including
living in `App.razor` so it covers static-SSR and prerendered-WASM alike with no client wiring.

## One thing that needed care

The demo's own `body` hardcodes `color: #0f172a` on `background: #f1f5f9`. Setting the dark
attribute without addressing that produces a **hybrid** — component tokens dark, page still light —
and every dark route would report a pile of violations that are artifacts of the demo chrome rather
than anything wrong in the library.

The dark body rule is scoped to `[data-dx-theme="dark"]` rather than switching `body` onto tokens,
deliberately: **the light values stay byte-identical**, so adding this coverage cannot shift the
contrast of the sixty routes already swept and passing. A consumer theming a real app would bind
`body` to the tokens instead, which is what `dx-theme.css` is for.

## Six routes to start

Chosen per stylesheet rather than per feature, since a token that fails to theme shows up as
contrast rather than as layout: the demo chrome, `dx-datagrid`, `dx-form`, `dx-overlay`,
`dx-filemanager`, `dx-input`.

## I don't know yet whether these pass

`--dx-danger` and ten other tokens are defined by no stylesheet, with dark-red fallbacks that are
fine on white and probably not on `#0f172a`. **If CI comes back red, that's the sweep working on
its first run** — a pre-existing bug becoming visible, not one this PR introduced. I'd rather find
out that way than reason about it further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
