### PR TITLE
Restore grid focus after exiting DataGrid cell-edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@ All notable changes to BlazorDX are documented here. The format is loosely based
   bubble up and *also* advance the carousel, moving the slide out from under whatever the user
   was actually navigating. Moved the listener onto the previous/next buttons only, the same
   sibling-not-ancestor shape `DxTabs`' tablist and `DxSplitter`'s divider already use. (#78)
+- **`DxDataGrid` lost keyboard focus after exiting cell-edit mode.** Committing (Enter) or
+  cancelling (Escape) an edit unmounts the editor `<input>`, taking real DOM focus with it — the
+  browser drops it to `<body>`, and the grid container never reclaimed it. Arrow-key cell
+  navigation, which depends on the container itself holding focus, was dead until the user clicked
+  or Tabbed back in. Added `IGridDomInterop.FocusElementAsync` (focuses an element directly, unlike
+  the existing `FocusFirstAsync`, which would have landed on a header button instead of the grid
+  body) and call it after both Commit and Cancel, when `KeyboardNavigation` is on.
 
 ## [0.6.0] — 2026-09-05
 

--- a/src/BlazorDX.Components/DxDataGrid.cs
+++ b/src/BlazorDX.Components/DxDataGrid.cs
@@ -768,15 +768,9 @@ public sealed class DxDataGrid<TRow> : DataGridPrimitive<TRow>
     private Task OnEditKeyDownAsync(KeyboardEventArgs args) => args.Key switch
     {
         "Enter" => CommitEditAsync(),
-        "Escape" => Run(CancelEdit),
+        "Escape" => CancelEditAsync(),
         _ => Task.CompletedTask,
     };
-
-    private static Task Run(Action action)
-    {
-        action();
-        return Task.CompletedTask;
-    }
 
     private void BuildGroupHeader(RenderTreeBuilder builder, int groupIndex)
     {

--- a/src/BlazorDX.Interop.Ts/src/grid-dom.ts
+++ b/src/BlazorDX.Interop.Ts/src/grid-dom.ts
@@ -169,3 +169,11 @@ export function focusFirst(elementId: string): void {
   );
   (focusable ?? element).focus();
 }
+
+// Moves focus to the element itself, not a descendant — for restoring focus to the grid's
+// own tab stop (e.g. after exiting cell-edit mode unmounts the editor input that briefly held
+// it), where focusFirst would instead land on the first header button/filter input in document
+// order.
+export function focusElement(elementId: string): void {
+  document.getElementById(elementId)?.focus();
+}

--- a/src/BlazorDX.Interop/GridDomInterop.cs
+++ b/src/BlazorDX.Interop/GridDomInterop.cs
@@ -56,6 +56,12 @@ public sealed partial class GridDomInterop : IGridDomInterop
         FocusFirst(elementId);
     }
 
+    public async ValueTask FocusElementAsync(string elementId)
+    {
+        await EnsureLoadedAsync();
+        FocusElement(elementId);
+    }
+
     public async ValueTask DownloadTextAsync(string filename, string mime, string content)
     {
         await EnsureLoadedAsync();
@@ -120,4 +126,7 @@ public sealed partial class GridDomInterop : IGridDomInterop
 
     [JSImport("focusFirst", ModuleName)]
     private static partial void FocusFirst(string elementId);
+
+    [JSImport("focusElement", ModuleName)]
+    private static partial void FocusElement(string elementId);
 }

--- a/src/BlazorDX.Interop/IGridDomInterop.cs
+++ b/src/BlazorDX.Interop/IGridDomInterop.cs
@@ -26,6 +26,13 @@ public interface IGridDomInterop : IAsyncDisposable
     /// <summary>Moves focus to the first focusable descendant of the element.</summary>
     ValueTask FocusFirstAsync(string elementId);
 
+    /// <summary>
+    /// Moves focus to the element itself (not a descendant) — used to restore focus to the
+    /// grid's own tab stop after an action removes the element that briefly held it, e.g.
+    /// exiting cell-edit mode unmounts the editor input.
+    /// </summary>
+    ValueTask FocusElementAsync(string elementId);
+
     /// <summary>Triggers a client-side download of text content (e.g. an exported CSV).</summary>
     ValueTask DownloadTextAsync(string filename, string mime, string content);
 

--- a/src/BlazorDX.Interop/NullGridDomInterop.cs
+++ b/src/BlazorDX.Interop/NullGridDomInterop.cs
@@ -21,6 +21,8 @@ public sealed class NullGridDomInterop : IGridDomInterop
 
     public ValueTask FocusFirstAsync(string elementId) => ValueTask.CompletedTask;
 
+    public ValueTask FocusElementAsync(string elementId) => ValueTask.CompletedTask;
+
     public ValueTask DownloadTextAsync(string filename, string mime, string content) => ValueTask.CompletedTask;
 
     public ValueTask DownloadBytesAsync(string filename, string mime, byte[] content) => ValueTask.CompletedTask;

--- a/src/BlazorDX.Primitives/Grid/DataGridPrimitive.cs
+++ b/src/BlazorDX.Primitives/Grid/DataGridPrimitive.cs
@@ -709,11 +709,12 @@ public partial class DataGridPrimitive<TRow> : ComponentBase, IAsyncDisposable
     }
 
     /// <summary>Cancels the in-progress edit without writing back.</summary>
-    protected void CancelEdit()
+    protected async Task CancelEditAsync()
     {
         EditingRow = -1;
         EditingColumn = -1;
         StateHasChanged();
+        await RestoreFocusAfterEditAsync();
     }
 
     /// <summary>Writes the current draft back through the generated accessor and exits edit mode.</summary>
@@ -742,10 +743,24 @@ public partial class DataGridPrimitive<TRow> : ComponentBase, IAsyncDisposable
 
         RebuildSlots();
         StateHasChanged();
+        await RestoreFocusAfterEditAsync();
 
         if (RowEdited.HasDelegate)
         {
             await RowEdited.InvokeAsync(Items[rowIndex]);
+        }
+    }
+
+    // The editor <input> is unmounted the instant edit mode exits, taking real DOM focus with
+    // it (the browser drops it to <body>). Without this, arrow-key cell navigation — which
+    // depends on the grid container itself holding focus — is dead until the user clicks or
+    // Tabs back in. Only meaningful when KeyboardNavigation is on; the container has no
+    // tabindex at all otherwise, so focusing it would be a no-op.
+    private async Task RestoreFocusAfterEditAsync()
+    {
+        if (KeyboardNavigation)
+        {
+            await Dom.FocusElementAsync(ContainerId);
         }
     }
 

--- a/tests/BlazorDX.Components.Tests/DxDataGridChooserTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridChooserTests.cs
@@ -127,6 +127,7 @@ public sealed class DxDataGridChooserTests : TestContext
             ValueTask.FromResult<(double, double, double, double)>((0, 0, 0, 0));
         public ValueTask SubscribeScrollAsync(string id, Action onScroll) => ValueTask.CompletedTask;
         public ValueTask FocusFirstAsync(string id) => ValueTask.CompletedTask;
+        public ValueTask FocusElementAsync(string id) => ValueTask.CompletedTask;
         public ValueTask DownloadTextAsync(string filename, string mime, string content)
         {
             onDownload(content);

--- a/tests/BlazorDX.Components.Tests/DxDataGridExportTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridExportTests.cs
@@ -26,6 +26,7 @@ public sealed class DxDataGridExportTests : TestContext
             ValueTask.FromResult<(double, double, double, double)>((0, 0, 0, 0));
         public ValueTask SubscribeScrollAsync(string id, Action onScroll) => ValueTask.CompletedTask;
         public ValueTask FocusFirstAsync(string id) => ValueTask.CompletedTask;
+        public ValueTask FocusElementAsync(string id) => ValueTask.CompletedTask;
         public ValueTask DownloadTextAsync(string filename, string mime, string content)
         {
             File = filename;

--- a/tests/BlazorDX.Components.Tests/DxDataGridKeyboardTests.cs
+++ b/tests/BlazorDX.Components.Tests/DxDataGridKeyboardTests.cs
@@ -116,4 +116,91 @@ public sealed class DxDataGridKeyboardTests : TestContext
         Assert.Empty(grid.FindAll(".dx-grid-cell-active"));
         Assert.False(grid.Find("[role=grid]").HasAttribute("tabindex"));
     }
+
+    // ---- Focus restoration after exiting cell-edit mode ----
+    // The editor <input> is unmounted the instant Commit/Cancel exits edit mode, taking real
+    // DOM focus with it. Without an explicit restore, arrow-key navigation (which depends on
+    // the grid container itself holding focus) would be dead until the user clicked or Tabbed
+    // back in.
+
+    private sealed class RecordingFocusDom : IGridDomInterop
+    {
+        public List<string> FocusedElementIds { get; } = [];
+
+        public ValueTask EnsureLoadedAsync() => ValueTask.CompletedTask;
+        public ValueTask<(double, double, double)> MeasureViewportAsync(string id) =>
+            ValueTask.FromResult<(double, double, double)>((0, 0, 0));
+        public ValueTask<(double, double, double, double)> MeasureViewport2dAsync(string id) =>
+            ValueTask.FromResult<(double, double, double, double)>((0, 0, 0, 0));
+        public ValueTask SubscribeScrollAsync(string id, Action onScroll) => ValueTask.CompletedTask;
+        public ValueTask FocusFirstAsync(string id) => ValueTask.CompletedTask;
+        public ValueTask FocusElementAsync(string id)
+        {
+            FocusedElementIds.Add(id);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DownloadTextAsync(string f, string m, string c) => ValueTask.CompletedTask;
+        public ValueTask DownloadBytesAsync(string f, string m, byte[] c) => ValueTask.CompletedTask;
+        public ValueTask<bool> WriteClipboardAsync(string text) => ValueTask.FromResult(true);
+        public ValueTask ScrollToAsync(string id, double top) => ValueTask.CompletedTask;
+        public ValueTask SuppressArrowKeysAsync(string id) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public void Committing_an_edit_restores_focus_to_the_grid_container()
+    {
+        RecordingFocusDom dom = new();
+        Services.AddScoped<IGridDomInterop>(_ => dom);
+        IRenderedComponent<DxDataGrid<WidgetRow>> grid = RenderComponent<DxDataGrid<WidgetRow>>(parameters => parameters
+            .Add(g => g.Items, Rows())
+            .Add(g => g.Accessor, new WidgetRowGridAccessor())
+            .Add(g => g.KeyboardNavigation, true)
+            .Add(g => g.Editable, true));
+
+        grid.Find(".dx-grid-cell").DoubleClick();
+        var editor = grid.Find(".dx-grid-edit-input");
+        editor.KeyDown(new KeyboardEventArgs { Key = "Enter" });
+
+        string containerId = grid.Find("[role=grid]").GetAttribute("id")!;
+        Assert.Contains(containerId, dom.FocusedElementIds);
+    }
+
+    [Fact]
+    public void Cancelling_an_edit_restores_focus_to_the_grid_container()
+    {
+        RecordingFocusDom dom = new();
+        Services.AddScoped<IGridDomInterop>(_ => dom);
+        IRenderedComponent<DxDataGrid<WidgetRow>> grid = RenderComponent<DxDataGrid<WidgetRow>>(parameters => parameters
+            .Add(g => g.Items, Rows())
+            .Add(g => g.Accessor, new WidgetRowGridAccessor())
+            .Add(g => g.KeyboardNavigation, true)
+            .Add(g => g.Editable, true));
+
+        grid.Find(".dx-grid-cell").DoubleClick();
+        var editor = grid.Find(".dx-grid-edit-input");
+        editor.KeyDown(new KeyboardEventArgs { Key = "Escape" });
+
+        string containerId = grid.Find("[role=grid]").GetAttribute("id")!;
+        Assert.Contains(containerId, dom.FocusedElementIds);
+    }
+
+    [Fact]
+    public void Exiting_edit_without_keyboard_navigation_does_not_call_FocusElementAsync()
+    {
+        RecordingFocusDom dom = new();
+        Services.AddScoped<IGridDomInterop>(_ => dom);
+        IRenderedComponent<DxDataGrid<WidgetRow>> grid = RenderComponent<DxDataGrid<WidgetRow>>(parameters => parameters
+            .Add(g => g.Items, Rows())
+            .Add(g => g.Accessor, new WidgetRowGridAccessor())
+            .Add(g => g.KeyboardNavigation, false)
+            .Add(g => g.Editable, true));
+
+        grid.Find(".dx-grid-cell").DoubleClick();
+        var editor = grid.Find(".dx-grid-edit-input");
+        editor.KeyDown(new KeyboardEventArgs { Key = "Enter" });
+
+        Assert.Empty(dom.FocusedElementIds);
+    }
 }

--- a/tests/BlazorDX.Components.Tests/ObservabilityTests.cs
+++ b/tests/BlazorDX.Components.Tests/ObservabilityTests.cs
@@ -232,6 +232,7 @@ public sealed class ObservabilityTests : TestContext
         public ValueTask<(double, double, double, double)> MeasureViewport2dAsync(string id) => ValueTask.FromResult<(double, double, double, double)>((0, 0, 0, 0));
         public ValueTask SubscribeScrollAsync(string id, Action onScroll) => ValueTask.CompletedTask;
         public ValueTask FocusFirstAsync(string id) => ValueTask.CompletedTask;
+        public ValueTask FocusElementAsync(string id) => ValueTask.CompletedTask;
         public ValueTask DownloadTextAsync(string f, string m, string c) => ValueTask.CompletedTask;
         public ValueTask DownloadBytesAsync(string f, string m, byte[] c) => ValueTask.CompletedTask;
         public ValueTask<bool> WriteClipboardAsync(string text) => ValueTask.FromResult(false);   // permission denied


### PR DESCRIPTION
## What was wrong

Committing (Enter) or cancelling (Escape) an inline cell edit unmounts the editor `<input>`, taking real DOM focus with it — the browser drops it to `<body>`, and the grid container (the actual tab stop when `KeyboardNavigation` is on) never reclaimed it. Arrow-key cell navigation depends on that container holding focus, so it was dead until the user clicked or Tabbed back in.

Found while closing out the remaining items from an earlier cross-component keyboard-composition review (same review that produced #76–#79).

## Fix

The existing `IGridDomInterop.FocusFirstAsync` doesn't fit: it focuses the first focusable *descendant* of an element, and the grid container's header buttons/filter inputs come before the body in document order — it would land focus on a header control instead of back on the grid body. Added `FocusElementAsync`, which focuses the element itself, and call it from both `CommitEditAsync` and the renamed `CancelEditAsync` (was a void `CancelEdit()`, wrapped at its one call site with a local `Run(Action)` adapter — now a real async method, so that adapter is gone) whenever `KeyboardNavigation` is on.

## Verification

Two layers, since local builds have been blocked all session by a pinned-Roslyn-version mismatch (CS9057) — unrelated in-progress work elsewhere in the tree reverted that pin mid-session:

- **Before the revert landed:** a scratch bunit project with a hand-written `IGridRowAccessor` stand-in (the real `[GridRow]` generator couldn't run either way) proved the new tests fail against the pre-fix source (`FocusElementAsync` never called, empty collection) and pass against the fix.
- **After the revert:** `BlazorDX.Components` now builds locally for real. Ran the actual `tests/BlazorDX.Components.Tests/DxDataGridKeyboardTests.cs` directly against the real `[GridRow]` source generator and the real Rust wasm grid module — 9/9 pass, including the three new tests (`Committing_an_edit_restores_focus_to_the_grid_container`, `Cancelling_an_edit_restores_focus_to_the_grid_container`, `Exiting_edit_without_keyboard_navigation_does_not_call_FocusElementAsync`).

Also updated the other `IGridDomInterop` implementers required by the new interface member: `NullGridDomInterop`, and three test fakes (`DxDataGridChooserTests.cs`, `DxDataGridExportTests.cs`, `ObservabilityTests.cs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
