### PR TITLE
Send focus to the top of the folder tree once a move is armed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ All notable changes to BlazorDX are documented here. The format is loosely based
   no busy signal anywhere. Added an opt-in `Announce` parameter — one per loading region, not one
   per skeleton — that renders a visually-hidden `role="status"` text node alongside the shimmer,
   following the same `DxStrings`/localized-default pattern `DxSpinner` already uses. (#69)
+- **`DxFileManager`'s keyboard move path stranded focus once a move was armed.** The folder tree
+  renders before the contents pane in the DOM, so Tab from a row's "Move" button could never
+  reach it — only Shift+Tab all the way back past every row, the toolbar, and the breadcrumb
+  could. A keyboard-only user heard "choose a destination folder" with no forward path to one.
+  Arming a move now sends focus straight to the top of the folder tree. (#73)
 
 ## [0.6.0] — 2026-09-05
 

--- a/src/BlazorDX.Components/DxFileManager.cs
+++ b/src/BlazorDX.Components/DxFileManager.cs
@@ -89,6 +89,7 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
     // still visible in the contents view; consumed in OnAfterRenderAsync.
     private FileSystemEntry? focusAfterRender;
     private bool focusStatusAfterRender;
+    private bool focusTreeAfterRender;
     private bool disposed;
 
     private string RowId(int index) => $"{baseId}-row-{index}";
@@ -220,6 +221,11 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
             }
 
             builder.AddAttribute(45, "aria-selected", row.Selected ? "true" : "false");
+            // tabindex="-1" so the node can receive programmatic focus (never reachable via
+            // Tab on its own — the twisty/label buttons inside it already are). This is the
+            // "top of the folder tree" landing target once a move is armed; see
+            // FocusAfterArmAsync. Same fallback-target idiom as the status region's tabindex.
+            builder.AddAttribute(4301, "tabindex", "-1");
             builder.AddAttribute(46, "style",
                 string.Create(CultureInfo.InvariantCulture, $"padding-left:{row.Depth * IndentPerLevel}px;"));
 
@@ -598,12 +604,35 @@ public sealed class DxFileManager : FileManagerPrimitive, IAsyncDisposable
         return Task.CompletedTask;
     }
 
+    // Once a move is armed, remember to send focus to the top of the folder tree on the next
+    // render — the destination picker the user needs next. Deferred to OnAfterRenderAsync for
+    // the same reason as the two hooks above: the "Move here" targets that make the tree the
+    // right place to be aren't in the DOM yet until this render commits.
+    protected override Task FocusAfterArmAsync()
+    {
+        focusTreeAfterRender = true;
+        return Task.CompletedTask;
+    }
+
     private async Task ApplyPendingFocusAsync()
     {
         FileSystemEntry? moved = focusAfterRender;
         bool wantStatus = focusStatusAfterRender;
+        bool wantTree = focusTreeAfterRender;
         focusAfterRender = null;
         focusStatusAfterRender = false;
+        focusTreeAfterRender = false;
+
+        if (wantTree)
+        {
+            // The top of the folder tree is focusable only if the tree is non-empty. An empty
+            // tree can't be a move destination anyway (there is nowhere to place the item), but
+            // focus must still land somewhere rather than silently staying on a button whose
+            // aria-pressed state just changed — the status region, which already announced the
+            // "ready to move" message, is the honest fallback.
+            await Dnd.FocusElementAsync(renderedNodes.Count > 0 ? NodeId(0) : StatusId);
+            return;
+        }
 
         if (moved is not null)
         {

--- a/src/BlazorDX.Primitives/Files/FileManagerPrimitive.cs
+++ b/src/BlazorDX.Primitives/Files/FileManagerPrimitive.cs
@@ -253,22 +253,34 @@ public class FileManagerPrimitive : ComponentBase
     /// control places it. A second press on the same item cancels. This is the WCAG
     /// 2.5.7 "mark then place" alternative to the drag gesture — no pointer drag, no JS.
     /// </summary>
-    protected Task ToggleMoveCandidateAsync(FileSystemEntry item)
+    protected async Task ToggleMoveCandidateAsync(FileSystemEntry item)
     {
         if (ReferenceEquals(moveCandidate, item))
         {
             moveCandidate = null;
             StatusMessage = $"Move of {item.Name} cancelled.";
-        }
-        else
-        {
-            moveCandidate = item;
-            StatusMessage = $"{item.Name} ready to move. Choose a destination folder, then select Move here.";
+            StateHasChanged();
+            return;
         }
 
+        moveCandidate = item;
+        StatusMessage = $"{item.Name} ready to move. Choose a destination folder, then select Move here.";
         StateHasChanged();
-        return Task.CompletedTask;
+
+        // Send focus to the destination picker (the folder tree) rather than leaving it on
+        // this now-armed button. The tree renders before the contents pane in the DOM, so a
+        // plain Tab from here can never reach it — only Shift+Tab all the way back past every
+        // preceding row, the toolbar, and the breadcrumb would. This is what makes the
+        // keyboard/single-pointer move path actually usable without a mouse (WCAG 2.4.3 / 2.5.7).
+        await FocusAfterArmAsync();
     }
+
+    /// <summary>
+    /// Hook for the styled tier to move keyboard focus to the destination picker once a move is
+    /// armed. The headless primitive renders nothing, so this is a no-op here; the DOM-aware
+    /// subclass overrides it to send focus to the top of the folder tree.
+    /// </summary>
+    protected virtual Task FocusAfterArmAsync() => Task.CompletedTask;
 
     /// <summary>Places the currently-marked item into <paramref name="target"/> (root when null).</summary>
     protected async Task PlaceMoveCandidateAsync(FileSystemEntry? target)

--- a/tests/BlazorDX.Components.Tests/DxFileManagerTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxFileManagerTests.cs
@@ -249,7 +249,9 @@ public sealed class DxFileManagerTests : TestContext
 
         // "src" is the only top-level folder in Roots() (README.md is a file and never
         // appears in the tree), so it is node 0 — the top of the tree.
-        string topOfTree = fm.Find(".dx-fm-tree [role='treeitem']").Id;
+        // AngleSharp's Id is nullable in general (not every element has one); this one always
+        // does, since BuildTree stamps it explicitly on every node.
+        string topOfTree = fm.Find(".dx-fm-tree [role='treeitem']").Id!;
         Assert.Equal("src", fm.Find(".dx-fm-node-label").TextContent);
         Assert.Contains(topOfTree, dnd.FocusedIds);
 

--- a/tests/BlazorDX.Components.Tests/DxFileManagerTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxFileManagerTests.cs
@@ -205,6 +205,61 @@ public sealed class DxFileManagerTests : TestContext
         Assert.NotEmpty(fm.FindAll(".dx-fm-move-here"));
     }
 
+    // Records every id focus was sent to, so a test can assert *where* focus went without a
+    // real DOM to observe it landing.
+    private sealed class RecordingFileDndInterop : IFileDndInterop
+    {
+        public List<string> FocusedIds { get; } = [];
+
+        public ValueTask EnsureLoadedAsync() => ValueTask.CompletedTask;
+
+        public ValueTask RegisterDraggableAsync(string elementId) => ValueTask.CompletedTask;
+
+        public ValueTask RegisterDropTargetAsync(
+            string elementId,
+            Action<string, string> onMove,
+            Action<IReadOnlyList<DroppedFile>> onFiles) => ValueTask.CompletedTask;
+
+        public ValueTask UnregisterAsync(string elementId) => ValueTask.CompletedTask;
+
+        public ValueTask FocusElementAsync(string elementId)
+        {
+            FocusedIds.Add(elementId);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public void Arming_a_move_sends_focus_to_the_top_of_the_folder_tree()
+    {
+        // Without this, a keyboard user who just armed a move has no way to reach the
+        // destination picker except Shift+Tab-ing back past every row, the toolbar, and the
+        // breadcrumb — the tree renders before the contents pane, so a plain Tab from the
+        // "Move" button can never reach it.
+        RecordingFileDndInterop dnd = new();
+        Services.AddSingleton<IFileDndInterop>(dnd);
+
+        IRenderedComponent<DxFileManager> fm = Render();
+
+        fm.FindAll(".dx-fm-content-row")
+            .First(r => r.TextContent.Contains("README.md"))
+            .QuerySelector(".dx-fm-action")!.Click();
+
+        // "src" is the only top-level folder in Roots() (README.md is a file and never
+        // appears in the tree), so it is node 0 — the top of the tree.
+        string topOfTree = fm.Find(".dx-fm-tree [role='treeitem']").Id;
+        Assert.Equal("src", fm.Find(".dx-fm-node-label").TextContent);
+        Assert.Contains(topOfTree, dnd.FocusedIds);
+
+        // Cancelling the same arm (a second press) must not re-trigger it — focus already
+        // being on the tree from the first press is exactly where a cancelling user still is.
+        int countAfterArm = dnd.FocusedIds.Count;
+        fm.FindAll(".dx-fm-action").First(a => a.GetAttribute("aria-pressed") == "true").Click();
+        Assert.Equal(countAfterArm, dnd.FocusedIds.Count);
+    }
+
     [Fact]
     public void Keyboard_single_pointer_move_relocates_the_item_and_announces_it()
     {

--- a/tests/BlazorDX.Components.Tests/DxFileManagerTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxFileManagerTests.cs
@@ -252,7 +252,9 @@ public sealed class DxFileManagerTests : TestContext
         // AngleSharp's Id is nullable in general (not every element has one); this one always
         // does, since BuildTree stamps it explicitly on every node.
         string topOfTree = fm.Find(".dx-fm-tree [role='treeitem']").Id!;
-        Assert.Equal("src", fm.Find(".dx-fm-node-label").TextContent);
+        // Contains, not Equal: the label's TextContent is "📁src" — BuildTree renders the
+        // folder glyph as its own content node immediately before the name.
+        Assert.Contains("src", fm.Find(".dx-fm-node-label").TextContent);
         Assert.Contains(topOfTree, dnd.FocusedIds);
 
         // Cancelling the same arm (a second press) must not re-trigger it — focus already


### PR DESCRIPTION
Fixes #73.

## Bug

`DxFileManager.BuildRenderTree` renders the folder tree before the contents pane:

```csharp
BuildTree(builder);       // the destination picker
BuildContents(builder);   // the rows, including each row's "Move" toggle
```

Tab only moves forward through DOM order, so once focus lands on a row's "Move" button, a further
Tab press can **never** reach the tree — it already passed. The only route there was Shift+Tab
backward past every row still above it, the toolbar, and the breadcrumb.

A keyboard-only user heard the status announcement — "ready to move, choose a destination
folder" — and then had no forward path to one, despite the WCAG 2.5.7 comment already in the code
claiming this path needs no mouse.

## Fix

`FileManagerPrimitive.ToggleMoveCandidateAsync` now calls a new virtual hook,
`FocusAfterArmAsync`, on the **arm** branch only — not on cancel, since a cancelling press already
leaves focus exactly where it was, which is correct. This mirrors the existing
`FocusAfterMoveAsync`/`FocusStatusAsync` hooks the primitive already has for the completed-move
and completed-upload cases. Arming a move was the one action in this component with no focus hook
at all.

`DxFileManager`'s override defers to the next `OnAfterRenderAsync`, same deferral the other two
hooks use and for the same reason — the "Move here" targets that make the tree the right place to
land aren't in the DOM until this render commits. It focuses the id of the first tree node via the
existing `Dnd.FocusElementAsync(id)` interop call, falling back to the status region if the tree
is empty (never lose focus, matching the existing fallback in the completed-move case).

The tree node `div` needed `tabindex="-1"` added — it had none, so it wasn't a valid focus target
at all, and the fix would have silently no-oped. Same idiom the status region already uses for the
same reason.

## Verification

Compiled the **real dependency closure** — `FileManagerPrimitive.cs`, `DxFileManager.cs`, and
every type they actually reference (both interop interfaces, `SafeActionDispatcher`, `FileHasher`,
`DxStrings`) — under `TreatWarningsAsErrors`. Zero warnings, zero errors. This subsystem has no
source-generator dependency, so unlike most of `BlazorDX.Components` this is a genuine semantic
compile, not a syntax approximation.

New test: `Arming_a_move_sends_focus_to_the_top_of_the_folder_tree`, using a small recording
`IFileDndInterop` fake (none existed) to assert *which* id focus was sent to, plus that cancelling
an armed move doesn't re-fire it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
