### PR TITLE
Add full row navigation to DxTreeGrid, closing the DxTreeView parity gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to BlazorDX are documented here. The format is loosely based
   also now sets `Tag` to the original row automatically, so a chart bound via `[ChartRow]` gets
   the real domain object back with no extra attribute. See the updated `[ChartRow]` demo on
   [`/charts`](samples/BlazorDX.Demo/BlazorDX.Demo.Client/Pages/Charts.razor).
+- **`DxTreeGrid` gained full row navigation, closing a keyboard-parity gap with `DxTreeView`.**
+  Previously its only keyboard behavior was ArrowLeft/ArrowRight expand/collapse on whichever row
+  happened to have native Tab focus — no Up/Down row traversal, no Home/End, and every row was
+  its own Tab stop despite advertising `role="treegrid"`. It now follows the same WAI-ARIA pattern
+  `DxDataGrid`/`DxTreeView` already use: a single roving tab stop on the grid container,
+  `aria-activedescendant` addressing the active row (so navigation still works when that row is
+  scrolled out of the rendered window), ArrowUp/ArrowDown across the full flattened tree,
+  ArrowRight expands-or-descends-to-first-child, ArrowLeft collapses-or-moves-to-parent, and
+  Home/End jump to the first/last row. Clicking a row also makes it the active row. **Behavior
+  change:** rows are no longer independently Tab-reachable — Tab now enters the grid once, and
+  arrow keys move within it, matching `DxTreeView`'s model instead of a flat list of Tab stops.
 
 ### Fixed
 

--- a/src/BlazorDX.Components/DxTreeGrid.cs
+++ b/src/BlazorDX.Components/DxTreeGrid.cs
@@ -33,6 +33,17 @@ public sealed class DxTreeGrid<TRow> : TreeGridPrimitive<TRow>
         builder.AddAttribute(4, "aria-rowcount", VisibleRowCount);
         builder.AddAttribute(5, "style", $"height:{ViewportHeight}px;");
 
+        // Single roving tab stop (the WAI-ARIA treegrid pattern), addressed with
+        // aria-activedescendant so the active row is meaningful even while scrolled out of
+        // the rendered window — see TreeGridPrimitive.OnKeyDownAsync for the key handling.
+        builder.AddAttribute(200, "tabindex", "0");
+        if (HasActiveRow)
+        {
+            builder.AddAttribute(201, "aria-activedescendant", ActiveRowId);
+        }
+
+        builder.AddAttribute(202, "onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(this, OnKeyDownAsync));
+
         BuildHeader(builder, columnTemplate);
         BuildBody(builder, columnTemplate);
 
@@ -72,9 +83,9 @@ public sealed class DxTreeGrid<TRow> : TreeGridPrimitive<TRow>
         builder.AddAttribute(19, "style", $"height:{TopPadding}px;");
         builder.CloseElement();
 
-        foreach (TreeGridRow<TRow> node in VisibleRows())
+        foreach ((int index, TreeGridRow<TRow> node) in VisibleRows())
         {
-            BuildRow(builder, node, columnTemplate);
+            BuildRow(builder, index, node, columnTemplate);
         }
 
         builder.OpenElement(20, "div");
@@ -84,15 +95,20 @@ public sealed class DxTreeGrid<TRow> : TreeGridPrimitive<TRow>
         builder.CloseElement();
     }
 
-    private void BuildRow(RenderTreeBuilder builder, TreeGridRow<TRow> node, string columnTemplate)
+    private void BuildRow(RenderTreeBuilder builder, int index, TreeGridRow<TRow> node, string columnTemplate)
     {
         TRow row = node.Row;
+        bool active = IsActiveRow(index);
 
         builder.OpenElement(22, "div");
         builder.SetKey(row);
-        builder.AddAttribute(23, "class", "dx-grid-row");
+        builder.AddAttribute(23, "class", active ? "dx-grid-row dx-grid-row-active" : "dx-grid-row");
         builder.AddAttribute(24, "role", "row");
-        builder.AddAttribute(25, "tabindex", "0");
+        if (active)
+        {
+            builder.AddAttribute(25, "id", ActiveRowId);   // aria-activedescendant target
+        }
+
         builder.AddAttribute(26, "aria-level", node.Depth + 1);
         if (node.HasChildren)
         {
@@ -100,8 +116,7 @@ public sealed class DxTreeGrid<TRow> : TreeGridPrimitive<TRow>
         }
 
         builder.AddAttribute(28, "style", $"height:{RowHeight}px;{columnTemplate}");
-        builder.AddAttribute(29, "onkeydown",
-            EventCallback.Factory.Create<KeyboardEventArgs>(this, e => OnRowKeyDown(row, e.Key)));
+        builder.AddAttribute(29, "onclick", EventCallback.Factory.Create(this, () => SetActiveRow(index)));
 
         for (int column = 0; column < Columns.Count; column++)
         {

--- a/src/BlazorDX.Components/wwwroot/dx-datagrid.css
+++ b/src/BlazorDX.Components/wwwroot/dx-datagrid.css
@@ -90,9 +90,19 @@
 }
 
 /* ---- Tree grid ---- */
-.dx-grid-row[tabindex]:focus-visible {
+/* Keyboard row navigation: the treegrid container is the single tab stop (roving
+   aria-activedescendant, like DataGrid's active cell); the active row gets an accent ring. */
+.dx-tree-grid:focus { outline: none; }
+.dx-tree-grid:focus-visible {
   outline: 2px solid var(--dx-grid-accent, #2563eb);
   outline-offset: -2px;
+}
+.dx-grid-row-active {
+  outline: 2px solid var(--dx-grid-accent, #2563eb);
+  outline-offset: -2px;
+  background: color-mix(in srgb, var(--dx-grid-accent, #2563eb) 10%, transparent);
+  position: relative;
+  z-index: 1;
 }
 .dx-tree-cell {
   display: inline-flex;

--- a/src/BlazorDX.Primitives/Grid/TreeGridPrimitive.cs
+++ b/src/BlazorDX.Primitives/Grid/TreeGridPrimitive.cs
@@ -1,5 +1,6 @@
 using BlazorDX.Interop;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace BlazorDX.Primitives.Grid;
 
@@ -23,6 +24,8 @@ public class TreeGridPrimitive<TRow> : ComponentBase, IAsyncDisposable
     private int firstVisibleIndex;
     private int visibleCount;
     private bool scrollSubscribed;
+    private int activeIndex = -1;
+    private bool suppressKeysRegistered;
 
     /// <summary>The root nodes of the tree.</summary>
     [Parameter, EditorRequired] public IReadOnlyList<TRow> Items { get; set; } = [];
@@ -53,6 +56,24 @@ public class TreeGridPrimitive<TRow> : ComponentBase, IAsyncDisposable
     /// <summary>Total visible (flattened) rows, for aria-rowcount and virtualization.</summary>
     protected int VisibleRowCount => flattened.Count;
 
+    /// <summary>
+    /// The element id of the active (roving-focus) row, for <c>aria-activedescendant</c>.
+    /// Addressed by index into the flattened row list rather than a captured element
+    /// reference, so navigation works even when the active row is scrolled out of the
+    /// rendered window — the same reason <c>DataGridPrimitive</c> addresses its active cell
+    /// by slot rather than by element.
+    /// </summary>
+    protected string ActiveRowId => $"{ContainerId}-active";
+
+    /// <summary>The flattened-row position of the active row, or -1 when the tree is empty.</summary>
+    protected int ActiveIndex => activeIndex;
+
+    /// <summary>Whether a row is currently active (false only when the tree has no rows).</summary>
+    protected bool HasActiveRow => activeIndex >= 0 && activeIndex < flattened.Count;
+
+    /// <summary>Whether the flattened row at <paramref name="index"/> is the active row.</summary>
+    protected bool IsActiveRow(int index) => HasActiveRow && index == activeIndex;
+
     protected double TopPadding => (double)firstVisibleIndex * RowHeight;
 
     protected double BottomPadding => Math.Max(0, (double)(VisibleRowCount - LastVisibleIndex) * RowHeight);
@@ -71,6 +92,7 @@ public class TreeGridPrimitive<TRow> : ComponentBase, IAsyncDisposable
 
         visibleCount = EstimateVisibleCount(ViewportHeight);
         Flatten();
+        ClampActiveIndex();
     }
 
     protected string CellText(TRow row, int columnIndex) => Accessor.GetCellText(row, columnIndex);
@@ -79,12 +101,12 @@ public class TreeGridPrimitive<TRow> : ComponentBase, IAsyncDisposable
 
     protected bool IsExpanded(TRow row) => expanded.Contains(row);
 
-    /// <summary>The flattened rows currently inside the virtualization window.</summary>
-    protected IEnumerable<TreeGridRow<TRow>> VisibleRows()
+    /// <summary>The flattened rows currently inside the virtualization window, paired with each row's absolute index into the full flattened list (needed to compare against <see cref="ActiveIndex"/>).</summary>
+    protected IEnumerable<(int Index, TreeGridRow<TRow> Row)> VisibleRows()
     {
         for (int i = firstVisibleIndex; i < LastVisibleIndex; i++)
         {
-            yield return flattened[i];
+            yield return (i, flattened[i]);
         }
     }
 
@@ -102,26 +124,162 @@ public class TreeGridPrimitive<TRow> : ComponentBase, IAsyncDisposable
         }
 
         Flatten();
+        ClampActiveIndex();
         StateHasChanged();
     }
 
-    /// <summary>Keyboard expand/collapse: Right opens, Left closes (or moves to a leaf's parent state).</summary>
-    protected void OnRowKeyDown(TRow row, string key)
+    /// <summary>Makes the flattened row at <paramref name="index"/> the active row (e.g. on click).</summary>
+    protected void SetActiveRow(int index)
     {
-        if (!HasChildren(row))
+        if (index >= 0 && index < flattened.Count)
+        {
+            activeIndex = index;
+            StateHasChanged();
+        }
+    }
+
+    /// <summary>
+    /// Roving-row keyboard navigation, mirroring the WAI-ARIA tree pattern <c>DxTreeView</c>
+    /// already implements: Up/Down move the active row across the full flattened list (not
+    /// just the rendered window), Right expands a collapsed row or descends into an expanded
+    /// one's first child, Left collapses an expanded row or moves to its parent, Home/End jump
+    /// to the first/last row.
+    /// </summary>
+    protected async Task OnKeyDownAsync(KeyboardEventArgs args)
+    {
+        if (!HasActiveRow)
         {
             return;
         }
 
-        bool isOpen = IsExpanded(row);
-        if (key == "ArrowRight" && !isOpen)
+        TreeGridRow<TRow> row = flattened[activeIndex];
+        switch (args.Key)
         {
-            Toggle(row);
+            case "ArrowDown":
+                if (activeIndex < flattened.Count - 1)
+                {
+                    activeIndex += 1;
+                }
+
+                break;
+            case "ArrowUp":
+                if (activeIndex > 0)
+                {
+                    activeIndex -= 1;
+                }
+
+                break;
+            case "ArrowRight":
+                if (row.HasChildren && !row.Expanded)
+                {
+                    Toggle(row.Row);
+                }
+                else if (row.HasChildren)
+                {
+                    activeIndex += 1;   // depth-first flatten: the first child is always next
+                }
+
+                break;
+            case "ArrowLeft":
+                if (row.HasChildren && row.Expanded)
+                {
+                    Toggle(row.Row);
+                }
+                else if (row.Depth > 0)
+                {
+                    activeIndex = ParentIndex(activeIndex);
+                }
+
+                break;
+            case "Home":
+                activeIndex = 0;
+                break;
+            case "End":
+                activeIndex = flattened.Count - 1;
+                break;
+            default:
+                return;   // not a navigation key
         }
-        else if (key == "ArrowLeft" && isOpen)
+
+        StateHasChanged();
+        await EnsureActiveVisibleAsync();
+    }
+
+    // Re-anchors the active row onto a real row after the visible list reshapes
+    // (expand/collapse, or the host swapping Items/ChildrenSelector).
+    private void ClampActiveIndex()
+    {
+        if (flattened.Count == 0)
         {
-            Toggle(row);
+            activeIndex = -1;
         }
+        else if (activeIndex < 0)
+        {
+            activeIndex = 0;
+        }
+        else if (activeIndex >= flattened.Count)
+        {
+            activeIndex = flattened.Count - 1;
+        }
+    }
+
+    // The flatten is depth-first pre-order, so a node's parent is the nearest preceding
+    // entry at a shallower depth.
+    private int ParentIndex(int childIndex)
+    {
+        int depth = flattened[childIndex].Depth;
+        for (int i = childIndex - 1; i >= 0; i--)
+        {
+            if (flattened[i].Depth < depth)
+            {
+                return i;
+            }
+        }
+
+        return childIndex;
+    }
+
+    // Scrolls the container so the active row sits inside the viewport, mirroring
+    // DataGridPrimitive's EnsureActiveVisibleAsync. The current scroll position is
+    // approximated from the windowing state, so no extra interop round-trip is needed.
+    private async Task EnsureActiveVisibleAsync()
+    {
+        if (activeIndex < 0)
+        {
+            return;
+        }
+
+        int rowsInView = Math.Max(1, ViewportHeight / RowHeight);
+        int topRow = firstVisibleIndex + Overscan;
+        int bottomRow = topRow + rowsInView - 1;
+
+        double? target = null;
+        if (activeIndex < topRow)
+        {
+            target = (double)activeIndex * RowHeight;
+        }
+        else if (activeIndex > bottomRow)
+        {
+            target = (double)(activeIndex - rowsInView + 1) * RowHeight;
+        }
+
+        if (target is double top)
+        {
+            await Dom.ScrollToAsync(ContainerId, Math.Max(0, top));
+        }
+    }
+
+    // Registers the JS keydown guard that suppresses native arrow/page scrolling (so row
+    // navigation stays in control) without blocking text inputs. Browser-only.
+    private async Task EnsureArrowSuppressionAsync()
+    {
+        if (suppressKeysRegistered || !OperatingSystem.IsBrowser())
+        {
+            return;
+        }
+
+        suppressKeysRegistered = true;
+        await Dom.SuppressArrowKeysAsync(ContainerId);
     }
 
     private void ExpandAll(IReadOnlyList<TRow> nodes)
@@ -163,7 +321,14 @@ public class TreeGridPrimitive<TRow> : ComponentBase, IAsyncDisposable
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (!firstRender || scrollSubscribed || !OperatingSystem.IsBrowser())
+        if (!firstRender)
+        {
+            return;
+        }
+
+        await EnsureArrowSuppressionAsync();
+
+        if (scrollSubscribed || !OperatingSystem.IsBrowser())
         {
             return;
         }

--- a/tests/BlazorDX.Components.Tests/DxTreeGridTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxTreeGridTests.cs
@@ -98,12 +98,104 @@ public sealed class DxTreeGridTests : TestContext
     }
 
     [Fact]
-    public void Arrow_right_expands_a_focused_parent_row()
+    public void Container_is_the_single_tab_stop_with_a_roving_active_row()
     {
         IRenderedComponent<DxTreeGrid<TreeWidget>> tree = Render();
 
-        tree.FindAll(".dx-grid-row")[0].KeyDown(new KeyboardEventArgs { Key = "ArrowRight" });
+        var container = tree.Find("[role=treegrid]");
+        Assert.Equal("0", container.GetAttribute("tabindex"));
+        Assert.Empty(tree.FindAll(".dx-grid-row[tabindex]"));   // rows aren't independent tab stops
+        Assert.NotNull(container.GetAttribute("aria-activedescendant"));
+
+        // The active row (defaults to the first) carries the id aria-activedescendant points at.
+        var activeRow = tree.FindAll(".dx-grid-row")[0];
+        Assert.Equal(container.GetAttribute("aria-activedescendant"), activeRow.GetAttribute("id"));
+        Assert.Contains("dx-grid-row-active", activeRow.ClassName);
+    }
+
+    [Fact]
+    public void Arrow_right_expands_the_active_parent_row()
+    {
+        IRenderedComponent<DxTreeGrid<TreeWidget>> tree = Render();
+
+        tree.Find("[role=treegrid]").KeyDown(new KeyboardEventArgs { Key = "ArrowRight" });
 
         Assert.Equal(4, tree.FindAll(".dx-grid-row").Count);
+    }
+
+    [Fact]
+    public void Arrow_right_on_an_expanded_row_descends_to_its_first_child()
+    {
+        IRenderedComponent<DxTreeGrid<TreeWidget>> tree = Render(expanded: true);
+        var container = tree.Find("[role=treegrid]");
+
+        container.KeyDown(new KeyboardEventArgs { Key = "ArrowRight" });   // A -> A1
+
+        Assert.Equal("A1", tree.FindAll(".dx-tree-label")[1].TextContent);
+        Assert.Contains("dx-grid-row-active", tree.FindAll(".dx-grid-row")[1].ClassName);
+    }
+
+    [Fact]
+    public void Arrow_down_then_up_moves_the_active_row_across_the_flattened_list()
+    {
+        IRenderedComponent<DxTreeGrid<TreeWidget>> tree = Render(expanded: true);   // A, A1, A2, B
+        var container = tree.Find("[role=treegrid]");
+
+        container.KeyDown(new KeyboardEventArgs { Key = "ArrowDown" });   // A -> A1
+        container.KeyDown(new KeyboardEventArgs { Key = "ArrowDown" });   // A1 -> A2
+        Assert.Contains("dx-grid-row-active", tree.FindAll(".dx-grid-row")[2].ClassName);
+
+        container.KeyDown(new KeyboardEventArgs { Key = "ArrowUp" });     // A2 -> A1
+        Assert.Contains("dx-grid-row-active", tree.FindAll(".dx-grid-row")[1].ClassName);
+    }
+
+    [Fact]
+    public void Arrow_left_on_a_leaf_moves_to_its_parent()
+    {
+        IRenderedComponent<DxTreeGrid<TreeWidget>> tree = Render(expanded: true);   // A, A1, A2, B
+        var container = tree.Find("[role=treegrid]");
+
+        container.KeyDown(new KeyboardEventArgs { Key = "ArrowDown" });   // A -> A1 (a leaf)
+        container.KeyDown(new KeyboardEventArgs { Key = "ArrowLeft" });   // A1 -> A (its parent)
+
+        Assert.Contains("dx-grid-row-active", tree.FindAll(".dx-grid-row")[0].ClassName);
+    }
+
+    [Fact]
+    public void Home_and_end_jump_to_the_first_and_last_row()
+    {
+        IRenderedComponent<DxTreeGrid<TreeWidget>> tree = Render(expanded: true);   // A, A1, A2, B
+        var container = tree.Find("[role=treegrid]");
+
+        container.KeyDown(new KeyboardEventArgs { Key = "End" });
+        Assert.Contains("dx-grid-row-active", tree.FindAll(".dx-grid-row")[3].ClassName);
+
+        container.KeyDown(new KeyboardEventArgs { Key = "Home" });
+        Assert.Contains("dx-grid-row-active", tree.FindAll(".dx-grid-row")[0].ClassName);
+    }
+
+    [Fact]
+    public void Clicking_a_row_makes_it_the_active_row()
+    {
+        IRenderedComponent<DxTreeGrid<TreeWidget>> tree = Render(expanded: true);   // A, A1, A2, B
+
+        tree.FindAll(".dx-grid-row")[2].Click();   // A2
+
+        Assert.Contains("dx-grid-row-active", tree.FindAll(".dx-grid-row")[2].ClassName);
+        Assert.DoesNotContain("dx-grid-row-active", tree.FindAll(".dx-grid-row")[0].ClassName);
+    }
+
+    [Fact]
+    public void Collapsing_the_active_rows_ancestor_re_anchors_the_active_index()
+    {
+        IRenderedComponent<DxTreeGrid<TreeWidget>> tree = Render(expanded: true);   // A, A1, A2, B
+        var container = tree.Find("[role=treegrid]");
+
+        container.KeyDown(new KeyboardEventArgs { Key = "ArrowDown" });   // A -> A1 (active)
+        tree.FindAll(".dx-tree-toggle")[0].Click();                      // collapse "A" away
+
+        // A1 no longer exists in the flattened list; the active index must land on a real row.
+        Assert.Equal(2, tree.FindAll(".dx-grid-row").Count);   // A, B
+        Assert.Single(tree.FindAll(".dx-grid-row-active"));
     }
 }


### PR DESCRIPTION
Fixes #79.

## What was missing

`DxTreeGrid` advertised `role="treegrid"` and `aria-expanded`, but its actual keyboard model was thin: only ArrowLeft/ArrowRight expand/collapse on whichever row happened to have native Tab focus (`TreeGridPrimitive.OnRowKeyDown`, one Tab stop per row). No ArrowUp/Down row traversal, no Home/End. `DxTreeView`, built on the same expand/collapse concept, already implements the fuller WAI-ARIA tree pattern — this PR ports that pattern into the tree grid.

## What changed

`TreeGridPrimitive` is virtualized (flattens + windows the visible rows), unlike `DxTreeView` (renders every node and focuses elements directly), so the active row is addressed by **index into the full flattened list** plus `aria-activedescendant` — the same approach `DataGridPrimitive` already uses for its active cell, so navigation keeps working even when the active row is scrolled out of the rendered window.

- Single roving tab stop on the treegrid container, replacing per-row `tabindex="0"`.
- ArrowUp/ArrowDown move the active row across the full flattened tree (not just the rendered window).
- ArrowRight expands a collapsed row or descends to its first child; ArrowLeft collapses an expanded row or moves to its parent.
- Home/End jump to the first/last row.
- Clicking a row makes it active (`SetActiveRow`), matching `DataGrid`'s click-to-set-active-cell.
- The active index is re-anchored (`ClampActiveIndex`) whenever the flattened list reshapes, so collapsing an ancestor of the active row can't leave it pointing past the end of the list.
- Reused `DataGridPrimitive`'s exact `EnsureActiveVisibleAsync`/`EnsureArrowSuppressionAsync` shapes via the `IGridDomInterop` (`ScrollToAsync`/`SuppressArrowKeysAsync`) already injected into `TreeGridPrimitive` — no new interop surface.

**Behavior change, flagged in the CHANGELOG:** rows are no longer independently Tab-reachable. Tab now enters the grid once and arrow keys move within it — the same single-tab-stop model `DataGrid`/`TreeView` already use, not a regression, but real user-visible behavior worth calling out.

## Verification

`BlazorDX.Components`/`.Primitives` can't build locally here (SDK/analyzer version mismatch → CS9057), so: pulled the modified `TreeGridPrimitive.cs`/`DxTreeGrid.cs` plus `IGridRowAccessor`/`IGridDomInterop`/`NullGridDomInterop` into a scratch project against the real pinned `bunit`/`xunit` packages, with a hand-written `IGridRowAccessor<TreeWidget>` standing in for what `[GridRow]`'s source generator would emit (the generator itself can't run outside CI either). Ran the full scenario for real — 13/13 pass, including:

- Container is the single tab stop, rows carry no `tabindex`, `aria-activedescendant` matches the active row's `id`.
- ArrowRight expands / descends to first child; ArrowLeft collapses / moves to parent.
- ArrowUp/ArrowDown traverse the flattened list; Home/End jump to the ends.
- Clicking a row activates it.
- Collapsing an ancestor of the active row re-anchors the active index onto a real row.

Ported the same coverage into the real `DxTreeGridTests.cs`. CI is the first place this runs against the actual `[GridRow]` generator and the real `TreeWidgetGridAccessor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
