### PR TITLE
Add Tag to ChartPoint/BulletPoint for drill-down to caller data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ All notable changes to BlazorDX are documented here. The format is loosely based
 
 ## [Unreleased]
 
+### Added
+
+- **`ChartPoint`/`BulletPoint` gained a `Tag` field for drill-down to your own data.** Every field
+  on `ChartPoint` before this was for the chart to draw with; nothing carried a reference back to
+  the caller's own domain object, so a selection handler had to re-correlate `Category`/`X`/`Y`
+  back to its source (e.g. `orders.First(o => o.Quarter == args.Point.Category)`) to drill down
+  further. `Tag` is `object?`, defaults to `null`, and no chart reads or draws it — it's returned
+  unchanged in `ChartPointEventArgs`/`BulletPointEventArgs`. Purely additive: every existing call
+  site, positional or named, keeps working unchanged. `[ChartRow]`'s generated `ToChartPoints()`
+  also now sets `Tag` to the original row automatically, so a chart bound via `[ChartRow]` gets
+  the real domain object back with no extra attribute. See the updated `[ChartRow]` demo on
+  [`/charts`](samples/BlazorDX.Demo/BlazorDX.Demo.Client/Pages/Charts.razor).
+
 ### Fixed
 
 - **The manual screen-reader testing matrix was missing NVDA + Firefox.** Added alongside the

--- a/samples/BlazorDX.Demo/BlazorDX.Demo.Client/Pages/Charts.razor
+++ b/samples/BlazorDX.Demo/BlazorDX.Demo.Client/Pages/Charts.razor
@@ -47,8 +47,11 @@
     No manual mapping: annotate a domain type's properties with <code>[ChartValue(ChartField.…)]</code>
     once, and <code>rows.ToChartPoints()</code> — a <c>BlazorDX.SourceGen</c>-generated extension,
     zero reflection — projects it for any chart. See <code>SalesRecord</code> below.
+    <code>ToChartPoints()</code> also sets <code>ChartPoint.Tag</code> to the original row, so a
+    selection handler gets the real <code>SalesRecord</code> back instead of re-correlating
+    <code>Category</code> to find it. Selected: <strong>@selectedSale</strong>.
 </p>
-<DxBarChart Points="salesPoints" Width="720" Height="220" />
+<DxBarChart Points="salesPoints" Width="720" Height="220" OnPointSelected="OnSaleSelected" />
 
 <h2 style="margin-top:32px">Histogram (Rust binning)</h2>
 <p class="dx-demo-meta">
@@ -194,9 +197,15 @@
 
     private string selectedBar = "(none)";
     private string legendStatus = "(none)";
+    private string selectedSale = "(none)";
 
     private void OnBarSelected(ChartPointEventArgs e) =>
         selectedBar = $"{e.Point.Category} = {e.Point.Y:0.##}";
+
+    private void OnSaleSelected(ChartPointEventArgs e) =>
+        selectedSale = e.Point.Tag is SalesRecord sale
+            ? $"{sale.Quarter} ({sale.Region}): {sale.Revenue:0.##}"
+            : "(none)";
 
     private GraphKind graphKind = GraphKind.Bar;
 

--- a/src/BlazorDX.Components/ChartData.cs
+++ b/src/BlazorDX.Components/ChartData.cs
@@ -8,9 +8,10 @@ namespace BlazorDX.Components;
 /// line/area/scatter chart reads <see cref="X"/> + <see cref="Y"/>; a stacked-bar/radar chart also
 /// reads <see cref="Series"/> to group points onto a shared category/axis list; a candlestick
 /// chart reads <see cref="Y"/>..<see cref="Y4"/> as Open/High/Low/Close. A field a given chart
-/// type doesn't use is simply ignored. Plain record struct — no reflection, no per-consumer mapping
-/// step (a <c>[ChartRow]</c> source generator for projecting an existing domain type onto this
-/// shape is planned as a follow-up).
+/// type doesn't use is simply ignored. Plain record struct — no reflection, and no hand-written
+/// mapping step is required either: annotate a domain type with <see cref="ChartRowAttribute"/>
+/// and its properties with <see cref="ChartValueAttribute"/>, and the generated
+/// <c>rows.ToChartPoints()</c> projects it directly.
 /// </summary>
 /// <param name="X">X-axis value (line/area/scatter charts).</param>
 /// <param name="Y">
@@ -25,6 +26,14 @@ namespace BlazorDX.Components;
 /// <param name="Y4">Candlestick Close.</param>
 /// <param name="Series">Series name, for charts with more than one series (stacked bar, radar).</param>
 /// <param name="Color">Optional CSS color override for this point/series; otherwise a palette color is used.</param>
+/// <param name="Tag">
+/// Anything you want back. No chart reads it, draws it, or does anything with it except return it
+/// unchanged in <see cref="ChartPointEventArgs"/> when this point is selected or hovered — a
+/// reference to your own domain object (an order, a row id, a full record), so a handler doesn't
+/// have to re-correlate <see cref="Category"/> or <see cref="X"/>/<see cref="Y"/> back to where the
+/// data came from. Optional and additive: every existing call site that doesn't set it keeps
+/// working unchanged, whether it builds a <see cref="ChartPoint"/> positionally or by name.
+/// </param>
 public readonly record struct ChartPoint(
     double X = 0,
     double Y = 0,
@@ -33,7 +42,8 @@ public readonly record struct ChartPoint(
     double? Y3 = null,
     double? Y4 = null,
     string? Series = null,
-    string? Color = null);
+    string? Color = null,
+    object? Tag = null);
 
 /// <summary>
 /// The point a click, keyboard selection, or hover interaction occurred on, for the discrete-mark
@@ -155,13 +165,18 @@ public sealed class ChartValueAttribute : Attribute
 /// <c>[40, 75]</c> for poor/satisfactory/good). <c>null</c> draws a single plain track.
 /// </param>
 /// <param name="Color">Optional CSS color override for the measure bar; otherwise a palette color is used.</param>
+/// <param name="Tag">
+/// Anything you want back — see <see cref="ChartPoint.Tag"/>, the same idea for the same reason.
+/// Returned unchanged in <see cref="BulletPointEventArgs"/>; nothing else reads it.
+/// </param>
 public readonly record struct BulletPoint(
     string Label,
     double Value,
     double Target,
     double Max = 100,
     IReadOnlyList<double>? Ranges = null,
-    string? Color = null);
+    string? Color = null,
+    object? Tag = null);
 
 /// <summary>The row a click, keyboard selection, or hover interaction occurred on, for <see cref="DxBulletChart"/>.</summary>
 /// <param name="Index">The row's index into the chart's <c>Points</c> list.</param>

--- a/src/BlazorDX.SourceGen/ChartAccessorGenerator.cs
+++ b/src/BlazorDX.SourceGen/ChartAccessorGenerator.cs
@@ -72,7 +72,12 @@ public sealed class ChartAccessorGenerator : IIncrementalGenerator
     }
 
     // Only the fields a [ChartValue] property actually maps become constructor arguments; every
-    // other field is simply omitted, falling back to ChartPoint's own default.
+    // other field is simply omitted, falling back to ChartPoint's own default. Tag is the one
+    // exception: it is not a [ChartValue] target — no per-property mapping makes sense for it,
+    // since the whole row is the value — so it is appended unconditionally rather than looked up
+    // in propertyByField. This is what lets a selection/hover handler on a [ChartRow]-projected
+    // chart reach the original row directly (args.Point.Tag), with no extra attribute and no step
+    // beyond what [ChartRow] already required.
     private static string BuildArguments(ChartRowModel model)
     {
         Dictionary<string, string> propertyByField = new(StringComparer.Ordinal);
@@ -95,6 +100,8 @@ public sealed class ChartAccessorGenerator : IIncrementalGenerator
 
             arguments.Add($"{field}: {expression}");
         }
+
+        arguments.Add("Tag: __row");
 
         return string.Join(", ", arguments);
     }

--- a/tests/BlazorDX.Components.Tests/ChartRowGeneratorTests.cs
+++ b/tests/BlazorDX.Components.Tests/ChartRowGeneratorTests.cs
@@ -94,6 +94,19 @@ public sealed class ChartRowGeneratorTests : TestContext
     }
 
     [Fact]
+    public void ToChartPoints_sets_Tag_to_the_original_row()
+    {
+        SalesRow q1 = new() { Quarter = "Q1", Revenue = 100, Region = "West" };
+        SalesRow q2 = new() { Quarter = "Q2", Revenue = 150, Region = "East" };
+        List<SalesRow> rows = [q1, q2];
+
+        IReadOnlyList<ChartPoint> points = rows.ToChartPoints();
+
+        Assert.Same(q1, points[0].Tag);
+        Assert.Same(q2, points[1].Tag);
+    }
+
+    [Fact]
     public void Generated_points_feed_a_real_chart_component()
     {
         // Proves the generated extension's output is exactly what DxBarChart already consumes -

--- a/tests/BlazorDX.Components.Tests/DxChartEventsTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxChartEventsTests.cs
@@ -63,6 +63,21 @@ public sealed class DxChartEventsTests : TestContext
     }
 
     [Fact]
+    public void Bar_chart_click_returns_the_points_Tag_unchanged()
+    {
+        object domainRow = new { OrderId = 42 };
+        ChartPointEventArgs? selected = null;
+        IRenderedComponent<DxBarChart> chart = RenderComponent<DxBarChart>(p => p
+            .Add(c => c.Points, new List<ChartPoint> { new(Category: "A", Y: 10, Tag: domainRow) })
+            .Add(c => c.OnPointSelected, e => selected = e));
+
+        chart.FindAll("rect.dx-bar-rect")[0].Click();
+
+        Assert.NotNull(selected);
+        Assert.Same(domainRow, selected!.Value.Point.Tag);
+    }
+
+    [Fact]
     public void Bar_chart_keyboard_arrow_then_enter_selects_the_active_bar()
     {
         ChartPointEventArgs? selected = null;


### PR DESCRIPTION
## Summary

Closes the one design gap flagged in the netclectic-request review: `ChartPoint` had no field carrying a reference back to the caller's own domain object, so a selection handler had to re-correlate `Category`/`X`/`Y` to its source to drill down further (e.g. `orders.First(o => o.Quarter == args.Point.Category)`).

- Added `object? Tag = null` to `ChartPoint` and `BulletPoint` — purely additive, defaults to `null`, no chart reads or draws it. Returned unchanged in `ChartPointEventArgs`/`BulletPointEventArgs`. Every existing call site (positional or named args) keeps working unchanged.
- `ChartAccessorGenerator.BuildArguments` now unconditionally appends `Tag: __row`, so a `[ChartRow]`-projected chart (`rows.ToChartPoints()`) gets the original row back automatically — no extra attribute needed.
- Wired `OnPointSelected` onto the demo's `[ChartRow]` `DxBarChart` on `/charts` to show `Tag` working live against the real `SalesRecord`.
- Fixed a stale doc comment on `ChartPoint` that still described `[ChartRow]` as "planned as a follow-up" — it already shipped.

**Flagging beyond the literal ask:** the user asked for a field on `ChartPoint`; wiring it into the generator (`Tag: __row`) goes one step further so the generator-based path gets the same benefit automatically. Low-risk (additive, no behavior change to existing rows) and it closes the loop the whole request was about, but calling it out explicitly since it wasn't asked for verbatim.

## Verification

`BlazorDX.Components`/`.Primitives` can't build locally here (installed SDK's Roslyn is older than this repo's pinned analyzer target → CS9057), so:

- Pulled the modified `ChartData.cs`, `DxBarChart.cs`, `DxStrings.cs`, `ChartSelectionPrimitive.cs`, `ChartGradients.cs`, `ChartResources.cs` into a scratch project against the real pinned `bunit 1.31.3`/`xunit 2.9.3`/`Microsoft.AspNetCore.Components.Web 10.0.11` packages (no analyzer reference, so no CS9057) and ran the new tests for real: clicking a bar and asserting `selected.Point.Tag` is the exact object passed in — 3/3 passed.
- The generator itself also can't be exercised locally (confirmed again: referencing it as an analyzer compiles with only a CS9057 warning outside `TreatWarningsAsErrors`, but codegen still silently doesn't run — `ToChartPoints()` never materializes). Hand-traced and compiled+ran the exact shape `BuildArguments` now emits (`Tag: __row` appended) against a `SalesRow`-shaped type — round-trips correctly.
- `dotnet build src/BlazorDX.SourceGen/BlazorDX.SourceGen.csproj` — clean, 0 warnings/errors.
- Added `ToChartPoints_sets_Tag_to_the_original_row` (`ChartRowGeneratorTests.cs`) and `Bar_chart_click_returns_the_points_Tag_unchanged` (`DxChartEventsTests.cs`) to the real test suite — CI is the first place these run against the actual generator and the actual `TreatWarningsAsErrors` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
