### PR TITLE
Give DxSkeleton an opt-in accessible busy signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ All notable changes to BlazorDX are documented here. The format is loosely based
   places (`DxToastHost`, grid/scheduler announcements), and NVDA's live-region behavior has
   documented differences between Firefox and Chromium that a Chromium-only pass would miss.
   (#70)
+- **`DxSkeleton` had no accessible busy signal when used standalone.** It renders
+  `aria-hidden="true"` on its shimmer, which is correct — the bars are decorative — but that also
+  means an `aria-busy`/`aria-live` attribute on the same element would never be conveyed, since
+  the hidden subtree drops it regardless. Every real usage of the component (as opposed to
+  `DxDataGrid`'s own internally-built loading row, which already sets `aria-busy` correctly) had
+  no busy signal anywhere. Added an opt-in `Announce` parameter — one per loading region, not one
+  per skeleton — that renders a visually-hidden `role="status"` text node alongside the shimmer,
+  following the same `DxStrings`/localized-default pattern `DxSpinner` already uses. (#69)
 
 ## [0.6.0] — 2026-09-05
 

--- a/samples/BlazorDX.Demo/BlazorDX.Demo.Client/Pages/Feedback.razor
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo.Client/Pages/Feedback.razor
@@ -34,7 +34,10 @@
 <div style="max-width:24rem; display:flex; flex-direction:column; gap:10px">
     <DxProgress Value="65" />
     <DxProgress />
-    <DxSkeleton Height="1rem" />
+    @* Announce on the first of the pair only: they stand in for one loading region (one
+       paragraph), and a screen reader hearing "Loading" once per line instead of once per
+       region is exactly the redundant-announcement problem Announce exists to avoid. *@
+    <DxSkeleton Height="1rem" Announce="true" />
     <DxSkeleton Width="70%" Height="1rem" />
 </div>
 

--- a/src/BlazorDX.Components/DxSkeleton.cs
+++ b/src/BlazorDX.Components/DxSkeleton.cs
@@ -3,8 +3,16 @@ using Microsoft.AspNetCore.Components.Rendering;
 
 namespace BlazorDX.Components;
 
-/// <summary>A shimmering placeholder block shown while content loads. Decorative
-/// (aria-hidden). Styling via dx-layout.css.</summary>
+/// <summary>
+/// A shimmering placeholder block shown while content loads. Styling via dx-layout.css.
+/// </summary>
+/// <remarks>
+/// The shimmer itself is always <c>aria-hidden</c> — it is decorative, and hiding it is correct.
+/// What it does not do by default is tell anyone the region is loading at all: several
+/// <see cref="DxSkeleton"/>s typically stand in for one paragraph or card, and if each announced
+/// itself, a screen reader user would hear "Loading" repeated once per line. See
+/// <see cref="Announce"/> for the one-per-region opt-in.
+/// </remarks>
 public sealed class DxSkeleton : ComponentBase
 {
     [Parameter] public string Width { get; set; } = "100%";
@@ -15,6 +23,24 @@ public sealed class DxSkeleton : ComponentBase
 
     [Parameter] public string? Class { get; set; }
 
+    /// <summary>
+    /// When true, this instance also renders a visually-hidden <c>role="status"</c> text node
+    /// announcing that the region is loading — the same <c>DxStrings</c>/localized-default pattern
+    /// <see cref="DxSpinner"/> uses. Off by default: a group of skeletons standing in for one
+    /// paragraph should set this on exactly one of them, not all of them, or a screen reader hears
+    /// "Loading" once per line instead of once per region.
+    /// </summary>
+    [Parameter] public bool Announce { get; set; }
+
+    /// <summary>Overrides the announced text. Defaults to the localized word for "Loading".</summary>
+    [Parameter] public string? Label { get; set; }
+
+    [Inject] private IServiceProvider Services { get; set; } = default!;
+
+    private DxStrings<DxSkeleton>? s;
+
+    private DxStrings<DxSkeleton> S => s ??= new(Services);
+
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenElement(0, "div");
@@ -22,5 +48,18 @@ public sealed class DxSkeleton : ComponentBase
         builder.AddAttribute(2, "aria-hidden", "true");
         builder.AddAttribute(3, "style", $"width:{Width};height:{Height};");
         builder.CloseElement();
+
+        if (Announce)
+        {
+            // A sibling top-level element, not a wrapper around the div above: wrapping would
+            // change the root element every existing consumer and stylesheet selector assumes.
+            // role="status" carries its own implicit aria-live="polite" + aria-atomic="true", so
+            // no explicit aria-live is needed.
+            builder.OpenElement(4, "span");
+            builder.AddAttribute(5, "class", "dx-skeleton-sr");
+            builder.AddAttribute(6, "role", "status");
+            builder.AddContent(7, Label ?? S["Loading", "Loading"]);
+            builder.CloseElement();
+        }
     }
 }

--- a/src/BlazorDX.Components/DxSkeleton.de.resx
+++ b/src/BlazorDX.Components/DxSkeleton.de.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Loading" xml:space="preserve">
+    <value>Wird geladen</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxSkeleton.fr.resx
+++ b/src/BlazorDX.Components/DxSkeleton.fr.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Loading" xml:space="preserve">
+    <value>Chargement</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/DxSkeleton.resx
+++ b/src/BlazorDX.Components/DxSkeleton.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Loading" xml:space="preserve">
+    <value>Loading</value>
+  </data>
+</root>

--- a/src/BlazorDX.Components/wwwroot/dx-layout.css
+++ b/src/BlazorDX.Components/wwwroot/dx-layout.css
@@ -569,6 +569,21 @@
   animation: dx-shimmer 1.3s ease-in-out infinite;
 }
 .dx-skeleton-circle { border-radius: 50%; }
+
+/* Visually-hidden live region for Announce="true" — same clip-rect technique as .dx-cal-sr
+   (no shared sr-only utility in this codebase). */
+.dx-skeleton-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @keyframes dx-shimmer {
   0% { background-position: 100% 0; }
   100% { background-position: 0 0; }


### PR DESCRIPTION
Fixes #69.

## Finding

Filed as [#69](https://github.com/logixrcorp/BlazorDX/issues/69) after a source-level accessibility
comparison against current W3C/WCAG component-engineering guidance, specifically the question
raised in [w3c/wcag#3840](https://github.com/w3c/wcag/discussions/3840): does a skeleton loader
need to communicate its loading *state*, or is it exempt as purely decorative/inactive UI?

`DxSkeleton` rendered `aria-hidden="true"` and nothing else. That half is correct — the shimmer
bars are decorative. But it also means an `aria-busy`/`aria-live` attribute placed on the same
element would never reach anyone: a hidden subtree drops everything inside it regardless of what
those attributes say. There was no signal anywhere else either.

`DxDataGrid`'s own loading row already does this right — but it builds its own markup with
`role="row"` and `aria-busy="true"` directly, and never uses the `<DxSkeleton>` component. So the
grid is fine. Every actual usage of `<DxSkeleton>` itself (`Feedback.razor`'s loading demo) had no
busy signal at all — not silence meaning "decoration," silence meaning "nothing is here."

## The fix

Added `Announce`, off by default, following the exact `DxStrings`/localized-default pattern
`DxSpinner` already uses for its own "Loading" text — same resource key, same fallback shape, and
the French/German values are reused verbatim from `DxSpinner`'s already-shipped translations
rather than introducing new, unreviewed strings.

It's opt-in and meant for **one instance per loading region**, not every instance: several
`DxSkeleton`s typically stand in for one paragraph or card, and if each announced itself, a screen
reader would hear "Loading" once per line. `Feedback.razor`'s pair now sets it on the first of the
two, representing the one region they stand in for together.

## Verification

`DxSkeleton.cs` has no source-generator dependency — unlike most of `BlazorDX.Components` — so I
compiled it against the real `DxStrings<T>` source standalone under `TreatWarningsAsErrors` before
pushing. That's real compiler verification, not a syntax approximation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
