### PR TITLE
Add NVDA + Firefox to the manual screen-reader testing matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ All notable changes to BlazorDX are documented here. The format is loosely based
 
 ## [Unreleased]
 
+### Fixed
+
+- **The manual screen-reader testing matrix was missing NVDA + Firefox.** Added alongside the
+  existing NVDA + Chrome/Edge pairing — this library leans on `aria-live` regions in several
+  places (`DxToastHost`, grid/scheduler announcements), and NVDA's live-region behavior has
+  documented differences between Firefox and Chromium that a Chromium-only pass would miss.
+  (#70)
+
 ## [0.6.0] — 2026-09-05
 
 ### Added

--- a/docs/accessibility-screen-reader-checklist.md
+++ b/docs/accessibility-screen-reader-checklist.md
@@ -4,8 +4,17 @@ The WCAG 2.2 AA gate ([ADR 0012](adr/0012-wcag-conformance-gate.md)) requires a
 **manual screen-reader pass** per component — the half axe-core cannot cover. axe is
 green in CI for every route; this checklist is the human verification that remains.
 
-**Matrix:** NVDA + Chrome/Edge (Windows), JAWS + Chrome (Windows), VoiceOver + Safari
-(macOS/iOS), TalkBack + Chrome (Android). Test with the monitor obscured where noted.
+**Matrix:** NVDA + Chrome/Edge and NVDA + Firefox (Windows), JAWS + Chrome (Windows),
+VoiceOver + Safari (macOS/iOS), TalkBack + Chrome (Android). Test with the monitor
+obscured where noted.
+
+NVDA + Firefox is listed alongside NVDA + Chrome/Edge deliberately, not redundantly: NVDA has
+had stronger `aria-live` region support with Firefox than with Chromium in a number of
+documented cases, and this library leans on live regions in exactly the places that would
+matter — `DxToastHost`, grid/scheduler announcements, the skeleton status regions. A
+Chromium-only pass can miss a live-region regression that Firefox would surface. (JAWS pairs
+with Chrome here, not IE, because IE is retired — that part of the matrix already reflects
+current practice.)
 
 Mark each: ✅ pass / ⚠ issue (link) / ⬜ not yet run.
 


### PR DESCRIPTION
Fixes #70.

## Finding

Filed as [#70](https://github.com/logixrcorp/BlazorDX/issues/70) after comparing this library's
accessibility engineering process against current W3C/WCAG component-testing guidance. The matrix
named NVDA + Chrome/Edge, JAWS + Chrome, VoiceOver + Safari, TalkBack + Chrome — never Firefox for
NVDA.

## Why it matters here specifically

NVDA has documented differences in `aria-live` handling between Firefox and Chromium. This library
leans on live regions in exactly the places that would surface such a difference — `DxToastHost`,
grid/scheduler announcements, and the skeleton status regions added in the companion fix for #69.
A Chromium-only NVDA pass can pass cleanly while missing a live-region regression Firefox would
catch.

## What this is not

Not a correction of what was already there. JAWS + Chrome is the current, correct pairing — JAWS +
IE, which older curricula still cite, is obsolete now that IE is retired. This adds the one missing
pairing rather than replacing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
