### PR TITLE
Scope DxCarousel arrow-key nav to the nav buttons, not the root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ All notable changes to BlazorDX are documented here. The format is loosely based
   reach it — only Shift+Tab all the way back past every row, the toolbar, and the breadcrumb
   could. A keyboard-only user heard "choose a destination folder" with no forward path to one.
   Arming a move now sends focus straight to the top of the folder tree. (#73)
+- **`DxCarousel` stole arrow keys from interactive slide content.** Its keydown listener lived on
+  the carousel root, an ancestor of every slide's content — so a slide holding its own
+  arrow-key-driven control (a chart with point selection, a grid, a tree) had its keystrokes
+  bubble up and *also* advance the carousel, moving the slide out from under whatever the user
+  was actually navigating. Moved the listener onto the previous/next buttons only, the same
+  sibling-not-ancestor shape `DxTabs`' tablist and `DxSplitter`'s divider already use. (#78)
 
 ## [0.6.0] — 2026-09-05
 

--- a/src/BlazorDX.Components/DxCarousel.cs
+++ b/src/BlazorDX.Components/DxCarousel.cs
@@ -5,10 +5,12 @@ using Microsoft.AspNetCore.Components.Web;
 namespace BlazorDX.Components;
 
 /// <summary>
-/// A slide carousel with previous/next controls, dot indicators, and
-/// Left/Right-arrow keyboard navigation. Slides wrap around. Follows the WAI-ARIA
-/// carousel pattern (group + roledescription). Two-way bind the active slide via
-/// <c>@bind-Index</c>. Styling is token-driven (see dx-structure.css).
+/// A slide carousel with previous/next controls, dot indicators, and Left/Right/Home/End
+/// keyboard navigation scoped to the previous/next buttons — so a slide holding its own
+/// interactive content (a chart, a grid, a tree) keeps its own arrow-key behavior instead of
+/// having it stolen by the carousel. Slides wrap around. Follows the WAI-ARIA carousel pattern
+/// (group + roledescription). Two-way bind the active slide via <c>@bind-Index</c>. Styling is
+/// token-driven (see dx-structure.css).
 /// </summary>
 public sealed class DxCarousel : ComponentBase
 {
@@ -51,8 +53,6 @@ public sealed class DxCarousel : ComponentBase
         builder.AddAttribute(2, "role", "group");
         builder.AddAttribute(3, "aria-roledescription", S["Carousel", "carousel"]);
         builder.AddAttribute(4, "aria-label", AriaLabel ?? S["CarouselLabel", "Carousel"]);
-        builder.AddAttribute(5, "tabindex", "0");
-        builder.AddAttribute(6, "onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(this, OnKeyDownAsync));
 
         BuildArrow(builder, 10, "‹", "Previous slide", () => GoAsync(Index - 1));
 
@@ -104,6 +104,11 @@ public sealed class DxCarousel : ComponentBase
         builder.CloseElement();
     }
 
+    // Keydown lives on the prev/next buttons, not the carousel root: a slide can hold
+    // arbitrary interactive content (a chart with its own arrow-key point selection, a grid,
+    // a tree), and putting the listener on an ancestor of that content would steal the
+    // keystroke via Blazor's own event bubbling. Same fix shape as DxTabs' tablist-only
+    // listener and DxSplitter's divider-only listener.
     private void BuildArrow(RenderTreeBuilder builder, int seq, string glyph, string label, Func<Task> onClick)
     {
         builder.OpenElement(seq, "button");
@@ -112,7 +117,8 @@ public sealed class DxCarousel : ComponentBase
         builder.AddAttribute(seq + 3, "aria-label", label);
         builder.AddAttribute(seq + 4, "disabled", Count < 2);
         builder.AddAttribute(seq + 5, "onclick", EventCallback.Factory.Create(this, onClick));
-        builder.AddContent(seq + 6, glyph);
+        builder.AddAttribute(seq + 6, "onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(this, OnKeyDownAsync));
+        builder.AddContent(seq + 7, glyph);
         builder.CloseElement();
     }
 

--- a/tests/BlazorDX.Components.Tests/DxStructureTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxStructureTests.cs
@@ -125,8 +125,45 @@ public sealed class DxStructureTests : TestContext
             .Add(c => c.Index, bound)
             .Add(c => c.IndexChanged, i => bound = i));
 
+        // Keyboard nav lives on the prev/next buttons, not the carousel root (see
+        // Carousel_arrow_key_on_slide_content_does_not_change_the_slide below for why).
         // ArrowLeft from the first slide wraps to the last.
-        car.Find(".dx-carousel").KeyDown(new KeyboardEventArgs { Key = "ArrowLeft" });
+        car.Find("[aria-label='Previous slide']").KeyDown(new KeyboardEventArgs { Key = "ArrowLeft" });
         Assert.Equal(2, bound);
+    }
+
+    [Fact]
+    public void Carousel_arrow_key_on_slide_content_does_not_change_the_slide()
+    {
+        // A slide can hold its own interactive content with its own arrow-key behavior (a
+        // chart's point selection, a grid's cell nav). Before the fix, the carousel root's
+        // own onkeydown was an ancestor of every slide, so an ArrowRight meant for the slide's
+        // own handler would *also* bubble up and advance the carousel. Give the slide content
+        // its own onkeydown (standing in for a chart) and assert only it fires.
+        int bound = 0;
+        bool innerHandlerFired = false;
+        IReadOnlyList<RenderFragment> slides =
+        [
+            b =>
+            {
+                b.OpenElement(0, "div");
+                b.AddAttribute(1, "class", "slide-content");
+                b.AddAttribute(2, "tabindex", "0");
+                b.AddAttribute(3, "onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(
+                    new object(), _ => innerHandlerFired = true));
+                b.AddContent(4, "One");
+                b.CloseElement();
+            },
+            b => b.AddContent(0, "Two"),
+        ];
+        IRenderedComponent<DxCarousel> car = RenderComponent<DxCarousel>(parameters => parameters
+            .Add(c => c.Slides, slides)
+            .Add(c => c.Index, bound)
+            .Add(c => c.IndexChanged, i => bound = i));
+
+        car.Find(".slide-content").KeyDown(new KeyboardEventArgs { Key = "ArrowRight" });
+
+        Assert.True(innerHandlerFired);
+        Assert.Equal(0, bound);
     }
 }


### PR DESCRIPTION
Fixes #78.

## What was wrong

`DxCarousel`'s `onkeydown`/`tabindex` lived on the carousel's outermost root div — an ancestor of every slide's rendered content, not just the previous/next buttons. If a slide held its own arrow-key-driven interactive content (a chart with `OnPointSelected` wired for roving point selection, a grid, a tree), pressing ArrowLeft/Right/Home/End to navigate *that* content would also bubble up through Blazor's synthetic event dispatch and advance the carousel — stealing the keystroke and changing the slide out from under whatever the user was actually interacting with.

## Fix

Moved the keydown listener (and the tabindex it needs) off the root onto the two nav buttons. This is the same sibling-not-ancestor shape three other components in this codebase already use correctly:
- `DxTabs`: `onkeydown` on the tablist only, sibling of the tab panel.
- `DxSplitter`: `onkeydown` on the divider only, sibling of both panes.
- `DxTileLayout`: `onkeydown` on the tile header only, sibling of the tile body.

Slide content now has no DOM path into the carousel's own arrow-key handling.

## Verification

Added `Carousel_arrow_key_on_slide_content_does_not_change_the_slide`, which gives a slide's content its own `onkeydown` (standing in for a chart/grid's own handler) and asserts only that handler fires. Ran this for real in a scratch bunit project against both versions of the source to confirm it's a genuine regression test, not a tautology:

- **Pre-fix source:** `bound` changes to `1` — the carousel advances even though the keydown originated inside slide content. Test fails, as expected.
- **Post-fix source:** `bound` stays `0`. Test passes.

Also updated the existing `Carousel_arrow_key_navigates` test to fire on the nav button (matching the new listener location) rather than the root. Full local suite (4 tests) passes against the real modified `DxCarousel.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
