### PR TITLE
Exempt text-entry targets from the global hotkey registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ All notable changes to BlazorDX are documented here. The format is loosely based
   reach it — only Shift+Tab all the way back past every row, the toolbar, and the breadcrumb
   could. A keyboard-only user heard "choose a destination folder" with no forward path to one.
   Arming a move now sends focus straight to the top of the folder tree. (#73)
+- **`DxHotkeys` could hijack a keystroke you were typing.** The global shortcut listener matched
+  purely on key/modifiers, with no check of what actually had focus — so a bound combo (a plain
+  letter is a common command-palette convention) ate that character everywhere a text input,
+  textarea, or contenteditable region had focus, including a `DxDataGrid` cell editor, a
+  `DxComboBox`/`DxCommandPalette` filter, or a `DxChat` message box. Added the same text-entry
+  exemption `grid-dom.ts`'s own arrow-key suppression already uses. (#76)
 - **Escape closed every open overlay at once instead of just the topmost one.** `DxDialog`,
   `DxSheet`, `DxCommandPalette`, and `DxContextMenu` each registered their own independent
   `document`-level Escape listener with no concept of stacking, so a context menu (or combobox

--- a/src/BlazorDX.Interop.Ts/src/hotkeys.ts
+++ b/src/BlazorDX.Interop.Ts/src/hotkeys.ts
@@ -22,6 +22,17 @@ function comboOf(e: KeyboardEvent): string | null {
   return parts.join("+");
 }
 
+// Same exemption grid-dom.ts already uses for its own arrow-key suppression: a global
+// shortcut must not hijack a keystroke the user is actually typing into a text field. Without
+// this, binding a plain letter (a common command-palette convention) would eat that character
+// everywhere a text input, textarea, or contenteditable region has focus - including inside a
+// DxDataGrid cell editor, a DxComboBox/DxCommandPalette filter, or a DxChat message box.
+function isTextEntryTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  const tag = el?.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || el?.isContentEditable === true;
+}
+
 export function subscribe(onMatch: (combo: string) => void): void {
   handler = onMatch;
   if (listening) {
@@ -29,6 +40,9 @@ export function subscribe(onMatch: (combo: string) => void): void {
   }
   listening = true;
   document.addEventListener("keydown", (e) => {
+    if (isTextEntryTarget(e.target)) {
+      return;
+    }
     const combo = comboOf(e);
     if (combo !== null && bindings.has(combo) && handler !== null) {
       e.preventDefault();

--- a/src/BlazorDX.Interop.Ts/test/hotkeys.test.ts
+++ b/src/BlazorDX.Interop.Ts/test/hotkeys.test.ts
@@ -1,0 +1,78 @@
+// Regression coverage for a real bug: the global hotkey registry matched purely on
+// key/ctrlKey/altKey/shiftKey with no check of what actually had focus, so a bound combo (e.g.
+// a plain letter, a common command-palette convention) hijacked that keystroke everywhere -
+// including while the user was typing into a text input, textarea, or contenteditable region.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("hotkeys text-entry exemption", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("does not fire while an <input> has focus", async () => {
+    const hotkeys = await import("../src/hotkeys");
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    const onMatch = vi.fn();
+    hotkeys.subscribe(onMatch);
+    hotkeys.setBindings(["k"]);
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "k", bubbles: true }));
+
+    expect(onMatch).not.toHaveBeenCalled();
+  });
+
+  it("does not fire while a <textarea> has focus", async () => {
+    const hotkeys = await import("../src/hotkeys");
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+
+    const onMatch = vi.fn();
+    hotkeys.subscribe(onMatch);
+    hotkeys.setBindings(["k"]);
+
+    textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "k", bubbles: true }));
+
+    expect(onMatch).not.toHaveBeenCalled();
+  });
+
+  it("does not fire while a contenteditable element has focus", async () => {
+    const hotkeys = await import("../src/hotkeys");
+    const editable = document.createElement("div");
+    editable.contentEditable = "true";
+    // jsdom does not implement the isContentEditable computed getter (it's always undefined
+    // regardless of the contentEditable attribute) - stub it so this test exercises the same
+    // branch a real browser would take, rather than skipping coverage of it entirely.
+    Object.defineProperty(editable, "isContentEditable", { value: true });
+    document.body.appendChild(editable);
+
+    const onMatch = vi.fn();
+    hotkeys.subscribe(onMatch);
+    hotkeys.setBindings(["k"]);
+
+    editable.dispatchEvent(new KeyboardEvent("keydown", { key: "k", bubbles: true }));
+
+    expect(onMatch).not.toHaveBeenCalled();
+  });
+
+  it("still fires for a plain, non-text-entry target (no regression)", async () => {
+    const hotkeys = await import("../src/hotkeys");
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+
+    const onMatch = vi.fn();
+    hotkeys.subscribe(onMatch);
+    hotkeys.setBindings(["k"]);
+
+    button.dispatchEvent(new KeyboardEvent("keydown", { key: "k", bubbles: true }));
+
+    expect(onMatch).toHaveBeenCalledWith("k");
+  });
+});


### PR DESCRIPTION
Fixes #76.

## What was wrong

`DxHotkeys`' single `document`-level keydown listener (`hotkeys.ts:25-37`) matched purely on `key`/`ctrlKey`/`altKey`/`shiftKey`, with no check of `event.target`. A bound combo — a plain unmodified letter is a common command-palette convention — hijacked that keystroke everywhere a text input, textarea, or contenteditable region had focus, since `preventDefault()` fires unconditionally in the match branch: the character never reaches the field at all. That includes a `DxDataGrid` cell editor, a `DxComboBox`/`DxCommandPalette` filter input, or a `DxChat` message box.

The codebase already has the right exemption elsewhere — `grid-dom.ts`'s own arrow-key suppression:

```ts
if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable === true) {
  return;
}
```

it just wasn't applied to the global hotkey registry.

## Fix

Added the identical exemption to `hotkeys.ts`, checked before combo matching so a text-entry keystroke is never intercepted or `preventDefault`'d.

## Verification

Added `src/BlazorDX.Interop.Ts/test/hotkeys.test.ts` — real vitest/jsdom execution, no mocking of the code under test:

- No match while an `<input>` has focus.
- No match while a `<textarea>` has focus.
- No match while a contenteditable element has focus (jsdom doesn't implement the `isContentEditable` computed getter, so this one stubs the property directly to exercise the real branch instead of skipping it).
- Still matches for a plain non-text-entry target — no regression to the common case.

4/4 new tests pass; full TS suite (9 tests) green. `npx tsc --noEmit` reports no new errors and `npm run build` still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
